### PR TITLE
makefile: remove some duplicated SOURCES entries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,11 @@ AM_PROG_AR
 AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_PROG_CC
+
+# for compat with old systems.
+# deprecated in favor of AC_PROG_CC since automake 1.14 and is now no-op
+AM_PROG_CC_C_O
+
 AC_PROG_CC_STDC
 AC_PROG_CXX
 AC_PROG_CPP

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -14,7 +14,7 @@ git_version.c:
 libcommon_a_SOURCES = cidr.c err.c list.c cache.c services.c get.c \
 		      fakepcap.c fakepcapnav.c fakepoll.c xX.c utils.c \
 		      timer.c git_version.c sendpacket.c \
-		      dlt_names.c mac.c interface.c git_version.c \
+		      dlt_names.c mac.c interface.c \
 		      flows.c txring.c
 
 if ENABLE_TCPDUMP

--- a/src/tcpedit/plugins/dlt_jnpr_ether/Makefile.am
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/Makefile.am
@@ -7,7 +7,6 @@
 # add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
-	%reldir%/jnpr_ether.c \
 	%reldir%/jnpr_ether.c
 
 noinst_HEADERS += \

--- a/src/tcpedit/plugins/dlt_pppserial/Makefile.am
+++ b/src/tcpedit/plugins/dlt_pppserial/Makefile.am
@@ -7,7 +7,6 @@
 # add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
-	%reldir%/pppserial.c \
 	%reldir%/pppserial.c
 
 noinst_HEADERS += \


### PR DESCRIPTION
This removes files that were listed several times from the *_SOURCES
variables.