### PR TITLE
Fix sleep calculation when using multiple pcap files

### DIFF
--- a/src/replay.c
+++ b/src/replay.c
@@ -47,8 +47,6 @@ tcpr_replay_index(tcpreplay_t *ctx)
     int idx;
     assert(ctx);
 
-    init_timestamp(&ctx->stats.last_time);
-
     /* only process a single file */
     if (! ctx->options->dualfile) {
         /* process each pcap file in order */
@@ -56,6 +54,8 @@ tcpr_replay_index(tcpreplay_t *ctx)
             /* reset cache markers for each iteration */
             ctx->cache_byte = 0;
             ctx->cache_bit = 0;
+            /* reset timer state */
+            init_timestamp(&ctx->stats.last_time);
             switch(ctx->options->sources[idx].type) {
                 case source_filename:
                     rcode = replay_file(ctx, idx);
@@ -77,6 +77,8 @@ tcpr_replay_index(tcpreplay_t *ctx)
     else {
         /* process each pcap file in order */
         for (idx = 0; idx < ctx->options->source_cnt && !ctx->abort; idx += 2) {
+            /* reset timer state */
+            init_timestamp(&ctx->stats.last_time);
             if (ctx->options->sources[idx].type != ctx->options->sources[(idx+1)].type) {
                 tcpreplay_seterr(ctx, "Both source indexes (%d, %d) must be of the same type", idx, (idx+1));
                 return -1;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -512,9 +512,16 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         prev_packet = NULL;
     }
 
+    if (ctx->first_time) {
+        gettimeofday(&now, NULL);
+        now_is_now = true;
+    }
+
     if (!top_speed) {
         gettimeofday(&now, NULL);
         now_is_now = true;
+        start_us = TIMEVAL_TO_MICROSEC(&now);
+        ctx->first_time = true;
     } else {
         now_is_now = false;
     }
@@ -576,8 +583,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
                     options->cache_packets ? sp : NULL, &pkthdr, pktdata, datalink);
 
         if (ctx->first_time) {
-            /* get time and timestamp of the first packet */
-            gettimeofday(&now, NULL);
+            /* get timestamp of the first packet */
             memcpy(&first_pkt_ts, &pkthdr.ts, sizeof(struct timeval));
         }
 
@@ -751,9 +757,16 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
     pktdata1 = get_next_packet(ctx, pcap1, &pkthdr1, cache_file_idx1, prev_packet1);
     pktdata2 = get_next_packet(ctx, pcap2, &pkthdr2, cache_file_idx2, prev_packet2);
 
+    if (ctx->first_time) {
+        gettimeofday(&now, NULL);
+        now_is_now = true;
+    }
+
     if (!top_speed) {
         gettimeofday(&now, NULL);
         now_is_now = true;
+        start_us = TIMEVAL_TO_MICROSEC(&now);
+        ctx->first_time = true;
     } else {
         now_is_now = false;
     }
@@ -841,8 +854,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             update_flow_stats(ctx, sp, pkthdr_ptr, pktdata, datalink);
 
         if (ctx->first_time) {
-            /* get time and timestamp of the first packet */
-            gettimeofday(&now, NULL);
+            /* get timestamp of the first packet */
             memcpy(&first_pkt_ts, &pkthdr_ptr->ts, sizeof(struct timeval));
         }
 


### PR DESCRIPTION
Assume every file starts a new replay session, so reset the time this
session started, the time last packet was sent, and the timestamp of
the first packet in this trace.  Don't reset the global start time so
that stats are correct.