### PR TITLE
Bug #472 Reset timestamps for multiplier between files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl $Id$
 AC_PREREQ([2.69])
 
 dnl Set version info here!
-AC_INIT([tcpreplay],[4.3.4beta1],
+AC_INIT([tcpreplay],[4.3.4-beta1],
     [https://github.com/appneta/tcpreplay/issues],
     [tcpreplay],
     [http://tcpreplay.sourceforge.net/])

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -12,8 +12,10 @@
     - CVE-2020-24265 heap buffer overflow in tcpprep (#616)
     - fix UNUSED macro declaration (#614)
     - handle malformed and unsupported packets as soft errors (#613)
-    - Compile failure on aarch64-linux-android (#612)
-    - Ensure automake version is at least 1.15 (#553)
+    - compile failure on aarch64-linux-android (#612)
+    - fix configure --without-libdnet (#567)
+    - ensure automake version is at least 1.15 (#553)
+    - with multiplier option only first file can be sent and hang (#472)
 
 05/20/2020 Version 4.3.3
     - Increase cache buffers size to accomodate VLAN edits (#594)

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -83,3 +83,18 @@ Gabriel Ganne <GitHub @GabrielGanne>
 
 Mario D Santana <GitHUB @@mariodsantana>
     - TCP seq/ack edit
+
+Fabrice Fontaine <GitHub @ffontaine>
+    - fix --without-libdnet configure option
+
+Gerald Combs <GitHub @geraldcombs>
+    - Wireshark and Ethereal reference updates
+
+Tim Gates <GitHub @timgates42>
+    - typos
+
+Dave DeAngelis <GitHub @ddeangelis>
+    - typos
+
+Dave Craig <GitHub @davecraig>
+    - Avoid clock drift

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -339,6 +339,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
 
     ctx->skip_packets = 0;
     timerclear(&last_pkt_ts);
+    timerclear(&stats->first_packet_sent_wall_time);
     if (options->limit_time > 0)
         end_us = TIMEVAL_TO_MICROSEC(&stats->start_time) +
             SEC_TO_MICROSEC(options->limit_time);
@@ -589,6 +590,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
 
     ctx->skip_packets = 0;
     timerclear(&last_pkt_ts);
+    timerclear(&stats->first_packet_sent_wall_time);
     if (options->limit_time > 0)
         end_us = TIMEVAL_TO_MICROSEC(&stats->start_time) +
             SEC_TO_MICROSEC(options->limit_time);


### PR DESCRIPTION
This issue became more evident with #630. First file has proper
deltas, second file sends with no delay.

Tested with 2 ping.pcap files and obverved proper delays.