### PR TITLE
Bug #632 fix pps invalid value protection

### DIFF
--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -178,6 +178,11 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
         options->speed.speed = 0;
     } else if (HAVE_OPT(PPS)) {
         n = atof(OPT_ARG(PPS));
+        if (!n) {
+            tcpreplay_seterr(ctx, "invalid pps value '%s'", OPT_ARG(PPS));
+            ret = -1;
+            goto out;
+        }
         options->speed.speed = (COUNTER)(n * 60.0 * 60.0); /* convert to packets per hour */
         options->speed.mode = speed_packetrate;
         options->speed.pps_multi = OPT_VALUE_PPS_MULTI;


### PR DESCRIPTION
```
cgs@idog-ubuntu:~/workspace/tcpreplay$ src/tcpreplay -i docker0 --pps abc --stats 1 tcp.pcap 
Warning: May need to run as root to get access to all network interfaces.

Fatal Error: Unable to parse args: invalid pps value 'abc'

```