### PR TITLE
Expand size of filter buffer to avoid overflows.

### DIFF
--- a/src/tcpliveplay.c
+++ b/src/tcpliveplay.c
@@ -617,7 +617,7 @@ set_live_filter(char *dev, input_addr* hostip, unsigned int port)
     pcap_t *handle = NULL;          /* Session handle */
     char errbuf[PCAP_ERRBUF_SIZE];  /* Error string buffer */
     struct bpf_program fp;          /* The compiled filter */
-    char filter_exp[50];
+    char filter_exp[52];
     sprintf(filter_exp,"tcp and dst host %d.%d.%d.%d and dst port %u",
             hostip->byte1, hostip->byte2, hostip->byte3, hostip->byte4, port);  /* The filter expression */
     bpf_u_int32 mask;           /* Our network mask */


### PR DESCRIPTION
With a long IP address and a 5 digit port, and filter expression can be 51 bytes long:

`tcp and dst host 192.192.192.192 and dst port 51997`

Adding an additional byte for the terminating NULL, the buffer should be 52 bytes instead of the previous 50.

This fixes a buffer overflow on some systems of the form:

```
*** buffer overflow detected ***: tcpliveplay terminated
======= Backtrace: =========
/lib64/libc.so.6(__fortify_fail+0x37)[0x7f95f78bd507]
/lib64/libc.so.6(+0x1003f0)[0x7f95f78bb3f0]
/lib64/libc.so.6(+0xff849)[0x7f95f78ba849]
/lib64/libc.so.6(_IO_default_xsputn+0xc9)[0x7f95f782f8b9]
/lib64/libc.so.6(_IO_vfprintf+0x11d8)[0x7f95f7800428]
/lib64/libc.so.6(__vsprintf_chk+0x9d)[0x7f95f78ba8ed]
/lib64/libc.so.6(__sprintf_chk+0x7f)[0x7f95f78ba82f]
tcpliveplay[0x4037d0]
tcpliveplay[0x404226]
/lib64/libc.so.6(__libc_start_main+0xfd)[0x7f95f77d9cdd]
tcpliveplay[0x4028a9]
```