### PR TITLE
Bug #424 Fix compatibility for netmap version 10 and higher

### DIFF
--- a/src/common/netmap.h
+++ b/src/common/netmap.h
@@ -35,15 +35,18 @@
 #   include <linux/sockios.h>
 #endif /* linux */
 
-#ifdef HAVE_NETMAP_RING_HEAD_TAIL
+#ifndef NETMAP_API
+#define NETMAP_API 0
+#endif
+
+#if NETMAP_API >= 10
+#define NETMAP_TX_RING_EMPTY(ring) (nm_tx_pending(ring))
+#define NETMAP_RING_NEXT(r, i) nm_ring_next(r, i)
+#elif defined HAVE_NETMAP_RING_HEAD_TAIL
 #define NETMAP_TX_RING_EMPTY(ring) (nm_ring_space(ring) >= (ring)->num_slots - 1)
 #define NETMAP_RING_NEXT(r, i) nm_ring_next(r, i)
 #else
 #define nm_ring_space(ring) (ring->avail)
-#endif /* NETMAP_API < 10 */
-
-#ifndef NETMAP_API
-#define NETMAP_API 0
 #endif
 
 #ifndef HAVE_NETMAP_NR_REG


### PR DESCRIPTION
As of netmap commit 7b16969f (version 10), should use nm_tx_pending()
to determine whether the TX buffers still contain data.

Fix is to use nm_tx_pending() rather than NETMAP_TX_RING_EMPTY,
unless using an older version of netmap.