### PR TITLE
Bug #708 fix support for feeding PCAP files from STDIN

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,7 @@
-02/09/2022 Version 4.4.1-beta1
+02/10/2022 Version 4.4.1-beta1
+    - fix support for piping PCAP files from STDIN (#708)
     - build failures Debian/kfreebsd (#706)
+    - bus error when building on armhf (#705)
 
 01/31/2022 Version 4.4.0
     - remove obsolete FORCE_ALIGN support to fix macOS 11 compile (#695)

--- a/src/tcpreplay.c
+++ b/src/tcpreplay.c
@@ -116,9 +116,15 @@ main(int argc, char *argv[])
     for (i = 0; i < argc; i++) {
 #ifdef HAVE_FTS_H
         struct stat statbuf;
+
+        if (!strcmp(argv[i], "-")) {
+            tcpreplay_add_pcapfile(ctx, argv[i]);
+            continue;
+        }
+
         if (stat(argv[i], &statbuf) != 0) {
             errx(-1,
-                 "Unable to retrieve informations from file %s: %s",
+                 "Unable to retrieve information from file %s: %s",
                  argv[i],
                  strerror(errno));
         }


### PR DESCRIPTION
Fixes regression due to feature #682 - Directories of pcaps as arguments