### PR TITLE
Allow non-versioned NetMap API support as seen in FreeBSD 8.4 - #78

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,3 +1,8 @@
+06/21/2014 Version 4.0.5beta1
+    - Support for Vale Switch (#91)
+    - Fix max replay rate for all loops except first when omitting --mbps (#85)
+    - Support for PF_RING DNA version of libpcap (#82)
+    - Fix build for FreeBSD version 8.4 (#78)
 
 03/22/2014 Version 4.0.4
     - Number of packets inaccurate when using --netmap method (#76)

--- a/src/common/flows.c
+++ b/src/common/flows.c
@@ -115,7 +115,7 @@ static inline flow_entry_type_t hash_put_data(flow_hash_table_t *fht, const uint
         const flow_entry_data_t *hash_entry, const struct timeval *tv, const int expiry)
 {
     uint32_t hash_value = key & (fht->num_buckets - 1);
-    flow_hash_entry_t *he = NULL;
+    flow_hash_entry_t *he;
     flow_entry_type_t res = FLOW_ENTRY_INVALID;
 
     for (he = fht->buckets[hash_value]; he; he = he->next) {

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -158,7 +158,6 @@ static sendpacket_t *sendpacket_open_netmap(const char *device, char *errbuf);
 #include <sys/utsname.h>
 #include <net/if.h>
 #include <netinet/in.h>
-#include <linux/if_ether.h>
 #include <net/if_arp.h>
 #include <netpacket/packet.h>
 

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -21,10 +21,21 @@
 #include "config.h"
 #include "defines.h"
 
+#include <sys/socket.h>
+
+#ifdef __NetBSD__
+#include <net/if_ether.h>
+#else
+#include <netinet/if_ether.h>
+#endif
+
 #if defined HAVE_NETMAP
 #include <net/if.h>
 #include <net/netmap.h>
 #include <net/netmap_user.h>
+#ifndef NETMAP_API
+#define NETMAP_API 0
+#endif
 #endif
 
 #ifdef HAVE_PF_PACKET
@@ -84,7 +95,6 @@ union sendpacket_handle {
 };
 
 #define SENDPACKET_ERRBUF_SIZE 1024
-#define NETMAP_BACKOFF (1 << 4)     /* 16 - must be power of 2 */
 
 struct sendpacket_s {
     tcpr_dir_t cache_dir;


### PR DESCRIPTION
FreeBSD version 8.4 has a non-versioned netmap. Defined this version as version 0 to get the feature to compile.
