### PR TITLE
Bug #718 improved heap-overflow protection

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 08/02/2022 Version 4.4.2 Beta 1
     - replaying on a loopback interface is broken (#732)
     - format string vulnerability in fix_ipv6_checksums (#723)
+    - heap-overflow in get_ipv6_next (#718)
     - reachable assertion in get_layer4_v6 (#717)
     - heap buffer overflow in get_l2len_protocol (#716)
     - remove bash-only test in configure script (#714)

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -42,6 +42,10 @@ extern const char pcap_version[];
 #define JUNIPER_FLAG_NO_L2          0x02     /* L2 header */
 #define JUNIPER_FLAG_EXT            0x80     /* Juniper extensions present */
 #define JUNIPER_PCAP_MAGIC          "MGC"
+
+static void *
+get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const u_char *end_ptr);
+
 /**
  * Depending on what version of libpcap/WinPcap there are different ways to get 
  * the version of the libpcap/WinPcap library.  This presents a unified way to 
@@ -571,15 +575,16 @@ get_ipv6(const u_char *pktdata, int datalen, int datalink, u_char **newbuff)
  * If the packet is to short, returns NULL
  */
 void *
-get_layer4_v4(const ipv4_hdr_t *ip_hdr, const int l3len)
+get_layer4_v4(const ipv4_hdr_t *ip_hdr, const u_char *end_ptr)
 {
     void *ptr;
 
     assert(ip_hdr);
+    assert(end_ptr);
 
     ptr = (u_char *)ip_hdr + (ip_hdr->ip_hl << 2);
     /* make sure we don't jump over the end of the buffer */
-    if ((u_char *)ptr > ((u_char *)ip_hdr + l3len))
+    if ((u_char *)ptr > end_ptr)
         return NULL;
 
     return ((void *)ptr);
@@ -591,24 +596,21 @@ get_layer4_v4(const ipv4_hdr_t *ip_hdr, const int l3len)
  * v6 Frag or ESP header.  Function is recursive.
  */
 void *
-get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int l3len)
+get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr)
 {
     struct tcpr_ipv6_ext_hdr_base *next, *exthdr;
     bool done = false;
-    uint32_t maxlen;
     uint8_t proto;
-    int min_len;
 
     assert(ip6_hdr);
-
-    min_len = TCPR_IPV6_H + sizeof(struct tcpr_ipv6_ext_hdr_base);
-    if (l3len < min_len)
-        return NULL;
+    assert(end_ptr);
 
     /* jump to the end of the IPv6 header */
     next = (struct tcpr_ipv6_ext_hdr_base *)((u_char *)ip6_hdr + TCPR_IPV6_H);
-    proto = ip6_hdr->ip_nh;
+    if ((u_char*)next > end_ptr)
+        return NULL;
 
+    proto = ip6_hdr->ip_nh;
     while (!done) {
         dbgx(3, "Processing proto: 0x%hx", (uint16_t)proto);
 
@@ -616,10 +618,7 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int l3len)
         /* recurse due to v6-in-v6, need to recast next as an IPv6 Header */
         case TCPR_IPV6_NH_IPV6:
             dbg(3, "recursing due to v6-in-v6");
-            next = get_layer4_v6((ipv6_hdr_t *)next, l3len - min_len);
-            if (next == NULL)
-                done = true;
-
+            next = get_layer4_v6((ipv6_hdr_t *)next, end_ptr);
             break;
 
         /* loop again */
@@ -628,9 +627,9 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int l3len)
         case TCPR_IPV6_NH_DESTOPTS:
         case TCPR_IPV6_NH_HBH:
             dbgx(3, "Going deeper due to extension header 0x%02X", proto);
-            maxlen = l3len - (int)((u_char *)ip6_hdr - (u_char *)next);
-            exthdr = get_ipv6_next(next, maxlen);
+            exthdr = get_ipv6_next(next, end_ptr);
             if (exthdr == NULL) {
+                next = NULL;
                 done = true;
                 break;
             }
@@ -661,10 +660,10 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int l3len)
 
             done = true;
         } /* switch */
-    } /* while */
 
-    if (!next || (u_char*)next > (u_char*)ip6_hdr + l3len)
-        return NULL;
+        if (next == NULL)
+            done = true;
+    } /* while */
 
     return next;
 }
@@ -674,15 +673,15 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const int l3len)
  * returns the next payload or header of the current extension header
  * returns NULL for none/ESP.
  */
-void *
-get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const int len)
+static void *
+get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const u_char *end_ptr)
 {
-    int extlen = 0;
-    int maxlen;
-    void *ptr;
+    uint8_t extlen = 0;
+    u_char *ptr;
     assert(exthdr);
 
-    maxlen = *((int*)((u_char *)exthdr + len));
+    if ((u_char*)exthdr + sizeof(*exthdr) > end_ptr)
+        return NULL;
 
     dbgx(3, "Jumping to next IPv6 header.  Processing 0x%02x", exthdr->ip_nh);
     switch (exthdr->ip_nh) {
@@ -701,9 +700,9 @@ get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const int len)
     case TCPR_IPV6_NH_FRAGMENT:
         dbg(3, "Looks like were a fragment header. Returning some frag'd data.");
         ptr = (void *)((u_char *)exthdr + sizeof(struct tcpr_ipv6_frag_hdr));
-        if (*(int*)ptr > maxlen)
+        if (ptr > end_ptr)
             return NULL;
-        return ptr;
+        return (void *)ptr;
         break;
 
     /* all the rest require us to go deeper using the ip_len field */
@@ -714,11 +713,11 @@ get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const int len)
     case TCPR_IPV6_NH_AH:
         extlen = IPV6_EXTLEN_TO_BYTES(exthdr->ip_len);
         dbgx(3, "Looks like we're an ext header (0x%hhx).  Jumping %u bytes"
-               " to the next", exthdr->ip_nh, extlen);
-        ptr = (void *)((u_char *)exthdr + extlen);
-        if (*(int*)ptr > maxlen)
+                " to the next", exthdr->ip_nh, extlen);
+        ptr = (u_char *)exthdr + extlen;
+        if (ptr > end_ptr)
             return NULL;
-        return ptr;
+        return (void *)ptr;
         break;
 
     default:
@@ -733,7 +732,7 @@ get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const int len)
  * the extension headers
  */
 uint8_t 
-get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const int l3len)
+get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr)
 {
     u_char *ptr = (u_char *)ip6_hdr + TCPR_IPV6_H; /* jump to the end of the IPv6 header */
     uint8_t proto;
@@ -741,15 +740,15 @@ get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const int l3len)
 
     assert(ip6_hdr);
 
-    proto = ip6_hdr->ip_nh;
-    int l4len = l3len - TCPR_IPV6_H;
-    if (l4len < 0)
-        return proto;
+    if (ptr > end_ptr)
+        return TCPR_IPV6_NH_NO_NEXT;
 
+    proto = ip6_hdr->ip_nh;
     while (TRUE) {
         dbgx(3, "Processing next proto 0x%02X", proto);
         switch (proto) {
             /* no further processing for IPV6 types with nothing beyond them */
+            case TCPR_IPV6_NH_NO_NEXT:
             case TCPR_IPV6_NH_FRAGMENT:
             case TCPR_IPV6_NH_ESP:
                 dbg(3, "No-Next or ESP... can't go any further...");
@@ -759,7 +758,7 @@ get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const int l3len)
             /* recurse */
             case TCPR_IPV6_NH_IPV6:
                 dbg(3, "Recursing due to v6 in v6");
-                return get_ipv6_l4proto((ipv6_hdr_t *)ptr, l4len);
+                return get_ipv6_l4proto((ipv6_hdr_t *)ptr, end_ptr);
                 break;
 
             /* loop again */
@@ -769,11 +768,10 @@ get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const int l3len)
             case TCPR_IPV6_NH_HBH:
                 dbgx(3, "Jumping to next extension header (0x%hhx)", proto);
                 exthdr = get_ipv6_next((struct tcpr_ipv6_ext_hdr_base *)ptr,
-                        l4len);
-                if (exthdr == NULL)
-                    return proto;
+                        end_ptr);
+                if (exthdr == NULL || (u_char*)exthdr + sizeof(*exthdr) > end_ptr)
+                    return TCPR_IPV6_NH_NO_NEXT;
                 proto = exthdr->ip_nh;
-                l4len -= (u_char *)exthdr - ptr;
                 ptr = (u_char *)exthdr;
                 break;
 

--- a/src/common/get.h
+++ b/src/common/get.h
@@ -47,11 +47,10 @@ int get_l2len_protocol(const u_char *pktdata,
                        uint32_t *l2offset,
                        uint32_t *vlan_offset);
 
-void *get_layer4_v4(const ipv4_hdr_t *ip_hdr, const int l3len);
-void *get_layer4_v6(const ipv6_hdr_t *ip_hdr, const int l3len);
+void *get_layer4_v4(const ipv4_hdr_t *ip_hdr, const u_char *end_ptr);
+void *get_layer4_v6(const ipv6_hdr_t *ip_hdr, const u_char *end_ptr);
 
-u_int8_t get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const int l3len);
-void *get_ipv6_next(struct tcpr_ipv6_ext_hdr_base *exthdr, const int l3len);
+u_int8_t get_ipv6_l4proto(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr);
 
 const u_char *get_ipv4(const u_char *pktdata, int datalen, int datalink, u_char **newbuff);
 const u_char *get_ipv6(const u_char *pktdata, int datalen, int datalink, u_char **newbuff);

--- a/src/tcpedit/checksum.c
+++ b/src/tcpedit/checksum.c
@@ -34,7 +34,12 @@ static int do_checksum_math(uint16_t *, int);
  * Returns -1 on error and 0 on success, 1 on warn
  */
 int
-do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len) {
+do_checksum(tcpedit_t *tcpedit,
+            uint8_t *data,
+            int proto,
+            int len,
+            const u_char *end_ptr)
+{
     ipv4_hdr_t *ipv4;
     ipv6_hdr_t *ipv6;
     tcp_hdr_t *tcp;
@@ -60,10 +65,10 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len) {
         ipv6 = (ipv6_hdr_t *)data;
         ipv4 = NULL;
 
-        proto = get_ipv6_l4proto(ipv6, len + sizeof(ipv6_hdr_t));
+        proto = get_ipv6_l4proto(ipv6, end_ptr);
         dbgx(3, "layer4 proto is 0x%hx", (uint16_t)proto);
 
-        layer = (u_char*)get_layer4_v6(ipv6, len + sizeof(ipv6_hdr_t));
+        layer = (u_char*)get_layer4_v6(ipv6, end_ptr);
         if (!layer) {
             tcpedit_setwarn(tcpedit, "%s", "Packet to short for checksum");
             return TCPEDIT_WARN;

--- a/src/tcpedit/checksum.h
+++ b/src/tcpedit/checksum.h
@@ -24,6 +24,6 @@
 #define CHECKSUM_CARRY(x) \
     (x = (x >> 16) + (x & 0xffff), (~(x + (x >> 16)) & 0xffff))
 
-int do_checksum(tcpedit_t *, u_int8_t *, int, int);
+int do_checksum(tcpedit_t *, u_int8_t *, int, int, const u_char*);
 
 #endif

--- a/src/tcpedit/fuzzing.c
+++ b/src/tcpedit/fuzzing.c
@@ -123,7 +123,8 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
     switch (l2proto) {
     case (ETHERTYPE_IP):
     {
-        l4data = get_layer4_v4((ipv4_hdr_t*)l3data, pkthdr->caplen - l2len);
+        l4data = get_layer4_v4((ipv4_hdr_t*)l3data,
+                               l3data + pkthdr->caplen - l2len);
         if (!l4data)
             goto done;
 
@@ -131,7 +132,8 @@ fuzzing(tcpedit_t *tcpedit, struct pcap_pkthdr *pkthdr,
         break;
     }
     case (ETHERTYPE_IP6): {
-        l4data = get_layer4_v6((ipv6_hdr_t*)l3data, pkthdr->caplen - l2len);
+        l4data = get_layer4_v6((ipv6_hdr_t*)l3data,
+                               l3data + pkthdr->caplen - l2len);
         if (!l4data)
             goto done;
 

--- a/src/tcpedit/portmap.c
+++ b/src/tcpedit/portmap.c
@@ -370,7 +370,7 @@ rewrite_ipv4_ports(tcpedit_t *tcpedit, ipv4_hdr_t **ip_hdr, const int l3len)
                 l3len);
         return TCPEDIT_ERROR;
     } else if ((*ip_hdr)->ip_p == IPPROTO_TCP || (*ip_hdr)->ip_p == IPPROTO_UDP) {
-        l4 = get_layer4_v4(*ip_hdr, l3len);
+        l4 = get_layer4_v4(*ip_hdr, (u_char *)ip_hdr + l3len);
         if (l4)
             return rewrite_ports(tcpedit, (*ip_hdr)->ip_p, l4,
                     l3len - (l4 - (u_char*)*ip_hdr));
@@ -394,7 +394,7 @@ rewrite_ipv6_ports(tcpedit_t *tcpedit, ipv6_hdr_t **ip6_hdr, const int l3len)
                 l3len);
         return TCPEDIT_ERROR;
     } else if ((*ip6_hdr)->ip_nh == IPPROTO_TCP || (*ip6_hdr)->ip_nh == IPPROTO_UDP) {
-        l4 = get_layer4_v6(*ip6_hdr, l3len);
+        l4 = get_layer4_v6(*ip6_hdr, (u_char*)ip6_hdr + l3len);
         if (l4)
             return rewrite_ports(tcpedit, (*ip6_hdr)->ip_nh, l4,
                     l3len - (l4 - (u_char*)*ip6_hdr));

--- a/src/tcpedit/rewrite_sequence.c
+++ b/src/tcpedit/rewrite_sequence.c
@@ -70,7 +70,8 @@ rewrite_ipv4_tcp_sequence(tcpedit_t *tcpedit, ipv4_hdr_t **ip_hdr,
     assert(*ip_hdr && ip_hdr);
 
     if (*ip_hdr && (*ip_hdr)->ip_p == IPPROTO_TCP) {
-        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v4(*ip_hdr, l3len);
+        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v4(*ip_hdr,
+                                                        (u_char *)ip_hdr + l3len);
         if (!tcp_hdr) {
             tcpedit_setwarn(tcpedit, "caplen to small to set TCP sequence for IP packet: l3 len=%d",
                     l3len);
@@ -91,7 +92,8 @@ rewrite_ipv6_tcp_sequence(tcpedit_t *tcpedit, ipv6_hdr_t **ip6_hdr,
     assert(*ip6_hdr && ip6_hdr);
 
     if (*ip6_hdr && (*ip6_hdr)->ip_nh == IPPROTO_TCP) {
-        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v6(*ip6_hdr, l3len);
+        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v6(*ip6_hdr,
+                                                        (u_char*)ip6_hdr + l3len);
         if (!tcp_hdr) {
             tcpedit_setwarn(tcpedit, "caplen to small to set TCP sequence for IP packet: l3 len=%d",
                     l3len);

--- a/src/tcpedit/tcpedit.c
+++ b/src/tcpedit/tcpedit.c
@@ -174,7 +174,7 @@ again:
         if (ip_hdr == NULL)
             return TCPEDIT_SOFT_ERROR;
 
-        p = get_layer4_v4(ip_hdr, (*pkthdr)->caplen - l2len);
+        p = get_layer4_v4(ip_hdr, (u_char*)ip_hdr + (*pkthdr)->caplen - l2len);
         if (!p) {
             tcpedit_seterr(tcpedit, "Packet length %d is too short to contain a layer %d byte IP header for DLT 0x%04x",
                     pktlen, ip_hdr->ip_hl << 2,  dst_dlt);
@@ -195,7 +195,7 @@ again:
         if (ip6_hdr == NULL)
             return TCPEDIT_SOFT_ERROR;
 
-        p = get_layer4_v6(ip6_hdr, (*pkthdr)->caplen - l2len);
+        p = get_layer4_v6(ip6_hdr, (u_char*)ip6_hdr + (*pkthdr)->caplen - l2len);
         if (!p) {
             tcpedit_seterr(tcpedit, "Packet length %d is too short to contain an IPv6 header for DLT 0x%04x",
                     pktlen, dst_dlt);

--- a/src/tcpprep.c
+++ b/src/tcpprep.c
@@ -215,14 +215,14 @@ check_dst_port(ipv4_hdr_t *ip_hdr, ipv6_hdr_t *ip6_hdr, int len)
             return 0; /* not enough data in the packet to know */
 
         proto = ip_hdr->ip_p;
-        l4 = get_layer4_v4(ip_hdr, len);
+        l4 = get_layer4_v4(ip_hdr, (u_char*)ip_hdr + len);
     } else if (ip6_hdr) {
         if (len < (TCPR_IPV6_H + 4))
             return 0; /* not enough data in the packet to know */
 
-        proto = get_ipv6_l4proto(ip6_hdr, len);
+        proto = get_ipv6_l4proto(ip6_hdr, (u_char*)ip6_hdr + len);
         dbgx(3, "Our layer4 proto is 0x%hhu", proto);
-        if ((l4 = get_layer4_v6(ip6_hdr, len)) == NULL)
+        if ((l4 = get_layer4_v6(ip6_hdr, (u_char*)ip6_hdr + len)) == NULL)
             return 0;
 
         dbgx(3, "Found proto %u at offset %p.  base %p (%p)", proto, (void *)l4, (void *)ip6_hdr, (void*)(l4 - (u_char *)ip6_hdr));


### PR DESCRIPTION
Add end_ptr to key functions, which make it easier to implement
overflow protections.