### PR TITLE
Bug #558 Restructure includes to pick up proper header

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -9,8 +9,10 @@
     - Increase max snaplen to 262144 (#571)
     - Fix divide by zero in fuzzing (#570)
     - Unique IP repeats at very high iteration counts (#566)
+    - Fails to compile on FreeBSD amd64 13.0 (#558)
     - Heap Buffer Overflow in do_checksum (#556) (#577)
     - Fix GCC v10 warnings (#555)
+    - Remove some duplicated SOURCES entries (#551)
 
 03/12/2019 Version 4.3.2
     - CVE-2019-8381 memory access in do_checksum() (#538)

--- a/src/fragroute/fragroute.c
+++ b/src/fragroute/fragroute.c
@@ -8,6 +8,7 @@
  */
 
 #include "config.h"
+#include "lib/queue.h"
 #include "defines.h"
 #include "common.h"
 

--- a/src/fragroute/mod.c
+++ b/src/fragroute/mod.c
@@ -8,6 +8,7 @@
  */
 
 #include "config.h"
+#include "lib/queue.h"
 #include "defines.h"
 #include "common.h"
 

--- a/src/fragroute/mod_ip_frag.c
+++ b/src/fragroute/mod_ip_frag.c
@@ -7,6 +7,7 @@
  */
 
 #include "config.h"
+#include "lib/queue.h"
 #include "defines.h"
 #include "common.h"
 

--- a/src/fragroute/mod_tcp_seg.c
+++ b/src/fragroute/mod_tcp_seg.c
@@ -7,6 +7,7 @@
  */
 
 #include "config.h"
+#include "lib/queue.h"
 #include "defines.h"
 #include "common.h"
 

--- a/src/fragroute/pkt.h
+++ b/src/fragroute/pkt.h
@@ -10,8 +10,8 @@
 #define PKT_H
 
 #include "config.h"
+#include "lib/queue.h"
 #include "defines.h"
-#include "../../lib/queue.h"
 #include <sys/time.h>
 
 #ifdef HAVE_LIBDNET


### PR DESCRIPTION
Fragroute relies on down-level `lib/queue.h` which is
copied from older versions of FreeBSD. Depending on the
order of includes, some source files were using
it, and others were picking up `/usr/include/sys/queue.h`.

Fix is to ensure that there is a `lib/queue.h` include before
any `#include defines.h`