### PR TITLE
fuzzing  ignores layers 2, 3, and 4

### DIFF
--- a/src/tcpedit/fuzzing.c
+++ b/src/tcpedit/fuzzing.c
@@ -37,8 +37,8 @@ fuzz_get_sgt_size(uint32_t r, uint32_t caplen)
 }
 
 static inline int
-fuzz_reduce_packet_size(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
-        u_char **pktdata, COUNTER new_len)
+fuzz_reduce_packet_size(tcpedit_t * tcpedit, struct pcap_pkthdr * pkthdr,
+        COUNTER new_len)
 {
     assert(new_len <= pkthdr->len);
 
@@ -60,17 +60,83 @@ fuzz_reduce_packet_size(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
     return 1;
 }
 
+
+static inline int
+fuzz_get_datalen(tcpedit_t * tcpedit, struct pcap_pkthdr * pkthdr,
+        u_char ** pktdata)
+{
+    int datalen;
+    uint8_t l4proto;
+    u_char * l3data, * l4data;
+
+    datalen = pkthdr->len;
+
+    l3data = tcpedit->dlt_ctx->encoder->plugin_get_layer3(tcpedit->dlt_ctx,
+            *pktdata, pkthdr->caplen);
+    if (l3data == NULL) {
+        return -1;
+    }
+    datalen -= l3data - *pktdata;
+
+    if (datalen <= 0) {
+        return -1;
+    }
+
+    /* switch on layer 2 */
+    switch (ntohs(tcpedit->dlt_ctx->proto))
+    {
+        /* TODO: ntohs on constants could be done at compile time */
+        case (ETHERTYPE_IP):
+            {
+                l4data = get_layer4_v4((ipv4_hdr_t*) l3data, datalen);
+                if (l4data == NULL) {
+                    return -1;
+                }
+                l4proto = ((ipv4_hdr_t *) l3data)->ip_p;
+                break;
+            }
+        case (ETHERTYPE_IP6):
+            {
+                l4data = get_layer4_v6((ipv6_hdr_t*) l3data, datalen);
+                if (l4data == NULL) {
+                    return -1;
+                }
+                l4proto = ((ipv6_hdr_t *) l3data)->ip_nh;
+                break;
+            }
+        default:
+            /* apply fuzzing on unknown packet types */
+            return datalen;
+    }
+
+    datalen -= (l4data - l3data);
+
+    /* switch on layer 3 */
+    switch (l4proto) {
+        case IPPROTO_TCP:
+            datalen -= sizeof(tcp_hdr_t);
+            break;
+        case IPPROTO_UDP:
+            datalen -= sizeof(udp_hdr_t);
+            break;
+    }
+
+    return datalen;
+}
+
 int
-fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
-        u_char **pktdata)
+fuzzing(tcpedit_t * tcpedit, struct pcap_pkthdr * pkthdr,
+        u_char ** _pktdata)
 {
     int packet_changed;
     uint32_t r;
     unsigned int * len;
+    int datalen;
+    u_char * pktdata;
 
     assert(tcpedit != NULL);
     assert(pkthdr != NULL);
-    assert(pktdata != NULL);
+    assert(_pktdata != NULL);
 
     if (fuzz_running == 0) {
         return 0;
@@ -78,7 +144,16 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
 
     len = &(pkthdr->caplen);
     packet_changed = 0;
+
+    /* skip packets without payload */
+    datalen = fuzz_get_datalen(tcpedit, pkthdr, _pktdata);
+    if (datalen <= 0 || datalen >= *len) {
+        return 0;
+    }
+
+    r = rand();
     r = tcpr_random(&fuzz_seed);
+    pktdata = *_pktdata + (*len - datalen);
 
     /* TODO sktip ip/tcp/udp headers */
 
@@ -93,7 +168,7 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
             case FUZZING_DROP_PACKET:
                 {
                     /* simulate droping the packet */
-                    packet_changed = fuzz_reduce_packet_size(tcpedit, pkthdr, pktdata, 0);
+                    packet_changed = fuzz_reduce_packet_size(tcpedit, pkthdr, 0);
                     if (packet_changed < 0) {
                         /* could not change packet size, so packet left unchanged */
                         return 0;
@@ -104,7 +179,7 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
                 {
                     /* reduce packet size */
                     uint32_t new_len = (r % ((*len) - 1)) + 1;
-                    packet_changed = fuzz_reduce_packet_size(tcpedit, pkthdr, pktdata, new_len);
+                    packet_changed = fuzz_reduce_packet_size(tcpedit, pkthdr, new_len);
                     if (packet_changed < 0) {
                         /* could not change packet size, so packet left unchanged */
                         return 0;
@@ -115,8 +190,8 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
             case FUZZING_CHANGE_START_ZERO:
                 {
                     /* fuzz random-size segment at the begining of the packet with 0x00 */
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len));
-                    memset((*pktdata), 0x00, sgt_size);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen);
+                    memset(pktdata, 0x00, sgt_size);
                     packet_changed = 1;
                 }
                 break;
@@ -124,9 +199,9 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
                 {
                     /* fuzz random-size segment at the begining of the packet with random Bytes */
                     int i;
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len));
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen);
                     for (i = 0; i < sgt_size; i++) {
-                        (*pktdata)[i] = (*pktdata)[i] ^ (r >> 4);
+                        pktdata[i] = pktdata[i] ^ (r >> 4);
                     }
                     packet_changed = 1;
                 }
@@ -134,8 +209,8 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
             case FUZZING_CHANGE_START_FF:
                 {
                     /* fuzz random-size segment at the begining of the packet with 0xff */
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len));
-                    memset((*pktdata), 0xff, sgt_size);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen);
+                    memset(pktdata, 0xff, sgt_size);
                     packet_changed = 1;
                 }
                 break;
@@ -143,8 +218,8 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
                 {
                     /* fuzz random-size segment inside the packet with 0x00 */
                     uint32_t offset = ((r >> 16) % ((*len) - 1)) + 1;
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len) - offset);
-                    memset((*pktdata) + offset, 0x00, sgt_size);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen - offset);
+                    memset(pktdata + offset, 0x00, sgt_size);
                     packet_changed = 1;
                 }
                 break;
@@ -152,16 +227,16 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
                 {
                     /* fuzz random-size segment inside the packet with 0xff */
                     uint32_t offset = ((r >> 16) % ((*len) - 1)) + 1;
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len) - offset);
-                    memset((*pktdata) + offset, 0xff, sgt_size);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen - offset);
+                    memset(pktdata + offset, 0xff, sgt_size);
                     packet_changed = 1;
                 }
                 break;
             case FUZZING_CHANGE_END_ZERO:
                 {
                     /* fuzz random-sized segment at the end of the packet with 0x00 */
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len));
-                    memset((*pktdata) + (*len) - sgt_size, 0x00, sgt_size);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen);
+                    memset(pktdata + (*len) - sgt_size, 0x00, sgt_size);
                     packet_changed = 1;
                 }
                 break;
@@ -169,9 +244,9 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
                 {
                     /* fuzz random-sized segment at the end of the packet with random Bytes */
                     int i;
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len));
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen);
                     for (i = ((*len) - sgt_size); i < (*len); i++) {
-                        (*pktdata)[i] = (*pktdata)[i] ^ (r >> 4);
+                        pktdata[i] = pktdata[i] ^ (r >> 4);
                     }
                     packet_changed = 1;
                 }
@@ -179,8 +254,8 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
             case FUZZING_CHANGE_END_FF:
                 {
                     /* fuzz random-sized segment at the end of the packet with 0xff00 */
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len));
-                    memset((*pktdata) + (*len) - sgt_size, 0xff, sgt_size);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen);
+                    memset(pktdata + (*len) - sgt_size, 0xff, sgt_size);
                     packet_changed = 1;
                 }
                 break;
@@ -191,9 +266,9 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
                     /* fuzz random-size segment inside the packet with random Bytes */
                     int i;
                     uint32_t offset = ((r >> 16) % ((*len) - 1)) + 1;
-                    uint32_t sgt_size = fuzz_get_sgt_size(r, (*len) - offset);
+                    uint32_t sgt_size = fuzz_get_sgt_size(r, datalen - offset);
                     for (i = offset; i < offset + sgt_size; i++) {
-                        (*pktdata)[i] = (*pktdata)[i] ^ (r >> 4);
+                        pktdata[i] = pktdata[i] ^ (r >> 4);
                     }
                     packet_changed = 1;
                 }


### PR DESCRIPTION
For example, this means :
- skipping TCP SYN packets
- no ethertype, ip addresses, not port number will be modified

Signed-off-by: Gabriel Ganne <gabriel.ganne@enea.com>