### PR TITLE
remove duplicate #include "lib/strlcpy.h"

### DIFF
--- a/src/common/cidr.c
+++ b/src/common/cidr.c
@@ -21,9 +21,6 @@
 #include "config.h"
 #include "defines.h"
 #include "common.h"
-#ifndef HAVE_STRLCPY
-#include "lib/strlcpy.h"
-#endif 
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/common/tcpdump.c
+++ b/src/common/tcpdump.c
@@ -49,10 +49,6 @@
 
 #include "tcpdump.h"
 
-#ifndef HAVE_STRLCPY
-#include "lib/strlcpy.h"
-#endif
-
 #ifdef DEBUG
 extern int debug;
 #endif

--- a/src/tcpprep.c
+++ b/src/tcpprep.c
@@ -49,9 +49,6 @@
 #include "lib/tree.h"
 #include "tree.h"
 #include "lib/sll.h"
-#ifndef HAVE_STRLCPY
-#include "lib/strlcpy.h"
-#endif
 
 /*
  * global variables


### PR DESCRIPTION
This #include and the #ifdef around it are both already inside the defines.h.in header