### PR TITLE
Fix divide by zero in fuzzing

### DIFF
--- a/src/tcpedit/fuzzing.c
+++ b/src/tcpedit/fuzzing.c
@@ -156,7 +156,7 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
         break;
     }
 
-    if (l4len < 1)
+    if (l4len <= 1)
         goto done;
 
     /* add some additional randomization */


### PR DESCRIPTION
Some fuzzer mutations do divide by zero when l4len equals to 1.

Note that the patch affects on fuzzer ability to fuzz packets where l4len equals to 1.

Tested on:
OS: Ubuntu 18.04 x64

```
./tcprewrite --version
tcprewrite version: 4.3.2 (build git:v4.3.2-5-g11507365)
Copyright 2013-2018 by Fred Klassen <tcpreplay at appneta dot com> - AppNeta
Copyright 2000-2012 by Aaron Turner <aturner at synfin dot net>
The entire Tcpreplay Suite is licensed under the GPLv3
Cache file supported: 04
Not compiled with libdnet.
Compiled against libpcap: 1.8.1
64 bit packet counters: enabled
Verbose printing via tcpdump: enabled
Fragroute engine: disabled

```

Minimized test case as an attachment. [FPE-6a2-06c-a94.zip](https://github.com/appneta/tcpreplay/files/3964782/FPE-6a2-06c-a94.zip)

To reproduce, extract the .zip and run:
```
: ./tcprewrite --verbose --fuzz-seed=2 --fuzz-factor=2 -i ./FPE-6a2-06c-a94 -o /dev/null
reading from file -, link-type EN10MB (Ethernet)
21:33:38.1113852818 IP 204.178.31.8 > 192.168.1.33: [|tcp]
AddressSanitizer:DEADLYSIGNAL
=================================================================
==16839==ERROR: AddressSanitizer: FPE on unknown address 0x0000004df6a2 (pc 0x0000004df6a2 bp 0x631000000817 sp 0x7ffe24ee0740 T0)
    #0 0x4df6a2 in fuzzing /tcpreplay/src/tcpedit/fuzzing.c:244:38
    #1 0x4c806c in tcpedit_packet /tcpreplay/src/tcpedit/tcpedit.c:273:18
    #2 0x4c6a94 in rewrite_packets /tcpreplay/src/tcprewrite.c:291:22
    #3 0x4c5a22 in main /tcpreplay/src/tcprewrite.c:130:9
    #4 0x7fbf61913b96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #5 0x41be59 in _start (/tcpreplay/src/tcprewrite+0x41be59)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE /tcpreplay/src/tcpedit/fuzzing.c:244:38 in fuzzing
==16839==ABORTING
```
I used AddressSanitizer for better stack trace, but divide by zero reproduces even without it.

