### PR TITLE
Reduce Travis CL build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ addons:
 matrix:
   include:
     - os: osx
-      osx_image: xcode6.4
-      compiler: gcc
-      before_install:
-        - brew update
-        - brew install autogen homebrew/dupes/libpcap
-    - os: osx
       osx_image: xcode8.2
       compiler: clang
       before_install:


### PR DESCRIPTION
OS X builds taking too long, so only test clang with XCode 8.2