### PR TITLE
Fix build errors when ENABLE_VERBOSE is not set

### DIFF
--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -690,7 +690,7 @@ tcpreplay_set_verbose(tcpreplay_t *ctx, bool value)
     ctx->options->verbose = value;
     return 0;
 #else
-    tcpreplay_seterr(ctx, "verbose mode not supported");
+    tcpreplay_seterr(ctx, "%s", "verbose mode not supported");
     return -1;
 #endif
 }
@@ -710,7 +710,7 @@ tcpreplay_set_tcpdump_args(tcpreplay_t *ctx, char *value)
     ctx->options->tcpdump_args = safe_strdup(value);
     return 0;
 #else
-    tcpreplay_seterr(ctx, "verbose mode not supported");
+    tcpreplay_seterr(ctx, "%s", "verbose mode not supported");
     return -1;
 #endif
 }
@@ -731,7 +731,7 @@ tcpreplay_set_tcpdump(tcpreplay_t *ctx, tcpdump_t *value)
     ctx->options->tcpdump = value;
     return 0;
 #else
-    tcpreplay_seterr(ctx, "verbose mode not supported");
+    tcpreplay_seterr(ctx, "%s", "verbose mode not supported");
     return -1;
 #endif
 }


### PR DESCRIPTION
Fixes #59

When ENABLE_VERBOSE is not set some additional calls to tcpreplay_seterr
are made. When conforming to C99 variadic macros at least one argument is
required after the format string[1]. To avoid this problem update the
calls to tcpreplay_seterr to use a "%s" format string.

[1] - http://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html

Signed-off-by: Chris Packham judge.packham@gmail.com
