### PR TITLE
Bug #474 enable pcap_findalldevs when --with-testnic is specified

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1712,6 +1712,22 @@ AC_ARG_WITH(testnic,
     AC_HELP_STRING([--with-testnic=NIC], [Select which network card to use for testing]),
     [ nic1=$withval
       nic2=$withval
+  
+disable_pcap_findalldevs=no
+osx_frameworks=no
+
+case $host in
+
+  *-apple-darwin*)
+  
+      if test x$libpcap_version_096 = xno ; then
+        disable_pcap_findalldevs=yes
+      fi
+	  osx_frameworks=yes
+  ;;
+  *)
+  ;;
+  esac;
       AC_MSG_RESULT([Using --with-testnic=$withval])],
     [
 


### PR DESCRIPTION
This setting was being skipped when --with-testnic=xxx was specified to ./configure.

Also enables osx_frameworks var when the option is specified when building for OS X.  This should make the option have only the intended effect of setting test test nic values on the build.

There may be some other issues with the current structure.  E.g. lines such as AC_DEFINE([HAVE_LINUX], [1], [Building Linux]) are never reached with testnic defined.