### PR TITLE
#211 fix build and cross-compile issues on ARM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,7 @@ AC_SUBST(target)
 
 CROSS_ARCH=
 CROSS_LD=
+build_arch=$(echo $MACHTYPE | cut -d'-' -f1)
 if test "$cross_compiling" = "yes" ; then
     CROSS_ARCH="ARCH=$host_cpu"
     CROSS_LD="LD=$LD"
@@ -705,7 +706,7 @@ AC_ARG_WITH(libpcap,
                 LPCAPINCDIR="${testdir}/include"
                 if test $dynamic_link = yes; then
                     for ext in .dylib .so .tbd; do
-                        for dir in . lib lib64 lib/${host_cpu}-${host_os} ${host_cpu}-${host_os}; do
+                        for dir in . lib lib64 ${host_cpu} lib/${host_cpu} ${host_cpu}-${host_os} lib/${host_cpu}-${host_os} ${build_arch}-${host_os} lib/${build_arch}-${host_os}; do
                             sharefile=$(ls "${testdir}/$dir/libpcap${ext}" 2> /dev/null | sort | head -n1)
                             if test -n "${sharefile}"; then
                                 LPCAPLIB="-L$(dirname ${sharefile}) -lpcap"

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,6 @@
 --/--/2015 Version 4.1.1-beta3
 	- Correct company name in license #217
+	- Compile and mult-arch cross-compile on ARM #211
 	- Master doesn't compile on OS X 10.11 #203
 	- Buffer overflow bug in tcpprep #167
 

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -248,8 +248,8 @@ get_ipv4(const u_char *pktdata, int datalen, int datalink, u_char **newbuff)
      * we do all this work to prevent byte alignment issues
      */
     if (l2_len % 4) {
+        memcpy(*newbuff, (pktdata + l2_len), (datalen - l2_len));
         ip_hdr = *newbuff;
-        memcpy(ip_hdr, (pktdata + l2_len), (datalen - l2_len));
     } else {
 
         /* we don't have to do a memcpy if l2_len lands on a boundry */
@@ -310,8 +310,8 @@ get_ipv6(const u_char *pktdata, int datalen, int datalink, u_char **newbuff)
      * we do all this work to prevent byte alignment issues
      */
     if (l2_len % 4) {
+        memcpy(*newbuff, (pktdata + l2_len), (datalen - l2_len));
         ip6_hdr = *newbuff;
-        memcpy(ip6_hdr, (pktdata + l2_len), (datalen - l2_len));
     } else {
 
         /* we don't have to do a memcpy if l2_len lands on a boundry */

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -158,10 +158,10 @@ packet_stats(const tcpreplay_stats_t *stats)
 
     if (diff_us >= 1000000)
         printf("Actual: " COUNTER_SPEC " packets (" COUNTER_SPEC " bytes) sent in %zd.%02zd seconds.\n",
-                stats->pkts_sent, stats->bytes_sent, diff.tv_sec, diff.tv_usec / (100 * 1000));
+                stats->pkts_sent, stats->bytes_sent, (ssize_t)diff.tv_sec, (ssize_t)(diff.tv_usec / (100 * 1000)));
     else
         printf("Actual: " COUNTER_SPEC " packets (" COUNTER_SPEC " bytes) sent in %zd.%06zd seconds.\n",
-                stats->pkts_sent, stats->bytes_sent, diff.tv_sec, diff.tv_usec);
+                stats->pkts_sent, stats->bytes_sent, (ssize_t)diff.tv_sec, (ssize_t)diff.tv_usec);
 
 
     if (mb_sec >= 1)


### PR DESCRIPTION
Fix for ARM builds. Tested on SheevaPlug, and assume fix will work on Pi2. Also fixed cross compile for [multi-arch](https://wiki.debian.org/Multiarch) builds. For example, can cross compile on x86_64 Debian 8 (Jessie) for SheevaPlug with the following (assuming set up for multi-arch and all required libraries installed):

    ./configure --host=arm-linux-gnueabi
