### PR TITLE
Stop sending and exit when limit is reached

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -491,8 +491,10 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
             return;
 
         /* stop sending based on the limit -L? */
-        if (limit_send > 0 && ctx->stats.pkts_sent > (COUNTER)limit_send)
+        if (limit_send > 0 && ctx->stats.pkts_sent >= (COUNTER)limit_send) {
+            ctx->abort = true;
             break;
+        }
 
         packetnum++;
 #if defined TCPREPLAY || defined TCPREPLAY_EDIT
@@ -704,8 +706,10 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             return;
 
         /* stop sending based on the limit -L? */
-        if (limit_send > 0 && ctx->stats.pkts_sent > (COUNTER)limit_send)
+        if (limit_send > 0 && ctx->stats.pkts_sent >= (COUNTER)limit_send) {
+            ctx->abort = true;
             break;
+        }
 
         packetnum++;
 


### PR DESCRIPTION
The limit check improperly lets an extra packet get sent
When the limit is reached, the program enters a busy loop and does not exit.

This patch sets the abort flag so we exit when the limit is reached as well as fixing the send counter check so we only send the number of packets requested.