### PR TITLE
vale: permit operation with netmap vale switch.

### DIFF
--- a/src/common/interface.c
+++ b/src/common/interface.c
@@ -54,6 +54,9 @@ get_interface(interface_list_t *list, const char *alias)
     
     assert(alias);
     
+    if (strncmp("vale", alias, 4) == 0)
+        goto vale;
+
     if (list != NULL) {        
         ptr = list;
     
@@ -68,6 +71,7 @@ get_interface(interface_list_t *list, const char *alias)
             ptr = ptr->next;
         } while (ptr != NULL);
     } else {
+vale:
         name = (char *)safe_malloc(strlen(alias) + 1);
         strlcpy(name, alias, sizeof(name));
         return(name);

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -113,6 +113,7 @@ struct sendpacket_s {
     void *mmap_addr;
     int mmap_size;
     uint32_t if_flags;
+    uint32_t is_vale;
 #ifdef linux
     uint32_t data;
     uint32_t gso;


### PR DESCRIPTION
This patch should enable tcpreplay to inject packets directly to netmap's vale switch.

vale: permit operation with netmap vale switch.  For example:  
    tcpreplay -i vale:tx --netmap my.pcap

This can be tested with pkt-gen as follows:
./pkt-gen -i vale:rx -f rx

Note vale is a learning bridge, so once addresses are learned they are no longer broadcast to all listeners.  Vale is easily modified to bypass learning.
