### PR TITLE
Bug #617 CVE-2020-24266 fix tcpprep get_l2len()

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 03/12/2021 Version 4.3.4 Beta1
     - Fix gcc 8.3.0 build warnings (#634)
-    - CVE-2020-24265 heap buffer overflow in tcp-prep (#616)
+    - CVE-2020-24266 heap buffer overflow in tcpprep get_l2len (#617)
+    - CVE-2020-24265 heap buffer overflow in tcpprep (#616)
     - Compile failure on aarch64-linux-android (#612)
 
 05/20/2020 Version 4.3.3


### PR DESCRIPTION
Fixed in #616 and PR #637