### PR TITLE
send_packet: Avoid clock drift by using time since first packet

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -36,6 +36,8 @@ typedef struct {
     struct timeval end_time;
     struct timeval pkt_ts_delta;
     struct timeval last_print;
+    struct timeval first_packet_sent_wall_time;
+    struct timeval first_packet_pcap_timestamp;
     COUNTER flow_non_flow_packets;
     COUNTER flows;
     COUNTER flows_unique;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -588,8 +588,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
             ctx->skip_packets = 0;
 
             if (options->speed.mode == speed_multiplier) {
-                if(!timerisset(&stats->first_packet_sent_wall_time))
-                {
+                if(!timerisset(&stats->first_packet_sent_wall_time)) {
                     /* We're sending the first packet, so we have an absolute time reference. */
                     TIMEVAL_SET(&stats->first_packet_sent_wall_time, &now);
                     TIMEVAL_SET(&stats->first_packet_pcap_timestamp, &pkthdr.ts);


### PR DESCRIPTION
Prior to this change, time between packets was calculated as deltas
and over time errors would quickly add up. The work here switches
to use the wall time since the first packet was sent as the reference
which is compared to the PCAP packet timestamp relative to the first
packet. In this way there are no errors and clock drift is avoided.
As a result tcpreplay can now be used to play back very time sensitive
captures such as video streams with PCR.

This is a suggested fix for https://github.com/appneta/tcpreplay/issues/630