### PR TITLE
Bug #674 - Revert "send_packet: Avoid clock drift by using time since first packet"

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -3,11 +3,12 @@
     - add a security policy document (#689)
     - ability to specify directory of pcap files (#682)
     - incorrect PPS rate for long-running sessions (#679)
+    - revert #630 to fix --multiplier issues (#674)
     - option --skipbroadcast not working (#677)
     - latest macOS SDK selected by default (#668)
     - add feature VLAN Q-in-Q (#625)
 
-06/19/2021 Version 4.3.5-beta1
+06/19/2021 Version 4.3.5-beta1f
     - gcc 9.3 compiler warnings (#670)
     - installed netmap not automatically detected (#669)
     - heap-buffer-overflow with flow_decode() (#665)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -36,8 +36,6 @@ typedef struct {
     struct timeval end_time;
     struct timeval pkt_ts_delta;
     struct timeval last_print;
-    struct timeval first_packet_sent_wall_time;
-    struct timeval first_packet_pcap_timestamp;
     COUNTER flow_non_flow_packets;
     COUNTER flows;
     COUNTER flows_unique;


### PR DESCRIPTION


This reverts commit ec50def8c84da9af2903ff878fd4d6d844f3efe0. 