### PR TITLE
Bug #485 Heap overflow fixed in #484

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -3,6 +3,7 @@
     - CVE-2018-18408 use-after-free in post_args (#489)
     - CVE-2018-18407 heap-buffer-overflow csum_replace4 (#488)
     - CVE-2018-17974 heap-buffer-overflow dlt_en10mb_encode (#486)
+    - CVE-2018-17580 heap-buffer-overflow fast_edit_packet (#485)
     - CVE-2018-17582 heap-buffer-overflow in get_next_packet (#484)
     - Out-of-tree build (#482)
     - CVE-2018-13112 heap-buffer-overflow in get_l2len (#477 dup #408)


### PR DESCRIPTION
Getting the following error message when attempting to reproduce bug:

tcpreplay -i ens33 --unique-ip -t --loop 4 fast_edit_package_02
safe_pcap_next ERROR: Invalid packet length in send_packets.c:get_next_packet() line 1054: packet length 28 is less than capture length 60