### PR TITLE
Ensure the argument to {to,is}xxxx() is within allowed range.

### DIFF
--- a/libopts/makeshell.c
+++ b/libopts/makeshell.c
@@ -396,7 +396,7 @@ emit_usage(tOptions * opts)
 
         /* Copy the program name into the time/name buffer */
         for (;;) {
-            if ((*pzPN++ = (char)tolower(*pz++)) == NUL)
+            if ((*pzPN++ = (char)tolower((unsigned char)*pz++)) == NUL)
                 break;
         }
 
@@ -653,7 +653,7 @@ emit_match_expr(char const * name, tOptDesc * cod, tOptions * opts)
              *  They must not be the same.  They cannot be, because it would
              *  not compile correctly if they were.
              */
-            while (toupper(od->pz_Name[match_ct]) == toupper(name[match_ct]))
+            while (toupper((unsigned char)od->pz_Name[match_ct]) == toupper((unsigned char)name[match_ct]))
                 match_ct++;
 
             if (match_ct > min_match_ct)
@@ -666,8 +666,8 @@ emit_match_expr(char const * name, tOptDesc * cod, tOptions * opts)
                 continue;
 
             match_ct = 0;
-            while (  toupper(od->pz_DisableName[match_ct])
-                  == toupper(name[match_ct]))
+            while (  toupper((unsigned char)od->pz_DisableName[match_ct])
+                  == toupper((unsigned char)name[match_ct]))
                 match_ct++;
             if (match_ct > min_match_ct)
                 min_match_ct = match_ct;
@@ -905,7 +905,7 @@ genshelloptUsage(tOptions * opts, int exit_cd)
         AGDUPSTR(pz, optionParseShellOptions->pzPROGNAME, "prog name");
         *pp = pz;
         while (*pz != NUL) {
-            *pz = (char)tolower(*pz);
+            *pz = (char)tolower((unsigned char)*pz);
             pz++;
         }
     }

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -569,7 +569,7 @@ get_name2addr4(const char *hostname, bool dnslookup)
      *  We only want dots 'n decimals.
      */
     else {
-        if (!isdigit(hostname[0])) {
+        if (!isdigit((unsigned char)hostname[0])) {
             warnx("Expected dotted-quad notation (%s) when DNS lookups are disabled", 
                     hostname);
             /* XXX - this is actually 255.255.255.255 */

--- a/src/common/mac.c
+++ b/src/common/mac.c
@@ -42,7 +42,7 @@ mac2hex(const char *mac, u_char *dst, int len)
     if (len < 6)
         return;
 
-    while (isspace(*mac))
+    while (isspace((unsigned char)*mac))
         mac++;
 
     /* expect 6 hex octets separated by ':' or space/NUL if last octet */
@@ -50,7 +50,7 @@ mac2hex(const char *mac, u_char *dst, int len)
         l = strtol(mac, &pp, 16);
         if (pp == mac || l > 0xFF || l < 0)
             return;
-        if (!(*pp == ':' || (i == 5 && (isspace(*pp) || *pp == '\0'))))
+        if (!(*pp == ':' || (i == 5 && (isspace((unsigned char)*pp) || *pp == '\0'))))
             return;
         dst[i] = (u_char) l;
         mac = pp + 1;


### PR DESCRIPTION
The allowed value range for the arguments to the toxxxx() and
isxxxx() set of functions or macros is the value range of "unsigned
char" plus -1 (for EOF), using them with signed char args may invoke
undefined behaviour (or out-of-bounds-read); this set of changes
casts the args to unsigned char.