### PR TITLE
fix typos throughout the repository

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -704,7 +704,7 @@ AC_ARG_WITH(libpcap,
     # and was created to address portability issues. Unfortunately, the script is not updated properly
     # outside of the base distribution. Examples: PF_RING requires 'pthreads', 'numa' and 'rt', but
     # this is not reflect that in the script. OS X Xcode 10.11 SDK creates its own very broken
-    # 'pcap-config' script that only occassionally works for dynamic defintions, and defintely
+    # 'pcap-config' script that only occasionally works for dynamic definitions, and defintely
     # does not work for static.
     #
     # The ability to enable this script exists for corner cases where libpcap distributions starts

--- a/docs/TODO
+++ b/docs/TODO
@@ -23,7 +23,7 @@ GENERAL:
 
 + Re-organize source tree
 
-+ tcpdump decoder should print packets syncronously w/ the main process
++ tcpdump decoder should print packets synchronously w/ the main process
 
 + Better use of GNU Autotools
 
@@ -37,7 +37,7 @@ GENERAL:
 - Detect system version of libopts b/c we need a recent version
 
 + Generalize packet editing and printing code so it can be shipped as a 
-  seperate library and plugged into tcpreplay/tcprewrite/flowreplay/etc
+  separate library and plugged into tcpreplay/tcprewrite/flowreplay/etc
 
 + See about removing libnet_init() from all binaries other then tcprewrite
   so we don't have to run as root:
@@ -101,7 +101,7 @@ TCPREWRITE:
   that tcpreplay can be more optimized
     ? perhaps use libnetdude?
     ? make into a library?
-    + definately put it into a seperate binary (tcprewrite)
+    + definitely put it into a separate binary (tcprewrite)
 
 - Add the ability to modify packet data via regex(es) in tcprewrite
   - Should support pcre

--- a/doxygen.cfg.in
+++ b/doxygen.cfg.in
@@ -389,7 +389,7 @@ SHOW_DIRECTORIES       = YES
 # version control system). Doxygen will invoke the program by executing (via 
 # popen()) the command <command> <input-file>, where <command> is the value of 
 # the FILE_VERSION_FILTER tag, and <input-file> is the name of an input file 
-# provided by doxygen. Whatever the progam writes to standard output 
+# provided by doxygen. Whatever the program writes to standard output
 # is used as the file version. See the manual for examples.
 
 FILE_VERSION_FILTER    = 

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -114,7 +114,7 @@ do_bridge_unidirectional(tcpbridge_opt_t *options, tcpedit_t *tcpedit)
 
 /**
  * main loop for bridging in both directions.  Since we dealing with two handles
- * we need to poll() on them which isn't the most efficent
+ * we need to poll() on them which isn't the most efficient
  */
 static void
 do_bridge_bidirectional(tcpbridge_opt_t *options, tcpedit_t *tcpedit)
@@ -245,7 +245,7 @@ do_bridge(tcpbridge_opt_t *options, tcpedit_t *tcpedit)
 
 /**
  * This is the callback we use with pcap_dispatch to process
- * each packet recieved by libpcap on the two interfaces.
+ * each packet received by libpcap on the two interfaces.
  * Need to return > 0 to denote success
  */
 static int

--- a/src/common/cache.h
+++ b/src/common/cache.h
@@ -32,7 +32,7 @@
 
 /* 
  * CACHEVERSION History:
- * 01 - Inital release.  1 bit of data/packet (primary or secondary nic)
+ * 01 - Initial release.  1 bit of data/packet (primary or secondary nic)
  * 02 - 2 bits of data/packet (drop/send & primary or secondary nic)
  * 03 - Write integers in network-byte order
  * 04 - Increase num_packets from 32 to 64 bit integer

--- a/src/common/fakepcap.c
+++ b/src/common/fakepcap.c
@@ -19,7 +19,7 @@
  */
 
 /*
- * This file impliments missing libpcap functions which only exist in really
+ * This file implements missing libpcap functions which only exist in really
  * recent versions of libpcap.  We assume the user has at least 0.6, so anything
  * after that needs to be re-implimented here unless we want to start 
  * requiring a newer version

--- a/src/common/fakepcapnav.c
+++ b/src/common/fakepcapnav.c
@@ -18,7 +18,7 @@
  *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*  This file impliments a fake, non-functioning version of the libpcapnav
+/*  This file implements a fake, non-functioning version of the libpcapnav
  *  API based on libpcap.  It's solely here for people who don't have 
  *  libpcapnav installed on their system, and to keep the code maintainable.
  */

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -270,7 +270,7 @@ get_ipv4(const u_char *pktdata, int datalen, int datalink, u_char **newbuff)
         ip_hdr = *newbuff;
     } else {
 
-        /* we don't have to do a memcpy if l2_len lands on a boundry */
+        /* we don't have to do a memcpy if l2_len lands on a boundary */
         ip_hdr = (pktdata + l2_len);
     }
 #else
@@ -332,7 +332,7 @@ get_ipv6(const u_char *pktdata, int datalen, int datalink, u_char **newbuff)
         ip6_hdr = *newbuff;
     } else {
 
-        /* we don't have to do a memcpy if l2_len lands on a boundry */
+        /* we don't have to do a memcpy if l2_len lands on a boundary */
         ip6_hdr = (pktdata + l2_len);
     }
 #else
@@ -438,7 +438,7 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int len)
 
 
 /**
- * returns the next payload or header of the current extention header
+ * returns the next payload or header of the current extension header
  * returns NULL for none/ESP.
  */
 void *

--- a/src/common/netmap.c
+++ b/src/common/netmap.c
@@ -269,7 +269,7 @@ sendpacket_open_netmap(const char *device, char *errbuf, void *arg) {
      * The nmreq structure must have the NETMAP_API version for the running machine.
      * However the binary may have been compiled on a different machine than the
      * running machine. Discover the true netmap API version, and be careful to call
-     * fuctions that are available on all netmap versions.
+     * functions that are available on all netmap versions.
      */
     if (sp->netmap_version >= 10) {
         switch (*port) {

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -20,7 +20,7 @@
 
  /* sendpacket.[ch] is my attempt to write a universal packet injection
   * API for BPF, libpcap, libdnet, and Linux's PF_PACKET.  I got sick
-  * and tired dealing with libnet bugs and its lack of active maintenence,
+  * and tired dealing with libnet bugs and its lack of active maintenance,
   * but unfortunately, libpcap frame injection support is relatively new
   * and not everyone uses Linux, so I decided to support all four as
   * best as possible.  If your platform/OS/hardware supports an additional
@@ -37,7 +37,7 @@
   * Right now, one big problem with the pcap_* methods is that libpcap
   * doesn't provide a reliable method of getting the MAC address of
   * an interface (required for tcpbridge).
-  * You can use PF_PACKET or BPF to get that, but if your system suports
+  * You can use PF_PACKET or BPF to get that, but if your system supports
   * those, might as well inject directly without going through another
   * level of indirection.
   *
@@ -1008,7 +1008,7 @@ get_iface_index(int fd, const char *device, char *errbuf) {
 }
 
 /**
- * get's the hardware address via Linux's PF packet interface
+ * gets the hardware address via Linux's PF packet interface
  */
 static struct tcpr_ether_addr *
 sendpacket_get_hwaddr_pf(sendpacket_t *sp)

--- a/src/common/tcpdump.c
+++ b/src/common/tcpdump.c
@@ -169,7 +169,7 @@ data_again:
 
     res = poll(&poller, 1, TCPDUMP_POLL_TIMEOUT);
     if (res < 0)
-        errx(-1, "Error out to fd %d during poll() to read frome tcpdump\n%s",
+        errx(-1, "Error out to fd %d during poll() to read from tcpdump\n%s",
                 PARENT_READ_FD, strerror(errno));
 
     if (res == 0)

--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -126,7 +126,7 @@ txring_put(txring_t *txp, const void * data, size_t length)
             first_loop = 0;
         }
 
-        /* check if we've runned over all ring */
+        /* check if we've ran over all ring */
         if ((txp->tx_index == start_index) && !first_loop) {
             errno = ENOBUFS;
             return -1;

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -282,7 +282,7 @@ read_hexstring(const char *l2string, u_char *hex, const int hexlen)
 
     memset(hex, '\0', hexlen);
 
-    /* data is hex, comma seperated, byte by byte */
+    /* data is hex, comma separated, byte by byte */
 
     /* get the first byte */
     l2byte = strtok_r(string, ",", &token);

--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -263,7 +263,7 @@ typedef enum tcpprep_mode_e {
 #endif
 #endif
 
-/* convert IPv6 Extention Header Len value to bytes */
+/* convert IPv6 Extension Header Len value to bytes */
 #define IPV6_EXTLEN_TO_BYTES(x) ((x * 4) + 8)
 
 #ifndef HAVE_UINT8_T

--- a/src/fragroute/bget.c
+++ b/src/fragroute/bget.c
@@ -100,7 +100,7 @@
     configured to the needs of an application.    BGET is  efficient  in
     both  the  time  needed to allocate and release buffers and in the
     memory  overhead  required    for  buffer   pool   management.    It
-    automatically    consolidates   contiguous     space     to   minimise
+    automatically    consolidates   contiguous     space     to   minimize
     fragmentation.  BGET is configured    by  compile-time  definitions,
     Major options include:
 

--- a/src/fragroute/mod_ip_frag.c
+++ b/src/fragroute/mod_ip_frag.c
@@ -83,7 +83,7 @@ ip_frag_apply(void *d, struct pktq *pktq)
 {
     struct pkt *pkt;
 
-    /* Select eth protocol via first packet in que: */
+    /* Select eth protocol via first packet in queue: */
     pkt = TAILQ_FIRST(pktq);
     if (pkt != TAILQ_END(pktq)) {
         uint16_t eth_type = htons(pkt->pkt_eth->eth_type);

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -1068,7 +1068,7 @@ get_next_packet(tcpreplay_t *ctx, pcap_t *pcap, struct pcap_pkthdr *pkthdr, int 
         pktdata = safe_pcap_next(pcap, pkthdr);
     }
 
-    /* this get's casted to a const on the way out */
+    /* this gets casted to a const on the way out */
     return pktdata;
 }
 

--- a/src/tcpedit/dlt.c
+++ b/src/tcpedit/dlt.c
@@ -92,7 +92,7 @@ dltrequires(tcpedit_t *tcpedit, int dlt)
         case DLT_EN10MB:
 /*        case DLT_USER:
         case DLT_VLAN: */
-            /* we have everthing we need in the original packet */
+            /* we have everything we need in the original packet */
             break;
 
         case DLT_NULL:

--- a/src/tcpedit/edit_packet.c
+++ b/src/tcpedit/edit_packet.c
@@ -49,11 +49,11 @@ static int ipv6_header_length(ipv6_hdr_t const * ip6_hdr, int pkt_len);
 /**
  * this code re-calcs the IP and Layer 4 checksums
  * the IMPORTANT THING is that the Layer 4 header 
- * is contiguious in memory after *ip_hdr we're actually
+ * is contiguous in memory after *ip_hdr we're actually
  * writing to the layer 4 header via the ip_hdr ptr.
  * (Yes, this sucks, but that's the way libnet works, and
  * I was too lazy to re-invent the wheel.
- * Returns 0 on sucess, -1 on error
+ * Returns 0 on success, -1 on error
  */
 int
 fix_ipv4_checksums(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr, ipv4_hdr_t *ip_hdr)
@@ -1054,7 +1054,7 @@ randomize_iparp(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
 /**
  * rewrite IP address (arp)
  * uses -a to rewrite (map) one subnet onto another subnet
- * pointer must point to the WHOLE and CONTIGOUS memory buffer
+ * pointer must point to the WHOLE and CONTIGUOUS memory buffer
  * because the arp_hdr_t doesn't have the space for the IP/MAC
  * addresses
  * return 0 if no change, 1 or 2 if changed

--- a/src/tcpedit/parse_args.c
+++ b/src/tcpedit/parse_args.c
@@ -31,8 +31,8 @@
 
 
 /**
- * returns 0 for sucess w/o errors
- * returns 1 for sucess w/ warnings
+ * returns 0 for success w/o errors
+ * returns 1 for success w/ warnings
  * returns -1 for error
  */
 int 

--- a/src/tcpedit/plugins/dlt_en10mb/Makefile.am
+++ b/src/tcpedit/plugins/dlt_en10mb/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
 	%reldir%/en10mb.c \
@@ -18,7 +18,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/en10mb_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 en10mb.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/en10mb.h \

--- a/src/tcpedit/plugins/dlt_en10mb/en10mb.c
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb.c
@@ -86,7 +86,7 @@ dlt_en10mb_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_hdlc/Makefile.am
+++ b/src/tcpedit/plugins/dlt_hdlc/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
 	%reldir%/hdlc.c \
@@ -17,7 +17,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/hdlc_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 hdlc.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/hdlc.h \

--- a/src/tcpedit/plugins/dlt_hdlc/hdlc.c
+++ b/src/tcpedit/plugins/dlt_hdlc/hdlc.c
@@ -84,7 +84,7 @@ dlt_hdlc_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_hdlc/hdlc_api.c
+++ b/src/tcpedit/plugins/dlt_hdlc/hdlc_api.c
@@ -27,7 +27,7 @@
 #include "hdlc_api.h"
 
 /**
- * \breif Set the HDLC control value
+ * \brief Set the HDLC control value
  *
  * Reasonable values are 0-255
  */

--- a/src/tcpedit/plugins/dlt_ieee80211/Makefile.am
+++ b/src/tcpedit/plugins/dlt_ieee80211/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
 	%reldir%/ieee80211.c \
@@ -17,7 +17,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/ieee80211_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 ieee80211.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/ieee80211_hdr.c \

--- a/src/tcpedit/plugins/dlt_ieee80211/ieee80211.c
+++ b/src/tcpedit/plugins/dlt_ieee80211/ieee80211.c
@@ -92,7 +92,7 @@ dlt_ieee80211_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_jnpr_ether/Makefile.am
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
 	%reldir%/jnpr_ether.c \
@@ -17,7 +17,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/jnpr_ether_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 jnpr_ether.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/jnpr_ether.h \

--- a/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.c
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.c
@@ -100,7 +100,7 @@ dlt_jnpr_ether_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_linuxsll/Makefile.am
+++ b/src/tcpedit/plugins/dlt_linuxsll/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += %reldir%/linuxsll.c
 
@@ -14,7 +14,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/linuxsll_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 linuxsll.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/../../tcpedit_api.h \

--- a/src/tcpedit/plugins/dlt_linuxsll/linuxsll.c
+++ b/src/tcpedit/plugins/dlt_linuxsll/linuxsll.c
@@ -87,7 +87,7 @@ dlt_linuxsll_register(tcpeditdlt_t *ctx)
 
 
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_loop/Makefile.am
+++ b/src/tcpedit/plugins/dlt_loop/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += %reldir%/loop.c
 
@@ -12,7 +12,7 @@ noinst_HEADERS += %reldir%/loop.h
 
 EXTRA_DIST += %reldir%/loop_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 loop.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/loop.h

--- a/src/tcpedit/plugins/dlt_null/Makefile.am
+++ b/src/tcpedit/plugins/dlt_null/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += %reldir%/null.c
 
@@ -12,7 +12,7 @@ noinst_HEADERS += %reldir%/null.h
 
 EXTRA_DIST += %reldir%/null_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 null.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/null.h

--- a/src/tcpedit/plugins/dlt_pppserial/Makefile.am
+++ b/src/tcpedit/plugins/dlt_pppserial/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
 	%reldir%/pppserial.c \
@@ -17,7 +17,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/pppserial_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 pppserial.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/pppserial.h \

--- a/src/tcpedit/plugins/dlt_pppserial/pppserial.c
+++ b/src/tcpedit/plugins/dlt_pppserial/pppserial.c
@@ -99,7 +99,7 @@ dlt_pppserial_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_radiotap/Makefile.am
+++ b/src/tcpedit/plugins/dlt_radiotap/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += %reldir%/radiotap.c
 
@@ -12,7 +12,7 @@ noinst_HEADERS += %reldir%/radiotap.h
 
 EXTRA_DIST += %reldir%/radiotap_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 radiotap.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/radiotap.h

--- a/src/tcpedit/plugins/dlt_radiotap/radiotap.c
+++ b/src/tcpedit/plugins/dlt_radiotap/radiotap.c
@@ -93,7 +93,7 @@ dlt_radiotap_register(tcpeditdlt_t *ctx)
 }
 
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN
@@ -218,7 +218,7 @@ dlt_radiotap_encode(tcpeditdlt_t *ctx, u_char *packet, _U_ int pktlen,
 
 /*
  * Function returns the Layer 3 protocol type of the given packet, or TCPEDIT_ERROR on error
- * Make sure you return this in host byte order since all the comparisions will be
+ * Make sure you return this in host byte order since all the comparisons will be
  * against the ETHERTYPE_* values which are oddly in host byte order.
  */
 int 

--- a/src/tcpedit/plugins/dlt_raw/Makefile.am
+++ b/src/tcpedit/plugins/dlt_raw/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += %reldir%/raw.c
 
@@ -12,7 +12,7 @@ noinst_HEADERS += %reldir%/raw.h
 
 EXTRA_DIST += %reldir%/raw_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 raw.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/raw.h

--- a/src/tcpedit/plugins/dlt_raw/raw.c
+++ b/src/tcpedit/plugins/dlt_raw/raw.c
@@ -87,7 +87,7 @@ dlt_raw_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_template/Makefile.am
+++ b/src/tcpedit/plugins/dlt_template/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 eol =
 
@@ -23,7 +23,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/%{plugin}_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 %{plugin}.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/%{plugin}.h \

--- a/src/tcpedit/plugins/dlt_template/plugin.c.tmpl
+++ b/src/tcpedit/plugins/dlt_template/plugin.c.tmpl
@@ -102,7 +102,7 @@ dlt_%{plugin}_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_user/Makefile.am
+++ b/src/tcpedit/plugins/dlt_user/Makefile.am
@@ -4,7 +4,7 @@
 # add your .c files to libtcpedit_a_SOURCES
 # add your .h files to noinst_HEADERS
 # add any other files (like documentation, notes, etc) to EXTRA_DIST
-# add your dependancy information (see comment below)
+# add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
 	%reldir%/user.c \
@@ -17,7 +17,7 @@ noinst_HEADERS += \
 
 EXTRA_DIST += %reldir%/user_opts.def
 
-# dependancies for your plugin source code.  Edit as necessary
+# dependencies for your plugin source code.  Edit as necessary
 user.c: \
 	$(TCPEDIT_PLUGINS_DEPS) \
 	%reldir%/user.h \

--- a/src/tcpedit/plugins/dlt_user/user.c
+++ b/src/tcpedit/plugins/dlt_user/user.c
@@ -84,7 +84,7 @@ dlt_user_register(tcpeditdlt_t *ctx)
 
  
 /*
- * Initializer function.  This function is called only once, if and only iif
+ * Initializer function.  This function is called only once, if and only if
  * this plugin will be utilized.  Remember, if you need to keep track of any state, 
  * store it in your plugin->config, not a global!
  * Returns: TCPEDIT_ERROR | TCPEDIT_OK | TCPEDIT_WARN

--- a/src/tcpedit/plugins/dlt_user/user_api.c
+++ b/src/tcpedit/plugins/dlt_user/user_api.c
@@ -54,7 +54,7 @@ tcpedit_user_set_dlt_type(tcpedit_t *tcpedit, uint16_t type)
 /**
  * \brief Define the actual L2 header content.
  *
- * You need to set the data, it's lenght and which direction(s) to apply to.
+ * You need to set the data, it's length and which direction(s) to apply to.
  * BOTH - both directions (or in the case of no tcpprep cache file)
  * S2C - server to client (primary interface)
  * C2S - client to server (secondary interface)

--- a/src/tcpedit/plugins/dlt_utils.c
+++ b/src/tcpedit/plugins/dlt_utils.c
@@ -271,7 +271,7 @@ tcpedit_dlt_copy_decoder_state(tcpeditdlt_t *ctx, tcpeditdlt_t *subctx)
     ctx->decoded_extra_size = subctx->decoded_extra_size;
 
     /* 
-     * the first decoder should of alraedy specified it's l2len, so we need to
+     * the first decoder should of already specified it's l2len, so we need to
      * add to it the l2len determined by the sub-plugin
      */
     ctx->l2len += subctx->l2len;

--- a/src/tcpedit/tcpedit.c
+++ b/src/tcpedit/tcpedit.c
@@ -73,7 +73,7 @@ tcpedit_checkdir(tcpedit_t *tcpedit, tcpr_dir_t direction)
 /**
  * \brief Edit the given packet
  *
- * Processs a given packet and edit the pkthdr/pktdata structures
+ * Process a given packet and edit the pkthdr/pktdata structures
  * according to the rules in tcpedit
  * Returns: TCPEDIT_ERROR on error
  *          TCPEDIT_SOFT_ERROR on remove packet
@@ -426,7 +426,7 @@ tcpedit_get_output_dlt(tcpedit_t *tcpedit)
  *
  * Validates that given the current state of tcpedit that the given
  * pcap source and destination (based on DLT) can be properly rewritten
- * return 0 on sucess
+ * return 0 on success
  * return -1 on error
  * DO NOT USE!
  */

--- a/src/tcpedit/tcpedit_api.c
+++ b/src/tcpedit/tcpedit_api.c
@@ -233,7 +233,7 @@ tcpedit_set_mtu(tcpedit_t *tcpedit, int value)
 }
 
 /**
- * Enable trucating packets to the MTU lenght
+ * Enable truncating packets to the MTU length
  */
 int tcpedit_set_mtu_truncate(tcpedit_t *tcpedit, bool value)
 {

--- a/src/tcpedit/tcpedit_api.h
+++ b/src/tcpedit/tcpedit_api.h
@@ -27,7 +27,7 @@ extern "C" {
 
 /**
  * Selection of the encoder plugin is usually done by tcpedit_post_args()
- * so when using the config API you must manually specifiy it using one of
+ * so when using the config API you must manually specify it using one of
  * the following functions
  */
 int tcpedit_set_encoder_dltplugin_byid(tcpedit_t *, int);

--- a/src/tcpliveplay.c
+++ b/src/tcpliveplay.c
@@ -47,7 +47,7 @@
  * packet or wait for a remote packet to arrive. 
 
  *
- * Usage: tcpliveplay <eth0/eth1> <file.pcap> <Destinatin IP [1.2.3.4]> <Destination mac [0a:1b:2c:3d:4e:5f]> <'random' dst port OR specify dport #>
+ * Usage: tcpliveplay <eth0/eth1> <file.pcap> <Destination IP [1.2.3.4]> <Destination mac [0a:1b:2c:3d:4e:5f]> <'random' dst port OR specify dport #>
  *
  * Example:  
  * yhsiam@yhsiam-VirtualBox:~$ tcpliveplay eth0 test1.pcap 192.168.1.4 52:57:01:11:31:92 random
@@ -164,7 +164,7 @@ main(int argc, char **argv)
 
     if((argc < 5) || (argv[1]==NULL) || (argv[2]==NULL) || (argv[3]==NULL) || (argv[4]==NULL) || (argv[5]==NULL)){
         printf("ERROR: Incorrect Usage!\n"); 
-        printf("Usage: tcpliveplay <eth0/eth1> <file.pcap> <Destinatin IP [1.2.3.4]> <Destination mac [0a:1b:2c:3d:4e:5f]> <specify 'random' or specific port#>\n");
+        printf("Usage: tcpliveplay <eth0/eth1> <file.pcap> <Destination IP [1.2.3.4]> <Destination mac [0a:1b:2c:3d:4e:5f]> <specify 'random' or specific port#>\n");
         printf("Example:\n    yhsiam@yhsiam-VirtualBox:~$ sudo tcpliveplay eth0 test1.pcap 192.168.1.4 52:57:01:11:31:92 random\n\n"); 
         exit(0);
     }
@@ -449,7 +449,7 @@ relative_sched(struct tcp_sched* sched, u_int32_t first_rseq, int num_packets){
         else if(sched[i].remote){
             sched[i].exp_rseq = sched[i].exp_rseq - first_rseq; /* Fix expected remote SEQ to be relative */
             sched[i].exp_rack = sched[i].exp_rack - first_lseq; /* Fix expected remote ACK to be relative*/
-            sched[i].exp_rack = sched[i].exp_rack + lseq_adjust; /* Fix expeted remote ACK to be absolute */
+            sched[i].exp_rack = sched[i].exp_rack + lseq_adjust; /* Fix expected remote ACK to be absolute */
         }
     }
 
@@ -544,7 +544,7 @@ setup_sched(struct tcp_sched* sched){
             remote_ip = dip;
         }
 
-        /*Compare IPs to see which packet is this comming from*/
+        /*Compare IPs to see which packet is this coming from*/
         if(compip(&local_ip, &remote_ip, &sip)==LOCAL_IP_MATCH){
             local = true;
             remote = false;
@@ -818,7 +818,7 @@ got_packet(_U_ u_char *args, _U_ const struct pcap_pkthdr *header,
         acked_index = sched_index; /*Keep track correctly ACKed packet index*/
     } 
 
-    /* Global variable to keep tack of last recieved packet info */
+    /* Global variable to keep tack of last received packet info */
     packet_keeper_rprev = packet;  
     etherhdr_rprev = etherhdr; 
     tcphdr_rprev = tcphdr;
@@ -1160,17 +1160,17 @@ fix_all_checksum_liveplay(ipv4_hdr *iphdr){
 
 /************************************************************************************/
 
-/*[copied from Aaron Turnor's checksum.c, but ommitting tcpedit_t structs] */
+/*[copied from Aaron Turnor's checksum.c, but omitting tcpedit_t structs] */
 /*[The following functions have been slightly modified to be integrated with tcpliveplay code structure] */
 
 /** 
  * This code re-calcs the IP and Layer 4 checksums
  * the IMPORTANT THING is that the Layer 4 header 
- * is contiguious in memory after *ip_hdr we're actually
+ * is contiguous in memory after *ip_hdr we're actually
  * writing to the layer 4 header via the ip_hdr ptr.
  * (Yes, this sucks, but that's the way libnet works, and
  * I was too lazy to re-invent the wheel.
- * Returns 0 on sucess, -1 on error
+ * Returns 0 on success, -1 on error
  */
 
 

--- a/src/tcpliveplay.h
+++ b/src/tcpliveplay.h
@@ -139,8 +139,8 @@ struct tcp_sched{
     u_int32_t calc_curr_lack; /* Calculated Current Local ACK (not used at the moment) */
     u_int32_t curr_lseq; /* Current Local SEQ */
     u_int32_t curr_lack; /* Current Local ACK */
-    unsigned int length_curr_ldata; /* Data Lenght of Currently seen local data */
-    unsigned int length_last_ldata; /* Data Lenght of last locally seen data */
+    unsigned int length_curr_ldata; /* Data Length of Currently seen local data */
+    unsigned int length_last_ldata; /* Data Length of last locally seen data */
     unsigned int length_curr_rdata; /* Length of currently seen remote data */
     unsigned int length_last_rdata; /* Length of last remote seen data*/
     u_char *packet_ptr;  /* The entire packet data to be sent */

--- a/src/tcpliveplay_opts.def
+++ b/src/tcpliveplay_opts.def
@@ -23,7 +23,7 @@ gnu-usage;
 help-value      = "H";
 save-opts-value = "";
 load-opts-value = "";
-argument = "<eth0/eth1> <file.pcap> <Destinatin IP [1.2.3.4]> <Destination mac [0a:1b:2c:3d:4e:5f]> <'random' dst port OR specify dport #>";
+argument = "<eth0/eth1> <file.pcap> <Destination IP [1.2.3.4]> <Destination mac [0a:1b:2c:3d:4e:5f]> <'random' dst port OR specify dport #>";
 
 config-header   = "config.h";
 

--- a/src/tcpprep.c
+++ b/src/tcpprep.c
@@ -21,8 +21,8 @@
 /*
  *  Purpose:
  *  1) Remove the performance bottleneck in tcpreplay for choosing an NIC
- *  2) Seperate code to make it more manageable
- *  3) Add addtional features which require multiple passes of a pcap
+ *  2) Separate code to make it more manageable
+ *  3) Add additional features which require multiple passes of a pcap
  *
  *  Support:
  *  Right now we support matching source IP based upon on of the following:

--- a/src/tcpprep_opts.def
+++ b/src/tcpprep_opts.def
@@ -370,7 +370,7 @@ corresponds to the packet number in the capture file.
 @example
 -x P:1-5,9,15,72-
 @end example
-would process packets 1 thru 5, the 9th and 15th packet, and packets 72 until the
+would process packets 1 through 5, the 9th and 15th packet, and packets 72 until the
 end of the file
 @item F:'<bpf>'
 - BPF filter.  See the @file{tcpdump(8)} man page for syntax.

--- a/src/tcpr.h
+++ b/src/tcpr.h
@@ -238,7 +238,7 @@ struct tcpr_arp_hdr
 #define ARPHRD_LOOPBACK 772 /* Loopback device */
     uint16_t ar_pro;         /* format of protocol address */
     uint8_t  ar_hln;         /* length of hardware address */
-    uint8_t  ar_pln;         /* length of protocol addres */
+    uint8_t  ar_pln;         /* length of protocol address */
     uint16_t ar_op;          /* operation type */
 #define ARPOP_REQUEST    1  /* req to resolve address */
 #define ARPOP_REPLY      2  /* resp to previous request */
@@ -340,7 +340,7 @@ struct tcpr_bgp4_notification_hdr
 struct tcpr_cdp_hdr
 {
     uint8_t cdp_version;     /* version (should always be 0x01) */
-    uint8_t cdp_ttl;         /* time reciever should hold info in this packet */
+    uint8_t cdp_ttl;         /* time receiver should hold info in this packet */
     uint16_t cdp_sum;        /* checksum */
     uint16_t cdp_type;       /* type */
 #define TCPR_CDP_DEVID    0x1 /* device id */
@@ -358,7 +358,7 @@ struct tcpr_cdp_hdr
 #define TCPR_CDP_CAP_L2B  0x02/* performs level 2 transparent bridging */
 #define TCPR_CDP_CAP_L2SRB 0x04/* performs level 2 sourceroute bridging */
 #define TCPR_CDP_CAP_L2S  0x08/* performs level 2 switching */
-#define TCPR_CDP_CAP_SR   0x10/* sends and recieves packets on a network */
+#define TCPR_CDP_CAP_SR   0x10/* sends and receives packets on a network */
 #define TCPR_CDP_CAP_NOI  0x20/* does not forward IGMP on non-router ports */
 #define TCPR_CDP_CAP_L1F  0x40/* provides level 1 functionality */
 };
@@ -686,7 +686,7 @@ struct tcpr_gre_hdr
  */
 struct tcpr_gre_sre_hdr
 {
-    uint16_t af;  /* address familly */
+    uint16_t af;  /* address family */
     uint8_t sre_offset;
     uint8_t sre_length;
     uint8_t *routing;
@@ -727,7 +727,7 @@ struct tcpr_ipv4_hdr
 #define IP_RF 0x8000        /* reserved fragment flag */
 #endif
 #ifndef IP_DF
-#define IP_DF 0x4000        /* dont fragment flag */
+#define IP_DF 0x4000        /* don't fragment flag */
 #endif
 #ifndef IP_MF
 #define IP_MF 0x2000        /* more fragments flag */
@@ -1394,7 +1394,7 @@ struct tcpr_lsa_hdr
 /*
  *  Router LSA data format
  *
- *  Other stuff for TOS can be added for backward compatability, for this
+ *  Other stuff for TOS can be added for backward compatibility, for this
  *  version, only OSPFv2 is being FULLY supported.
  */
 struct tcpr_rtr_lsa_hdr
@@ -1662,7 +1662,7 @@ struct tcpr_token_ring_addr
  */
 struct tcpr_udp_hdr
 {
-    uint16_t uh_sport;       /* soure port */
+    uint16_t uh_sport;       /* source port */
     uint16_t uh_dport;       /* destination port */
     uint16_t uh_ulen;        /* length */
     uint16_t uh_sum;         /* checksum */
@@ -1747,7 +1747,7 @@ struct tcpr_hsrp_hdr
     uint8_t state;            /* Current state of the router */
     uint8_t hello_time;       /* Period in seconds between hello messages */
     uint8_t hold_time;        /* Seconds that the current hello message is valid */
-    uint8_t priority;         /* Priority for the election proccess */
+    uint8_t priority;         /* Priority for the election process */
     uint8_t group;            /* Standby group */
     uint8_t reserved;         /* Reserved field */
 #define HSRP_AUTHDATA_LENGTH  8

--- a/src/tcprewrite_opts.def
+++ b/src/tcprewrite_opts.def
@@ -51,7 +51,7 @@ config-header   = "config.h";
 
 detail = <<- EOText
 Tcprewrite is a tool to rewrite packets stored in @file{pcap(3)} file format,
-such as crated by tools such as @file{tcpdump(1)} and @file{ethereal(1)}.
+such as created by tools such as @file{tcpdump(1)} and @file{ethereal(1)}.
 Once a pcap file has had it's packets rewritten, they can be replayed back
 out on the network using @file{tcpreplay(1)}.
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -210,7 +210,7 @@ process_tree(void)
 }
 
 /*
- * processes rbdata to bulid cidrdata based upon the
+ * processes rbdata to build cidrdata based upon the
  * given type (SERVER, CLIENT, UNKNOWN) using the given masklen
  *
  * is smart enough to prevent dupes
@@ -390,7 +390,7 @@ add_tree_first_ipv4(const u_char *data, const int len)
     /* prevent issues with byte alignment, must memcpy */
     memcpy(&ip_hdr, (data + TCPR_ETH_H), TCPR_IPV4_H);
 
-    /* copy over the source ip, and values to gurantee this a client */
+    /* copy over the source ip, and values to guarantee this a client */
     newnode->family = AF_INET;
     newnode->u.ip = ip_hdr.ip_src.s_addr;
     newnode->type = DIR_CLIENT;
@@ -444,7 +444,7 @@ add_tree_first_ipv6(const u_char *data, const int len)
     /* prevent issues with byte alignment, must memcpy */
     memcpy(&ip6_hdr, (data + TCPR_ETH_H), TCPR_IPV6_H);
 
-    /* copy over the source ip, and values to gurantee this a client */
+    /* copy over the source ip, and values to guarantee this a client */
     newnode->family = AF_INET6;
     newnode->u.ip6 = ip6_hdr.ip_src;
     newnode->type = DIR_CLIENT;


### PR DESCRIPTION
Hi,

I found those using codespell 1.14.0.
Should only be diffs on comments and documentation: I ignored the parts changing variable names.

Best regards,