### PR TITLE
Prevent multiple interfaces with --netmap option. Ensure that TX loop ca...

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -7,6 +7,7 @@
     - Seg fault on some IPv6 files when using -C option with tcprewrite (#83)
     - Support for PF_RING DNA version of libpcap (#82)
     - Fix segfault when using '-F pad' (#80)
+    - Disallow netmap on multiple interfaces (#79)
     - Fix build for FreeBSD version 8.4 (#78)
 
 06/19/2014 Version 4.0.5-beta1

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -131,6 +131,7 @@ abort_handler(int signo)
     if (signo == SIGINT && ctx) {
         notice(" User interrupt...");
         ctx->abort = true;
+        tcpreplay_abort(ctx);
     }
 }
 

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -224,6 +224,16 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
 
     if (HAVE_OPT(NETMAP)) {
 #ifdef HAVE_NETMAP
+        if (HAVE_OPT(INTF2)) {
+            tcpreplay_seterr(ctx, "%s", "multiple interfaces not supported in netmap mode");
+            ret = -1;
+            goto out;
+        }
+        if (HAVE_OPT(CACHEFILE)) {
+            tcpreplay_seterr(ctx, "%s", "--cachefile option not supported in netmap mode");
+            ret = -1;
+            goto out;
+        }
         options->netmap = 1;
         ctx->sp_type = SP_TYPE_NETMAP;
 #else


### PR DESCRIPTION
...n be interrupted. This closes #79
