### PR TITLE
Bug #566 Fix float to integer rounding issue

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -8,6 +8,7 @@
     - Call pcap_freecode() on pcap_compile() (#572)
     - Increase max snaplen to 262144 (#571)
     - Fix divide by zero in fuzzing (#570)
+    - Unique IP repeats at very high iteration counts (#566)
     - Heap Buffer Overflow in do_checksum (#556) (#577)
     - Fix GCC v10 warnings (#555)
 

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -89,7 +89,7 @@ static uint32_t get_user_count(tcpreplay_t *ctx, sendpacket_t *sp, COUNTER count
  */
 static void
 fast_edit_packet_dl(struct pcap_pkthdr *pkthdr, u_char **pktdata,
-        uint32_t iteration, bool cached, int datalink)
+        COUNTER iteration, bool cached, int datalink)
 {
     int l2_len = 0;
     ipv4_hdr_t *ip_hdr;
@@ -194,13 +194,13 @@ fast_edit_packet_dl(struct pcap_pkthdr *pkthdr, u_char **pktdata,
 
         /* CRC compensations  for wrap conditions */
         if (src_ip > src_ip_orig && dst_ip > dst_ip_orig) {
-            dbgx(1, "dst_ip > src_ip(%u): before(1) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): before(1) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
             --src_ip;
-            dbgx(1, "dst_ip > src_ip(%u): after(1)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): after(1)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
         } else if (dst_ip < dst_ip_orig && src_ip < src_ip_orig) {
-            dbgx(1, "dst_ip > src_ip(%u): before(2) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): before(2) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
             ++dst_ip;
-            dbgx(1, "dst_ip > src_ip(%u): after(2)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): after(2)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
         }
     } else {
         if (cached) {
@@ -213,17 +213,17 @@ fast_edit_packet_dl(struct pcap_pkthdr *pkthdr, u_char **pktdata,
 
         /* CRC compensations  for wrap conditions */
         if (dst_ip > dst_ip_orig && src_ip > src_ip_orig) {
-            dbgx(1, "src_ip > dst_ip(%u): before(1) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): before(1) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
             --dst_ip;
-            dbgx(1, "src_ip > dst_ip(%u): after(1)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): after(1)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
         } else if (src_ip < src_ip_orig && dst_ip < dst_ip_orig) {
-            dbgx(1, "src_ip > dst_ip(%u): before(2) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): before(2) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
             ++src_ip;
-            dbgx(1, "src_ip > dst_ip(%u): after(2)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): after(2)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
         }
     }
 
-    dbgx(1, "(%u): final src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+    dbgx(1, "(" COUNTER_SPEC "): final src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
 }
 
 static inline void wake_send_queues(sendpacket_t *sp _U_,
@@ -237,7 +237,7 @@ static inline void wake_send_queues(sendpacket_t *sp _U_,
 
 static inline void
 fast_edit_packet(struct pcap_pkthdr *pkthdr, u_char **pktdata,
-        uint32_t iteration, bool cached, int datalink)
+        COUNTER iteration, bool cached, int datalink)
 {
     uint16_t ether_type;
     ipv4_hdr_t *ip_hdr = NULL;
@@ -313,13 +313,13 @@ fast_edit_packet(struct pcap_pkthdr *pkthdr, u_char **pktdata,
 
         /* CRC compensations  for wrap conditions */
         if (src_ip > src_ip_orig && dst_ip > dst_ip_orig) {
-            dbgx(1, "dst_ip > src_ip(%u): before(1) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): before(1) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
             --src_ip;
-            dbgx(1, "dst_ip > src_ip(%u): after(1)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): after(1)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
         } else if (dst_ip < dst_ip_orig && src_ip < src_ip_orig) {
-            dbgx(1, "dst_ip > src_ip(%u): before(2) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): before(2) src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
             ++dst_ip;
-            dbgx(1, "dst_ip > src_ip(%u): after(2)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+            dbgx(1, "dst_ip > src_ip(" COUNTER_SPEC "): after(2)  src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
         }
     } else {
         if (cached) {
@@ -332,17 +332,17 @@ fast_edit_packet(struct pcap_pkthdr *pkthdr, u_char **pktdata,
 
         /* CRC compensations  for wrap conditions */
         if (dst_ip > dst_ip_orig && src_ip > src_ip_orig) {
-            dbgx(1, "src_ip > dst_ip(%u): before(1) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): before(1) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
             --dst_ip;
-            dbgx(1, "src_ip > dst_ip(%u): after(1)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): after(1)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
         } else if (src_ip < src_ip_orig && dst_ip < dst_ip_orig) {
-            dbgx(1, "src_ip > dst_ip(%u): before(2) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): before(2) dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
             ++src_ip;
-            dbgx(1, "src_ip > dst_ip(%u): after(2)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
+            dbgx(1, "src_ip > dst_ip(" COUNTER_SPEC "): after(2)  dst_ip=0x%08x src_ip=0x%08x", iteration, dst_ip, src_ip);
         }
     }
 
-    dbgx(1, "(%u): final src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
+    dbgx(1, "(" COUNTER_SPEC "): final src_ip=0x%08x dst_ip=0x%08x", iteration, src_ip, dst_ip);
 
     switch (ether_type) {
     case ETHERTYPE_IP:
@@ -460,7 +460,8 @@ static void increment_iteration(tcpreplay_t *ctx)
     if (options->unique_ip) {
         assert(options->unique_loops > 0.0);
         ctx->unique_iteration =
-                (COUNTER)((float)ctx->iteration / options->unique_loops) + 1;
+                ((ctx->iteration * 1000) / (COUNTER)(options->unique_loops * 1000.0))
+                + 1;
     }
 }
 


### PR DESCRIPTION
At very high iteration counts '--unique-ip' calculation
(which support floating point e.g. 0.75) has accuracy
issues. Corrected by converting to integer earlier,
and multiplying numerator/denominator by 1000.