### PR TITLE
stability fixes

### DIFF
--- a/src/common/get.c
+++ b/src/common/get.c
@@ -536,6 +536,8 @@ get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, int len)
             case TCPR_IPV6_NH_HBH:
                 dbgx(3, "Jumping to next extension header (0x%hhx)", proto);
                 exthdr = get_ipv6_next((struct tcpr_ipv6_ext_hdr_base *)ptr, len);
+                if (exthdr == NULL)
+                    return proto;
                 proto = exthdr->ip_nh;
                 ptr = (u_char *)exthdr;
                 break;

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -407,6 +407,8 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int len)
             dbgx(3, "Going deeper due to extension header 0x%02X", proto);
             maxlen = len - (int)((u_char *)ip6_hdr - (u_char *)next);
             exthdr = get_ipv6_next(next, maxlen);
+            if (exthdr == NULL)
+                return next;
             proto = exthdr->ip_nh;
             next = exthdr;
             break;


### PR DESCRIPTION
Hi,

Those are fix proposal for issues #536 and #537.

However, the #356 reproducer is in big endian for some reason, and when working on little endian, it fails to load because the read capture length is bigger than the maximum.
However both issues really look the same to me and the fixes are localized, so I'm confident about my proposal.
Please review.

Best regards