### PR TITLE
Bug #528 Yield in netmap main loop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl $Id$
 AC_PREREQ([2.69])
 
 dnl Set version info here!
-AC_INIT([tcpreplay],[4.3.0-beta2],
+AC_INIT([tcpreplay],[4.3.0-beta3],
     [https://github.com/appneta/tcpreplay/issues],
     [tcpreplay],
     [http://tcpreplay.sourceforge.net/])
@@ -144,7 +144,7 @@ else
 fi
 
 
-AM_INIT_AUTOMAKE([foreign subdir-objects no-dist-gzip dist-xz -Wall -Wno-override])
+AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Wno-override])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 dnl Checks for programs.

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -436,6 +436,10 @@ TRY_SEND_AGAIN:
                 /* this indicates that a retry was requested - this is not a failure */
                 sp->retry_eagain ++;
                 retcode = 0;
+#ifdef HAVE_SCHED_H
+                /* yield the CPU so other apps remain responsive */
+                sched_yield();
+#endif
                 goto TRY_SEND_AGAIN;
             }
 #endif /* HAVE_NETMAP */

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -359,7 +359,6 @@ EOText;
 flag = {
     name        = duration;
     arg-type    = number;
-    flags-must  = loop;
     max         = 1;
     arg-default = -1;
     arg-range   = "1->";


### PR DESCRIPTION
This fix will yield the CPU while netmap is waiting
for buffers.

On my test system, this improved performance by only
60Mbps, not the 4Gbps performance loss identified
by this bug. Therefore, this is not the final fix
for this bug.