### PR TITLE
Add option for limiting transmit by time

### DIFF
--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -101,6 +101,9 @@ tcpreplay_init()
     /* disable limit send */
     ctx->options->limit_send = -1;
 
+    /* disable limit time */
+    ctx->options->limit_time = 0;
+
 #ifdef ENABLE_VERBOSE
     /* clear out tcpdump struct */
     ctx->options->tcpdump = (tcpdump_t *)safe_malloc(sizeof(tcpdump_t));
@@ -164,6 +167,9 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
 
     if (HAVE_OPT(LIMIT))
         options->limit_send = OPT_VALUE_LIMIT;
+
+    if (HAVE_OPT(DURATION))
+        options->limit_time = OPT_VALUE_DURATION;
 
     if (HAVE_OPT(TOPSPEED)) {
         options->speed.mode = speed_topspeed;

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -124,6 +124,7 @@ typedef struct tcpreplay_opt_s {
 
     /* limit # of packets to send */
     COUNTER limit_send;
+    COUNTER limit_time;
 
     /* maximum sleep time between packets */
     struct timespec maxsleep;

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -356,6 +356,19 @@ specify a maximum number of packets to send.
 EOText;
 };
 
+flag = {
+    name        = duration;
+    arg-type    = number;
+    max         = 1;
+    arg-default = -1;
+    arg-range   = "1->";
+    descrip     = "Limit the trasmit duration";
+    doc         = <<- EOText
+By default, tcpreplay will send all the packets.  Alternatively, you can
+specify a maximum number of seconds to transmit.
+EOText;
+};
+
 /*
  * Replay speed modifiers: -m, -p, -r, -R, -o
  */


### PR DESCRIPTION
Add --duration option which lets the user set the number of seconds to  transmit
Implemented similarly to the -L option to break out to the send_packets loop and set the abort flag once we have exceeded the time limit.