### PR TITLE
build: fix bashism in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1808,7 +1808,7 @@ fi
 dnl No 'make test' when cross compile
 
 AC_MSG_CHECKING(for 'make test' profile)
-if test "$host" == "$build" ; then
+if test "$host" = "$build" ; then
     AC_MSG_RESULT([yes])
 else    
     AC_MSG_WARN(Unable to do tests when cross-compiling)


### PR DESCRIPTION
configure scripts are run with /bin/sh which is supposed
to be a POSIX-compliant shell, so if /bin/sh is provided
by e.g. dash (like on Debian) rather than bash, we hit
errors.

This has no effect on functionality for bash &
retains compatibility.

Signed-off-by: Sam James <sam@gentoo.org>