### PR TITLE
resolve possible null pointer dereference

### DIFF
--- a/src/fragroute/bget.c
+++ b/src/fragroute/bget.c
@@ -811,11 +811,11 @@ void brel(buf)
 {
     struct bfhead *b, *bn;
 
+    assert(buf != NULL);
     b = BFH(((char *) buf) - sizeof(struct bhead));
 #ifdef BufStats
     numrel++;			      /* Increment number of brel() calls */
 #endif
-    assert(buf != NULL);
 
 #ifdef BECtl
     if (b->bh.bsize == 0) {	      /* Directly-acquired buffer? */


### PR DESCRIPTION
issue detected by cppcheck

[src/fragroute/bget.c:814] -> [src/fragroute/bget.c:818]: (warning) Either the condition 'buf!=NULL' is redundant or there is overflow in pointer subtraction.