### PR TITLE
Add --skip-pkts and --skip-to-secs to allow skipping packets when replaying

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -381,6 +381,16 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         prev_packet = NULL;
     }
 
+    /* SKIP PACKETS
+     * Looping over packets to skip
+     */
+    if(ctx->options->skip_pkts > 0) {
+        for (uint32_t i = 0; i < ctx->options->skip_pkts && !ctx->abort && 
+              (pktdata = get_next_packet(options, pcap, &pkthdr, idx, prev_packet)) != NULL; i++) {
+        }
+    }
+
+
     /* MAIN LOOP
      * Keep sending while we have packets or until
      * we've sent enough packets
@@ -389,6 +399,11 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
            (pktdata = get_next_packet(options, pcap, &pkthdr, idx, prev_packet)) != NULL) {
         struct timespec pkthdr_ts;
         TIMEVAL_AS_TIMESPEC_SET(&pkthdr_ts, &pkthdr.ts); // libpcap puts nanosec values in tv_usec
+
+        /* Skip packets */
+        if(timerisset(&(ctx->options->skip_to)) && timercmp(&ctx->options->skip_to, &(pkthdr.ts), >)){
+            continue; /* Skip packet */
+        }
         now_is_now = false;
         packetnum++;
 #if defined TCPREPLAY || defined TCPREPLAY_EDIT

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -168,6 +168,9 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
     options->loopdelay_ms = OPT_VALUE_LOOPDELAY_MS;
     options->loopdelay_ns = OPT_VALUE_LOOPDELAY_NS;
 
+    options->skip_pkts = OPT_VALUE_SKIP_PKTS;
+    options->skip_to.tv_sec = OPT_VALUE_SKIP_TO_SECS;
+
     if (HAVE_OPT(LIMIT))
         options->limit_send = OPT_VALUE_LIMIT;
 

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -105,6 +105,10 @@ typedef struct tcpreplay_opt_s {
     u_int32_t loopdelay_ms;
     u_int32_t loopdelay_ns;
 
+    /* Skip packets */
+    u_int32_t skip_pkts;
+    struct timeval skip_to;
+
     int stats;
     bool use_pkthdr_len;
 

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -319,6 +319,24 @@ flag = {
 };
 
 flag = {
+    name        = skip-pkts;
+    arg-type    = number;
+    arg-range   = "0->";
+    descrip     = "Skip X packets into a packet file";
+    arg-default = 0;
+    doc         = "";
+};
+
+
+flag = {
+    name        = skip-to-secs;
+    arg-type    = number;
+    descrip     = "Skip X seconds since linux epoch into a packet file";
+    arg-default = 0;
+    doc         = "";
+};
+
+flag = {
     name        = loopdelay-ms;
     flags-cant  = loopdelay-ns;
     flags-must  = loop;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `--skip-pkts x` as parameter to `tcpreplay`. It adds support for skipping the first X packets in a pcap file
- Add `--skip-to-secs Y` as parameter to `tcpreplay`. It adds support for skipping until Y seconds into the pcap file. The seconds is absolute since since the unix epoch

## Other comments:
We needed this in a project where we used a series of pcap files for storing sound and video recordings. If a user wanted to start a replay from a certain date and time we would know which pcap file to replay (based on the filename of the pcap file) and by using `--skip-to-seconds` we could jump to the date and time in the pcap file.
