### PR TITLE
Tap device support for Linux and FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -478,6 +478,25 @@ if test x$inet_addr = no ; then
 fi
 
 dnl #####################################################
+dnl Checks for tuntap device support
+dnl #####################################################
+have_tuntap=no
+AC_ARG_ENABLE([tuntap],
+  AS_HELP_STRING([--disable-tuntap], [Disable tuntap support]), [:],
+  [case "$build_os" in
+    linux*)
+      AC_CHECK_HEADER([linux/if_tun.h], [have_tuntap=yes])
+      ;;
+    freebsd*)
+      AC_CHECK_HEADER([net/if_tun.h], [have_tuntap=yes])
+      ;;
+  esac])
+if test $have_tuntap = yes ; then
+    AC_DEFINE([HAVE_TUNTAP], [1],
+            [Do we have TUNTAP device support?])
+fi
+
+dnl #####################################################
 dnl Checks for libpcap
 dnl #####################################################
 foundpcap=no
@@ -1619,6 +1638,13 @@ case $host in
     AC_MSG_RESULT(OpenBSD)
     ;;
 
+    *-*-freebsd*)
+    nic1=em0
+    nic2=em0
+    AC_DEFINE([HAVE_FREEBSD], [1], [Building Free BSD])
+    AC_MSG_RESULT(FreeBSD)
+    ;;
+
     *-*-cygwin)
     AC_MSG_RESULT(Win32/Cygwin)
     nic1=%0
@@ -1718,6 +1744,7 @@ pcap_sendpacket:            ${have_pcap_sendpacket} **
 pcap_netmap                 ${have_pcap_netmap}
 Linux Quick TX:             ${have_linux_quick_tx} ${kerneldir}
 Linux/BSD netmap:           ${have_netmap}
+Tuntap device support:      ${have_tuntap}
 
 * In order of preference; see configure --help to override
 ** Required for tcpbridge

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -79,6 +79,7 @@ typedef enum sendpacket_type_e {
     SP_TYPE_KHIAL,
     SP_TYPE_NETMAP,
     SP_TYPE_QUICK_TX,
+    SP_TYPE_TUNTAP
 } sendpacket_type_t;
 
 /* these are the file_operations ioctls */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -145,6 +145,9 @@
 /* Define to 1 if you have the `fork' function. */
 #undef HAVE_FORK
 
+/* Building Free BSD */
+#undef HAVE_FREEBSD
+
 /* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
 #undef HAVE_FSEEKO
 
@@ -517,6 +520,9 @@
 
 /* Do we have tcpdump? */
 #undef HAVE_TCPDUMP
+
+/* Do we have TUNTAP device support? */
+#undef HAVE_TUNTAP
 
 /* Do we have Linux TX_RING socket support? */
 #undef HAVE_TX_RING


### PR DESCRIPTION
Tap devices must be up and running before using with tcpreplay.

Tap support in Apple devices works a little bit different and it is not compatible with main flow of tcpreplay.

Patch tested in Linux and FreeBSD with different capture files.