### PR TITLE
Bug #550 Expand /dev/bpfX limit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl $Id$
 AC_PREREQ([2.69])
 
 dnl Set version info here!
-AC_INIT([tcpreplay],[4.3.3-beta1],
+AC_INIT([tcpreplay],[4.3.3-beta2],
     [https://github.com/appneta/tcpreplay/issues],
     [tcpreplay],
     [http://tcpreplay.sourceforge.net/])

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,4 @@
-05/20/2020 Version 4.3.3 beta1
+05/20/2020 Version 4.3.3 beta2
     - Increase cache buffers size to accomodate VLAN edits (#594)
     - Correct L2 header length to correct IP header offset (#583)
     - Fix warnings from gcc version 10 (#580)
@@ -14,6 +14,7 @@
     - Attempt to correct corrupt pcap files, if possible (#557)
     - Fix GCC v10 warnings (#555)
     - Remove some duplicated SOURCES entries (#551)
+    - Expand /dev/bpfX hard limit to fix macOS Mojave (#550)
 
 03/12/2019 Version 4.3.2
     - CVE-2019-8381 memory access in do_checksum() (#538)

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -1053,7 +1053,7 @@ static sendpacket_t *
 sendpacket_open_bpf(const char *device, char *errbuf)
 {
     sendpacket_t *sp;
-    char bpf_dev[10];
+    char bpf_dev[16];
     int dev, mysocket, link_offset, link_type;
     struct ifreq ifr;
     struct bpf_version bv;
@@ -1066,15 +1066,18 @@ sendpacket_open_bpf(const char *device, char *errbuf)
     assert(errbuf);
     memset(&ifr, '\0', sizeof(struct ifreq));
 
-    dbg(1, "sendpacket: using BPF");
+    dbg(1, "sendpacket_open_bpf: using BPF");
     /* open socket */
     mysocket = -1;
-    for (dev = 0; dev <= 9; dev ++) {
+    for (dev = 0; dev < 512; dev ++) {
         memset(bpf_dev, '\0', sizeof(bpf_dev));
         snprintf(bpf_dev, sizeof(bpf_dev), "/dev/bpf%d", dev);
-        if ((mysocket = open(bpf_dev, O_RDWR, 0)) > 0) {
+        dbgx(3, "sendpacket_open_bpf: attempting to open %s", bpf_dev);
+        if (!access(bpf_dev, F_OK) && (mysocket = open(bpf_dev, O_RDWR, 0)) > 0) {
+            dbg(3, "Success!");
             break;
         }
+        dbgx(4, "failed with error %s", strerror(errno));
     }
 
     /* error?? */


### PR DESCRIPTION
Increase number of interfaces from 10 to 512. Now test
/dev/bpf0 to /dev/bpf511 to find and available BPF devices.

This fixes issues introduced in macOS Mojave (10.14).