### PR TITLE
Fix UNUSED Macro declaration

### DIFF
--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -362,7 +362,7 @@ typedef u_int32_t uint32_t
 */
 #ifdef UNUSED 
 #elif defined(__GNUC__) 
-# define UNUSED(x) UNUSED_ ## x __attribute__((unused)) 
+# define UNUSED(x) x __attribute__((unused))
 #elif defined(__LCLINT__) 
 # define UNUSED(x) /*@unused@*/ x 
 #else 


### PR DESCRIPTION
Depending on compilaiton flags, UNUSED() was declaring variables with
different names.
Meaning the following can be either expanded to:
  `UNUSED(var)` -> `var`
  `UNUSED(var)` -> `UNUSED_var __attribute__((unused))`
depending on the compilation flags.

The code using such a variable would need to also be conditional to the
same compilation flags ... and that's to heavy.
Let's declare variables by the name they are given instead.
  `UNUSED(var)` -> `var` /* with/without the attribute, but always "var" */

Fixes #612

Signed-off-by: Gabriel Ganne <gabriel.ganne@gmail.com>