### PR TITLE
Support GRE over IP for tcprewrite 

### DIFF
--- a/src/tcpedit/plugins/dlt_linuxsll/linuxsll.c
+++ b/src/tcpedit/plugins/dlt_linuxsll/linuxsll.c
@@ -189,7 +189,7 @@ dlt_linuxsll_decode(tcpeditdlt_t *ctx, const u_char *packet, const int pktlen)
 
 
     type = ntohs(linux_sll->type);
-    if (type == ARPHRD_ETHER || type == ARPHRD_LOOPBACK) { /* ethernet or loopback */
+    if (type == ARPHRD_ETHER || type == ARPHRD_LOOPBACK || type == ARPHRD_GRE_O_IP ) { /* ethernet or loopback or GRE_over_IP */
         memcpy(&(ctx->srcaddr), linux_sll->address, ETHER_ADDR_LEN);
     } else {
         tcpedit_seterr(ctx->tcpedit, "%s", "DLT_LINUX_SLL pcap's must contain only ethernet or loopback packets");

--- a/src/tcpr.h
+++ b/src/tcpr.h
@@ -250,6 +250,7 @@ struct tcpr_arp_hdr
     uint8_t  ar_hln;         /* length of hardware address */
     uint8_t  ar_pln;         /* length of protocol address */
     uint16_t ar_op;          /* operation type */
+#define ARPHRD_GRE_O_IP 778  /* GRE over IP */
 #define ARPOP_REQUEST    1  /* req to resolve address */
 #define ARPOP_REPLY      2  /* resp to previous request */
 #define ARPOP_REVREQUEST 3  /* req protocol address given hardware */


### PR DESCRIPTION
tcprewrite was failing to rewrite the lab ethernet addresses because the IP over GRE was not defined in the code and the source packet capture was missing L2 headers and tcprewrite was failing with 
Fatal Error: From plugins/dlt_linuxsll/linuxsll.c:dlt_linuxsll_decode() line 194: DLT_LINUX_SLL pcap's must contain only ethernet or loopback packets

We had to collate date from multiple sources to understand the changes that could be made to made this work:


 type = ntohs(linux_sll->type); if (type == ARPHRD_ETHER || type == ARPHRD_LOOPBACK) { /* ethernet or loopback */ memcpy(&(ctx->srcaddr), linux_sll->address, ETHER_ADDR_LEN); } else { tcpedit_seterr(ctx->tcpedit, "%s", "DLT_LINUX_SLL pcap's must contain only ethernet or loopback packets"); return TCPEDIT_ERROR; }



and 

/* 
*  ARP header 
*  Address Resolution Protocol 
*  Base header size: 8 bytes 
* 
*/ struct tcpr_arp_hdr 
{ 
uint16_t ar_hrd;         /* format of hardware address */ 
#define ARPHRD_NETROM   0   /* from KA9Q: NET/ROM pseudo */ 
#define ARPHRD_ETHER    1   /* Ethernet 10Mbps */ 
#define ARPHRD_EETHER   2   /* Experimental Ethernet */ 
#define ARPHRD_AX25     3   /* AX.25 Level 2 */ 
#define ARPHRD_PRONET   4   /* PROnet token ring */ 
#define ARPHRD_CHAOS    5   /* Chaosnet */ 
#define ARPHRD_IEEE802  6   /* IEEE 802.2 Ethernet/TR/TB */ 
#define ARPHRD_ARCNET   7   /* ARCnet */ 
#define ARPHRD_APPLETLK 8   /* APPLEtalk */ 
#define ARPHRD_LANSTAR  9   /* Lanstar */ 
#define ARPHRD_DLCI     15  /* Frame Relay DLCI */ 
#define ARPHRD_ATM      19  /* ATM */ 
#define ARPHRD_METRICOM 23  /* Metricom STRIP (new IANA id) */ 
#define ARPHRD_IPSEC    31  /* IPsec tunnel */ 
#define ARPHRD_LOOPBACK 772 /* Loopback device */ 
   uint16_t ar_pro;         /* format of protocol address */ 
   uint8_t  ar_hln;         /* length of hardware address */ 
   uint8_t  ar_pln;         /* length of protocol address */ 
   uint16_t ar_op;          /* operation type */ 
#define ARPOP_REQUEST    1  /* req to resolve address */ 
#define ARPOP_REPLY      2  /* resp to previous request */ 
#define ARPOP_REVREQUEST 3  /* req protocol address given hardware */ 
#define ARPOP_REVREPLY   4  /* resp giving protocol address */ 
#define ARPOP_INVREQUEST 8  /* req to identify peer */ 
#define ARPOP_INVREPLY   9  /* resp identifying peer */ /* address information allocated dynamically */ 

};


We then recompiled the package and were able to run the tcprewrite successfully 