### PR TITLE
Correct L2 header length calculations so that IP header offset is correct

### DIFF
--- a/src/common/flows.c
+++ b/src/common/flows.c
@@ -236,14 +236,12 @@ flow_entry_type_t flow_decode(flow_hash_table_t *fht, const struct pcap_pkthdr *
 
         /* no break */
     case DLT_EN10MB:
-        /* set l2_len if we did not fell through */
-        if (l2_len == 0)
-            l2_len = sizeof(eth_hdr_t);
-
-        if (pkthdr->caplen < l2_len)
+        /* l2_len will be zero if we did not fall through */
+        if (pkthdr->caplen < l2_len + sizeof(eth_hdr_t))
             return FLOW_ENTRY_INVALID;
 
         ether_type = ntohs(((eth_hdr_t*)(pktdata + l2_len))->ether_type);
+        l2_len += sizeof(eth_hdr_t);
 
         while (ether_type == ETHERTYPE_VLAN) {
             vlan_hdr_t *vlan_hdr = (vlan_hdr_t *)(pktdata + l2_len);
@@ -251,8 +249,6 @@ flow_entry_type_t flow_decode(flow_hash_table_t *fht, const struct pcap_pkthdr *
             ether_type = ntohs(vlan_hdr->vlan_len);
             l2_len += 4;
         }
-
-        l2_len += sizeof(eth_hdr_t);
         break;
 
     default:

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -274,12 +274,12 @@ fast_edit_packet(struct pcap_pkthdr *pkthdr, u_char **pktdata,
 
     /* assume Ethernet, IPv4 for now */
     ether_type = ntohs(((eth_hdr_t*)(packet + l2_len))->ether_type);
+    l2_len += sizeof(eth_hdr_t);
     while (ether_type == ETHERTYPE_VLAN) {
         vlan_hdr = (vlan_hdr_t *)(packet + l2_len);
         ether_type = ntohs(vlan_hdr->vlan_len);
         l2_len += 4;
     }
-    l2_len += sizeof(eth_hdr_t);
 
     switch (ether_type) {
     case ETHERTYPE_IP:

--- a/src/tcpedit/plugins/dlt_en10mb/en10mb.c
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb.c
@@ -771,7 +771,7 @@ dlt_en10mb_l2len(tcpeditdlt_t *ctx, const u_char *packet, const int pktlen)
     if (pktlen < l2len)
         return -1;
 
-    ether_type = ntohs(((eth_hdr_t*)(packet + l2len))->ether_type);
+    ether_type = ntohs(((eth_hdr_t*)packet)->ether_type);
     while (ether_type == ETHERTYPE_VLAN) {
         vlan_hdr_t *vlan_hdr = (vlan_hdr_t *)(packet + l2len);
         ether_type = ntohs(vlan_hdr->vlan_len);


### PR DESCRIPTION
Fix for bug #583 

Several places where the calculation of the offset to the eth_hdr_t is actually jumping past the ethernet header (so that the VLAN tag is not correctly identified). It's the last one (src/tcpedit/plugins/dlt_en10mb/en10mb.c) that is the proximate cause of the issue with corrupting the IP flags field.

Be aware that there is some interaction with DLT_JUNIPER_ETHERNET in a couple of these spots that I'm unable to test.