### PR TITLE
configure.ac: recognise tbd stubs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -494,7 +494,7 @@ AC_ARG_WITH(libpcap,
             LPCAPINC="${testdir}/pcap.h"
             LPCAPINCDIR="${testdir}"
             if test $dynamic_link = yes; then
-                for ext in .dylib .so ; do 
+                for ext in .dylib .so .tbd ; do 
                     if test -f "${withval}/libpcap${ext}" ; then
                         LPCAPLIB="-L${withval}/ -lpcap"
                     elif test -f "${withval}/lib/libpcap${ext}" ; then


### PR DESCRIPTION
Xcode 7 which is now the only App Store available Xcode for OS X Yosemite & OS X El Capitan replaced the `.dylib`s inside Xcode with `.tbd` files which point to the correct location on the system and provide symbols, etc.

Example of the first bit of the `libpcap.A.tdb` file:

```
---
archs:           [ i386, x86_64 ]
platform:        macosx
install-name:    /usr/lib/libpcap.A.dylib
exports:
  - archs:           [ i386, x86_64 ]
    symbols:         [ ___pcap_atodn, ___pcap_atoin, ___pcap_nametodnaddr,
```

This allows people (even those using 4.1.0) to do something like:

```
./configure --with-libpcap=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr
```
And let that work, rather than having to vendor in an external libpcap, etc. This is necessary on systems
without the Command Line Tools package because on some OS X versions `/usr/include` isn't created until you install the CLT package. Not sure if still the case on El Capitan, but historically it has been so.