### PR TITLE
Bug #751 don't exit after send error

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,6 @@
 12/28/2022 Version 4.4.3-Beta1
     - upgrade autogen/libopts to version 5.18.16 (#759)
+    - program exit after send error (#751)
 
 08/28/2022 Version 4.4.2
     - remove autogen.sh from distribution tarballs (#745)

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -487,7 +487,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         /* write packet out on network */
         if (sendpacket(sp, pktdata, pktlen, &pkthdr) < (int)pktlen) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
-            break;
+            continue;
         }
 
         /*
@@ -763,7 +763,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
         /* write packet out on network */
         if (sendpacket(sp, pktdata, pktlen, pkthdr_ptr) < (int)pktlen) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
-            break;
+            continue;
         }
 
         /*


### PR DESCRIPTION
Sample output:

```
/Users/fklassen/git/tcpreplay/build/src/tcpreplay -i en0 -t pkt_too_long.pcap
Actual: 2 packets (196 bytes) sent in 0.000066 seconds
Rated: 2969696.9 Bps, 23.75 Mbps, 30303.03 pps
Flows: 2 flows, 30303.03 fps, 3 flow packets, 0 non-flow
Statistics for network device: en0
	Successful packets:        2
	Failed packets:            1
	Truncated packets:         0
	Retried packets (ENOBUFS): 0
	Retried packets (EAGAIN):  0
Warning in /Users/fklassen/git/tcpreplay/src/send_packets.c:send_packets() line 489:
Unable to send packet: Error with bpf send() [2]: Input/output error (errno = 5)

Process finished with exit code 0
```