### PR TITLE
Wireshark and Ethereal reference updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tcpreplay
 
 Tcpreplay is a suite of [GPLv3] licensed utilities for UNIX (and Win32 under
 [Cygwin]) operating systems for editing and replaying network traffic which
-was previously captured by tools like [tcpdump] and [Ethereal]/[Wireshark]. 
+was previously captured by tools like [tcpdump] and [Wireshark]. 
 It allows you to classify traffic as client or server, rewrite Layer 2, 3 and 4 
 packets and finally replay the traffic back onto the network and through other
 devices such as switches, routers, firewalls, NIDS and IPS's. Tcpreplay supports
@@ -228,9 +228,8 @@ or visit our [developers wiki](https://github.com/appneta/tcpreplay/wiki)
 [flow]:     http://en.wikipedia.org/wiki/Traffic_flow_%28computer_networking%29
 [NetFlow]:  http://www.cisco.com/go/netflow
 [Cygwin]:   http://www.cygwin.com/
-[Wireshark]: http://www.wireshark.org
+[Wireshark]: https://www.wireshark.org
 [tcpdump]:  http://www.tcpdump.org
-[Ethereal]: http://www.ethreal.com
 [Cisco]:    http://www.cisco.com
 [AppNeta]:  http://www.appneta.com
 [git]:      https://help.github.com/articles/set-up-git

--- a/src/tcprewrite_opts.def
+++ b/src/tcprewrite_opts.def
@@ -51,7 +51,7 @@ config-header   = "config.h";
 
 detail = <<- EOText
 Tcprewrite is a tool to rewrite packets stored in @file{pcap(3)} file format,
-such as created by tools such as @file{tcpdump(1)} and @file{ethereal(1)}.
+such as created by tools such as @file{tcpdump(1)} and @file{wireshark(1)}.
 Once a pcap file has had it's packets rewritten, they can be replayed back
 out on the network using @file{tcpreplay(1)}.
 


### PR DESCRIPTION
Update or remove references to Ethereal as appropriate. It was renamed
to Wireshark in 2006 and www.ethereal.com has been inaccessible for
several years.

Change a www.wireshark.org link to HTTPS.