### PR TITLE
replace memset followed by strncpy with strlcpy

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -789,9 +789,7 @@ packet2tree(const u_char * data, const int len)
 
 
     /* copy over the source mac */
-    memset(&node->mac[0], 0, sizeof(node->mac));
-    strncpy((char *)node->mac, (char *)eth_hdr->ether_shost,
-            sizeof(node->mac) - 1);
+    strlcpy((char *)node->mac, (char *)eth_hdr->ether_shost, sizeof(node->mac));
 
     /* 
      * TCP 


### PR DESCRIPTION
Much cleaner than zeroing node->mac before strncpy()ing it.

edit: Oh I'm sorry but I just realized, I brainlessly made a pull request to 4.3.4 instead of master.