### PR TITLE
Newest version of PF_RING requires -lrt compile flag. This picks up supp...

### DIFF
--- a/configure
+++ b/configure
@@ -17711,7 +17711,7 @@ fi
 OLDLIBS="$LIBS"
 OLDCFLAGS="$CFLAGS -I$LPCAPINCDIR"
 if test $pf_ring_found = yes ; then
-    LIBS="$LPCAPLIB ${foundpcap}/../lib/libpfring.a -lnuma -lpthread"
+    LIBS="$LPCAPLIB ${foundpcap}/../lib/libpfring.a -lnuma -lpthread -lrt"
     LPCAPLIB=$LIBS
 else
     LIBS="$LPCAPLIB"

--- a/configure.ac
+++ b/configure.ac
@@ -468,7 +468,7 @@ dnl Checks to see what version of libpcap we've got
 OLDLIBS="$LIBS"
 OLDCFLAGS="$CFLAGS -I$LPCAPINCDIR"
 if test $pf_ring_found = yes ; then
-    LIBS="$LPCAPLIB ${foundpcap}/../lib/libpfring.a -lnuma -lpthread"
+    LIBS="$LPCAPLIB ${foundpcap}/../lib/libpfring.a -lnuma -lpthread -lrt"
     LPCAPLIB=$LIBS
 else
     LIBS="$LPCAPLIB"

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -12,7 +12,7 @@
     - Fix max replay rate for all loops except first when omitting --mbps (#85)
     - Add missing sanity check in libopt (#84)
     - Seg fault on some IPv6 files when using -C option with tcprewrite (#83)
-    - Support for PF_RING DNA version of libpcap (#82)
+    - Support for PF_RING DNA version of libpcap (#81)
     - Fix segfault when using '-F pad' (#80)
     - Disallow netmap on multiple interfaces (#79)
     - Fix build for FreeBSD version 8.4 (#78)


### PR DESCRIPTION
...ort for clock_gettime() - closes #81
