### PR TITLE
tcprewrite: Handle loopback for linux cooked capture files (Linux SLL)

### DIFF
--- a/src/tcpedit/plugins/dlt_linuxsll/linuxsll.c
+++ b/src/tcpedit/plugins/dlt_linuxsll/linuxsll.c
@@ -175,6 +175,7 @@ dlt_linuxsll_parse_opts(tcpeditdlt_t *ctx)
 int 
 dlt_linuxsll_decode(tcpeditdlt_t *ctx, const u_char *packet, const int pktlen)
 {
+    int type;
     linux_sll_header_t *linux_sll;
     assert(ctx);
     assert(packet);
@@ -185,10 +186,11 @@ dlt_linuxsll_decode(tcpeditdlt_t *ctx, const u_char *packet, const int pktlen)
     ctx->l2len = sizeof(linux_sll_header_t);
 
 
-    if (ntohs(linux_sll->type) == ARPHRD_ETHER) { /* ethernet */
+    type = ntohs(linux_sll->type);
+    if (type == ARPHRD_ETHER || type == ARPHRD_LOOPBACK) { /* ethernet or loopback */
         memcpy(&(ctx->srcaddr), linux_sll->address, ETHER_ADDR_LEN);
     } else {
-        tcpedit_seterr(ctx->tcpedit, "%s", "DLT_LINUX_SLL pcap's must contain only ethernet packets");
+        tcpedit_seterr(ctx->tcpedit, "%s", "DLT_LINUX_SLL pcap's must contain only ethernet or loopback packets");
         return TCPEDIT_ERROR;
     }
 

--- a/src/tcpr.h
+++ b/src/tcpr.h
@@ -235,6 +235,7 @@ struct tcpr_arp_hdr
 #define ARPHRD_ATM      19  /* ATM */
 #define ARPHRD_METRICOM 23  /* Metricom STRIP (new IANA id) */
 #define ARPHRD_IPSEC    31  /* IPsec tunnel */
+#define ARPHRD_LOOPBACK 772 /* Loopback device */
     uint16_t ar_pro;         /* format of protocol address */
     uint8_t  ar_hln;         /* length of hardware address */
     uint8_t  ar_pln;         /* length of protocol addres */


### PR DESCRIPTION
When capturing network packets with tcpdump using the "all" pseudo-interface, the resulting capture file is in linux cooked format (linux SLL). Furthermore, some packets might be coming from the loopback device depending on the activity of the machine. In such a case, when trying to use tcprewrite to replace the linux SLL header with an ethernet header, the program fails with the following error:
```
$ tcprewrite --dlt=enet --enet-dmac=aa:bb:cc:00:00:00 --enet-smac=dd:ee:ff:00:00:00 -i cooked.pcap -o ether.pcap

Fatal Error in tcpedit.c:tcpedit_packet() line 114:
 From ./plugins/dlt_linuxsll/linuxsll.c:dlt_linuxsll_decode() line 201:
DLT_LINUX_SLL pcap's must contain only ethernet packets
```
This pull request address this issue.