### PR TITLE
Bug #729 tcpreplay_edit: disallow both -K and -l options

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,6 @@
 08/02/2022 Version 4.4.2 Beta 1
     - replaying on a loopback interface is broken (#732)
+    - replay edit with both --loop and --preload_pcap options (#729)
     - test suite bus error on armhf (#725)
     - format string vulnerability in fix_ipv6_checksums (#723)
     - heap-overflow in parse_mpls (#719)

--- a/src/tcpreplay.c
+++ b/src/tcpreplay.c
@@ -67,11 +67,7 @@ main(int argc, char *argv[])
     fflush(NULL);
 
     ctx = tcpreplay_init();
-#ifdef TCPREPLAY
     optct = optionProcess(&tcpreplayOptions, argc, argv);
-#elif defined TCPREPLAY_EDIT
-    optct = optionProcess(&tcpreplay_editOptions, argc, argv);
-#endif
     argc -= optct;
     argv += optct;
 

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -227,6 +227,16 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
         options->preload_pcap = true;
     }
 
+#ifdef TCPREPLAY_EDIT
+    if (HAVE_OPT(PRELOAD_PCAP) && OPT_VALUE_LOOP > 1) {
+        tcpreplay_seterr(ctx,
+                         "%s",
+                         "tcpreplay_edit --loop (-l) and --preload_pcap (-K) options are mutually exclusive");
+        ret = -1;
+        goto out;
+    }
+#endif
+
     /* Dual file mode */
     if (HAVE_OPT(DUALFILE)) {
         options->dualfile = true;


### PR DESCRIPTION
Only for tcpreplay_edit. It is not well defined what should happen
when packets are both cached and edited. This forces packets to be
reloaded every loop iteration, resulting in edits on un-cached packets
every iteration.