### PR TITLE
make clone https so it works for non-contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The source code repository has moved to GitHub. You can get a working copy of th
 by installing [git] and executing:
 
 ```
-git clone git@github.com:appneta/tcpreplay.git
+git clone https://github.com/appneta/tcpreplay.git
 ```
 
 How To Contribute


### PR DESCRIPTION
when i run the old line i see:

```
$ git clone git@github.com:appneta/tcpreplay.git
Cloning into 'tcpreplay'...
The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.112' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```