### PR TITLE
Bug #629 Compensate for overflow on high pps tests

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,6 @@
 03/12/2021 Version 4.3.4 Beta1
     - Fix gcc 8.3.0 build warnings (#634)
+    - 64 bit rollover can cause pps replay issues after several hours (#629)
     - DLT_NULL/DLT_LOOP support for cross-platform PF_INET6 (#624)
     - armv5 Freescale compile (#623)
     - heap buffer overflow in tcpreplay fast_edit_packet (#620)


### PR DESCRIPTION
Change calculation after high packet sent count. The updated
calculation will not work well for something like `--pps=0.1`
but that would take many years to overflow, even on 32-bit
machines.