### PR TITLE
docs: fix simple typo, hierarcicaly -> hierarchically

### DIFF
--- a/libopts/autoopts/options.h
+++ b/libopts/autoopts/options.h
@@ -839,7 +839,7 @@ extern int optionFileLoad(tOptions *, char const *);
 
 
 /**
- * optionFindNextValue - find a hierarcicaly valued option instance
+ * optionFindNextValue - find a hierarchically valued option instance
  *
  *  This routine will find the next entry in a nested value option or
  *  configurable.  It will search through the list and return the next entry
@@ -856,7 +856,7 @@ extern const tOptionValue * optionFindNextValue(const tOptDesc *, const tOptionV
 
 
 /**
- * optionFindValue - find a hierarcicaly valued option instance
+ * optionFindValue - find a hierarchically valued option instance
  *
  *  This routine will find an entry in a nested value option or configurable.
  *  It will search through the list and return a matching entry.

--- a/libopts/configfile.c
+++ b/libopts/configfile.c
@@ -145,7 +145,7 @@ configFileLoad(char const * fname)
 
 /*=export_func  optionFindValue
  *
- * what:  find a hierarcicaly valued option instance
+ * what:  find a hierarchically valued option instance
  * arg:   + const tOptDesc * + odesc + an option with a nested arg type +
  * arg:   + char const *     + name  + name of value to find +
  * arg:   + char const *     + val   + the matching value    +
@@ -220,7 +220,7 @@ optionFindValue(const tOptDesc * odesc, char const * name, char const * val)
  *
  * FIXME: the handling of 'pzName' and 'pzVal' is just wrong.
  *
- * what:  find a hierarcicaly valued option instance
+ * what:  find a hierarchically valued option instance
  * arg:   + const tOptDesc * + odesc + an option with a nested arg type +
  * arg:   + const tOptionValue * + pPrevVal + the last entry +
  * arg:   + char const *     + name     + name of value to find +

--- a/libopts/restore.c
+++ b/libopts/restore.c
@@ -34,7 +34,7 @@
 /*
  *  optionFixupSavedOpts  Really, it just wipes out option state for
  *  options that are troublesome to copy.  viz., stacked strings and
- *  hierarcicaly valued option args.  We do duplicate string args that
+ *  hierarchically valued option args.  We do duplicate string args that
  *  have been marked as allocated though.
  */
 static void


### PR DESCRIPTION
There is a small typo in libopts/autoopts/options.h, libopts/configfile.c, libopts/restore.c.

Should read `hierarchically` rather than `hierarcicaly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md