### PR TITLE
common/sendpacket: avoid build error with musl-libc

### DIFF
--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -26,7 +26,9 @@
 #ifdef __NetBSD__
 #include <net/if_ether.h>
 #else
+#if defined(__UCLIBC__) || defined(__GLIBC__)
 #include <netinet/if_ether.h>
+#endif
 #endif
 
 #ifdef HAVE_QUICK_TX


### PR DESCRIPTION
Fixes #275

The musl C library has a definition of 'struct ethhdr' that conflicts
with the one provided by linux. Avoid this by not including
netinet/if_ether.h when building with something other than glibc or
uclibc.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>