### PR TITLE
Bug #423 Remove limit for tcpprep -S

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1291,7 +1291,6 @@ dnl ###########################################################
 if test "x$NETMAPINCDIR" != "x"; then
     OLDCPPFLAGS="$CPPFLAGS"
     CPPFLAGS="$CPPFLAGS -DNETMAP_WITH_LIBS -DND -I$NETMAPINCDIR"
-    AC_CHECK_HEADERS(stdio.h net/netmap_user.h)
 
     have_nm_open=no
     have_nm_nr_reg_mask=no
@@ -1492,12 +1491,13 @@ dnl If doesn't exist, we'll define them in src/common/fakepcap.h
 AC_MSG_CHECKING(for DLT_LINUX_SLL in libpcap)
 AC_TRY_COMPILE([#include "$LPCAPINC"],
                [ int foo;
-                 foo = DLT_LINUX_SLL ],
-                [ AC_DEFINE([HAVE_DLT_LINUX_SLL], [1],
-                            [Does pcap.h include a header with DLT_LINUX_SLL?])
-                  AC_MSG_RESULT(yes)
-                ],
-                AC_MSG_RESULT(no)
+                 foo = DLT_LINUX_SLL
+               ],
+               [ AC_DEFINE([HAVE_DLT_LINUX_SLL], [1],
+                           [Does pcap.h include a header with DLT_LINUX_SLL?])
+                 AC_MSG_RESULT(yes)
+               ],
+               [AC_MSG_RESULT(no)]
                )
 
 AC_MSG_CHECKING(for DLT_C_HDLC in libpcap)
@@ -1547,22 +1547,29 @@ for testfile in $LPCAPINCDIR/pcap/bpf.h $LPCAPINCDIR/pcap-bpf.h ; do
                 AC_SUBST(PCAP_BPF_H_FILE)
                 AC_DEFINE([INCLUDE_PCAP_BPF_HEADER], [1],
                         [What is the path (if any) to the libpcap bpf header file?])
-                AC_MSG_RESULT($testfile)
-            ],
-            AC_MSG_RESULT(no)
+            ]
             )
     fi
 done
 
+if test $foundbpfheader != no; then
+    AC_MSG_RESULT($testfile)
+else
+    AC_MSG_RESULT(no)
+fi
+
 dnl ## Test for netmap-libpcap
 have_pcap_netmap=no
 if test $foundpcap != no ; then
+	AC_MSG_CHECKING(for netmap libpcap)
     PCAP_NETMAP_C_FILE="$LPCAPINCDIR/pcap-netmap.c"
     if test -f "${PCAP_NETMAP_C_FILE}" ; then
         AC_DEFINE([HAVE_LIBPCAP_NETMAP], [1],
                                    [Does this version of libpcap support netmap?])
-        AC_MSG_RESULT(yes)
         have_pcap_netmap=yes
+        AC_MSG_RESULT(yes)
+    else
+        AC_MSG_RESULT(no)
     fi
 fi
 

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 01/18/2018 Version 4.3.0 beta1
     - Travis CI build fails due to new build images (#432)
     - Unable to build with libpcap 1.8.1 (#430)
+    - tcpprep -S not working for large cache files (#423)
     - Unable to tcprewrite range of ports with --portmap (#422)
     - Avoid non-blocking behaviour when using STDIN (#416)
     - pcap containing >1020 packets produces invalid cache file (#415)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -278,9 +278,6 @@
 /* Define to 1 if you have the <net/bpf.h> header file. */
 #undef HAVE_NET_BPF_H
 
-/* Define to 1 if you have the <net/netmap_user.h> header file. */
-#undef HAVE_NET_NETMAP_USER_H
-
 /* Define to 1 if you have the <net/route.h> header file. */
 #undef HAVE_NET_ROUTE_H
 
@@ -389,9 +386,6 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
-
-/* Define to 1 if you have the <stdio.h> header file. */
-#undef HAVE_STDIO_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H

--- a/src/tcpprep.c
+++ b/src/tcpprep.c
@@ -634,8 +634,8 @@ print_stats(const char *file)
     COUNTER pri = 0, sec = 0, nosend = 0;
     
     count = read_cache(&cachedata, file, &comment);
-    if (count > 65535)
-        exit(-1);
+//    if (count > 65535)
+//        exit(-1);
 
     for (COUNTER i = 1; i <= count; i ++) {
         int cacheval = check_cache(cachedata, i);


### PR DESCRIPTION
Found a limit of 65K packets for reporting cache files. Removed.