### PR TITLE
gcc-10 warnings fixes

### DIFF
--- a/libopts/boolean.c
+++ b/libopts/boolean.c
@@ -64,8 +64,8 @@ optionBooleanVal(tOptions * opts, tOptDesc * od)
         long  val = strtol(od->optArg.argString, &pz, 0);
         if ((val != 0) || (*pz != NUL))
             break;
-        /* FALLTHROUGH */
     }
+    /* FALLTHROUGH */
     case 'N':
     case 'n':
     case 'F':

--- a/libopts/configfile.c
+++ b/libopts/configfile.c
@@ -466,6 +466,7 @@ file_preset(tOptions * opts, char const * fname, int dir)
                 ftext = strchr(ftext + 2, '>');
                 if (ftext++ != NULL)
                     break;
+                /* fallthrough */
 
             default:
                 ftext = NULL;

--- a/src/common/flows.c
+++ b/src/common/flows.c
@@ -234,7 +234,7 @@ flow_entry_type_t flow_decode(flow_hash_table_t *fht, const struct pcap_pkthdr *
             l2_len = 4; /* no header extensions */
         }
 
-        /* no break */
+        /* fallthrough */
     case DLT_EN10MB:
         /* set l2_len if we did not fell through */
         if (l2_len == 0)

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -105,7 +105,7 @@ get_l2protocol(const u_char *pktdata, const int datalen, const int datalink)
         } else {
             eth_hdr_offset = 4; /* no header extensions */
         }
-        /* no break */
+        /* fallthrough */
     case DLT_EN10MB:
         if ((size_t)datalen >= (sizeof(eth_hdr_t) + eth_hdr_offset)) {
             vlan_hdr_t *vlan_hdr;
@@ -173,7 +173,7 @@ get_l2len(const u_char *pktdata, const int datalen, const int datalink)
 
     case DLT_JUNIPER_ETHER:
         l2_len = 24;
-        /* no break */
+        /* fallthrough */
     case DLT_EN10MB:
         if ((size_t)datalen >= sizeof(eth_hdr_t) + l2_len) {
             uint16_t ether_type = ntohs(((eth_hdr_t*)(pktdata + l2_len))->ether_type);

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -471,7 +471,7 @@ TRY_SEND_AGAIN:
  */
 sendpacket_t *
 sendpacket_open(const char *device, char *errbuf, tcpr_dir_t direction,
-        sendpacket_type_t sendpacket_type, void *arg)
+        sendpacket_type_t sendpacket_type _U_, void *arg _U_)
 {
     sendpacket_t *sp;
     struct stat sdata;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -226,7 +226,8 @@ fast_edit_packet_dl(struct pcap_pkthdr *pkthdr, u_char **pktdata,
     dbgx(1, "(%u): final src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
 }
 
-static inline void wake_send_queues(sendpacket_t *sp, tcpreplay_opt_t *options)
+static inline void wake_send_queues(sendpacket_t *sp _U_,
+		tcpreplay_opt_t *options _U_)
 {
 #ifdef HAVE_NETMAP
     if (options->netmap)

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -74,7 +74,7 @@ nanosleep_sleep(sendpacket_t *sp _U_, const struct timespec *nap,
  */
 static inline void
 gettimeofday_sleep(sendpacket_t *sp _U_, struct timespec *nap,
-        struct timeval *now, bool flush)
+        struct timeval *now, bool flush _U_)
 {
     struct timeval sleep_until, nap_for;
 #ifdef HAVE_NETMAP
@@ -116,7 +116,7 @@ gettimeofday_sleep(sendpacket_t *sp _U_, struct timespec *nap,
  */
 static inline void 
 select_sleep(sendpacket_t *sp _U_, const struct timespec *nap,
-        struct timeval *now,  bool flush)
+        struct timeval *now,  bool flush _U_)
 {
     struct timeval timeout;
 #ifdef HAVE_NETMAP

--- a/src/tcpedit/tcpedit.c
+++ b/src/tcpedit/tcpedit.c
@@ -42,7 +42,7 @@
 #include "lib/sll.h"
 #include "dlt.h"
 
-tOptDesc *const tcpedit_tcpedit_optDesc_p;
+extern tOptDesc *const tcpedit_tcpedit_optDesc_p;
 
 /**
  * \brief Checks to see if you should make an edit

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -769,7 +769,7 @@ tcpreplay_set_tcpprep_cache(tcpreplay_t *ctx, char *file)
  * Enable verbose mode
  */
 int
-tcpreplay_set_verbose(tcpreplay_t *ctx, bool value)
+tcpreplay_set_verbose(tcpreplay_t *ctx, bool value _U_)
 {
     assert(ctx);
 #ifdef ENABLE_VERBOSE
@@ -788,7 +788,7 @@ tcpreplay_set_verbose(tcpreplay_t *ctx, bool value)
  * verbose mode.  See TCPDUMP_ARGS in tcpdump.h for the default options
  */
 int
-tcpreplay_set_tcpdump_args(tcpreplay_t *ctx, char *value)
+tcpreplay_set_tcpdump_args(tcpreplay_t *ctx, char *value _U_)
 {
     assert(ctx);
 #ifdef ENABLE_VERBOSE
@@ -808,7 +808,7 @@ tcpreplay_set_tcpdump_args(tcpreplay_t *ctx, char *value)
  * tcpdump lives
  */
 int
-tcpreplay_set_tcpdump(tcpreplay_t *ctx, tcpdump_t *value)
+tcpreplay_set_tcpdump(tcpreplay_t *ctx, tcpdump_t *value _U_)
 {
     assert(ctx);
 #ifdef ENABLE_VERBOSE

--- a/src/timestamp_trace.h
+++ b/src/timestamp_trace.h
@@ -25,7 +25,6 @@
 
 #define TRACE_MAX_ENTRIES 15000
 
-uint32_t trace_num;
 struct timestamp_trace_entry {
     COUNTER skip_length;
     COUNTER size;
@@ -39,6 +38,7 @@ struct timestamp_trace_entry {
 typedef struct timestamp_trace_entry timestamp_trace_entry_t;
 
 #ifdef TIMESTAMP_TRACE
+uint32_t trace_num;
 timestamp_trace_entry_t timestamp_trace_entry_array[TRACE_MAX_ENTRIES];
 
 static inline void update_current_timestamp_trace_entry(COUNTER bytes_sent,


### PR DESCRIPTION
Hi,

In my setup, this leaves two warning:

A `cast-function-type` warnings caused by libpcap
In my opinion, the code calling libpcap is valid, and the warning can safely be ignored.

Another saying that the <sys/sysctl.h> header is deprecated and will be removed.
I'll just leave the warning for later.

Best regards,