### PR TITLE
Simulate packet loss

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -592,8 +592,9 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
             send_len -= l2len;
         }
 
-        /* write packet out on network */
-        if (sendpacket(sp, send_data, send_len, &pkthdr) < (int)send_len) {
+        /* write packet out on network, skipping it in random cases when asked for drop */
+        if ((options->drop == 1.0f || rand() > options->drop * RAND_MAX) &&
+            sendpacket(sp, send_data, send_len, &pkthdr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
             continue;
         }

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -875,8 +875,9 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             send_len -= l2len;
         }
 
-        /* write packet out on network */
-        if (sendpacket(sp, send_data, send_len, pkthdr_ptr) < (int)send_len) {
+        /* write packet out on network, skipping it in random cases when asked for drop */
+        if ((options->drop == 1.0f || rand() > options->drop * RAND_MAX) &&
+            sendpacket(sp, send_data, send_len, pkthdr_ptr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
             continue;
         }

--- a/src/tcpreplay.c
+++ b/src/tcpreplay.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #ifdef HAVE_FTS_H
 #include <fts.h>
 #endif
@@ -61,6 +62,8 @@ main(int argc, char *argv[])
     int rcode;
 
     fflush(NULL);
+
+    srand(time(NULL));
 
     ctx = tcpreplay_init();
     optct = optionProcess(&tcpreplayOptions, argc, argv);

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -204,6 +204,12 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
         options->speed.multiplier = atof(OPT_ARG(MULTIPLIER));
     }
 
+    if (HAVE_OPT(DROP)) {
+        options->drop = atof(OPT_ARG(DROP));
+    } else {
+        options->drop = 1.0f;
+    }
+
     if (HAVE_OPT(MAXSLEEP)) {
         options->maxsleep.tv_sec = OPT_VALUE_MAXSLEEP / 1000;
         options->maxsleep.tv_nsec = (OPT_VALUE_MAXSLEEP % 1000) * 1000 * 1000;

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -105,6 +105,7 @@ typedef struct tcpreplay_opt_s {
     COUNTER loop;
     u_int32_t loopdelay_ms;
     u_int32_t loopdelay_ns;
+    float drop;
 
     int stats;
     bool use_pkthdr_len;

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -571,6 +571,20 @@ EOText;
 };
 
 flag = {
+    name        = drop;
+    arg-type    = string;
+    max         = 1;
+    descrip     = "Simluate random packet loss";
+    doc         = <<- EOText
+Set to a value between 0 and 1 to simulate packet loss at send.
+Examples:
+@example
+    0.25 will drop around one quarter of packets (they will not be sent)
+@end example
+EOText;
+};
+
+flag = {
     name        = unique-ip;
     flags-must   = loop;
 #ifdef TCPREPLAY_EDIT


### PR DESCRIPTION
Useful when testing debugging UDP-based software like realtime audio streaming, simulates non-ideal network conditions.