### PR TITLE
Avoid non-blocking behaviour when using STDIN

### DIFF
--- a/src/tcprewrite.c
+++ b/src/tcprewrite.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 #include <errno.h>
 
@@ -149,6 +150,11 @@ main(int argc, char *argv[])
 #ifdef ENABLE_DMALLOC
     dmalloc_shutdown();
 #endif
+
+    /* avoid making STDIN non-blocking */
+    int nb = 0;
+    ioctl(0, FIONBIO, &nb)
+
     return 0;
 }
 


### PR DESCRIPTION
While on BSD systems, tcprewrite likely sets `O_NDELAY` which is 
proper for most posix systems as this is the newer flag and they 
likely treat both similarly. However BSD and unix derivatives should 
likely utilize `FIONBIO` due to known issues with reading from tty 
with a 0 byte read returning -1 opposed to 0.

Reference comment 1: https://stackoverflow.com/questions/1150635/unix-nonblocking-i-o-o-nonblock-vs-fionbio

on behalf of Cisco Talos