### PR TITLE
travis-ci: cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ addons:
     packages:
     - libpcap-dev
 
-cache:
-  apt: true
-
 script:
   - autoreconf -iv > build.log 2>&1 || (cat build.log && exit 1)
   - ./configure > build.log 2>&1 || (cat build.log && exit 1)


### PR DESCRIPTION
I added that option by mistake, travis is not capable of cacheing apt