### PR TITLE
Bug #749 flow stats: avoid overstating flow packet count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,5 @@ test/*1
 COPYING
 .vscode/
 .idea/
-build/
+build*/
+.run/

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -4,6 +4,7 @@
     - remove invalid assert in tree (#756)
     - program exit after send error (#751)
     - make libpcap version test more robust (#750)
+    - looping inflates some packet counters (#749)
 
 08/28/2022 Version 4.4.2
     - remove autogen.sh from distribution tarballs (#745)


### PR DESCRIPTION
Flow, fps, flow packet counts make sense for many combinations of packet modifiers and cache settings:

```
# tcpreplay -i enp0s5 -l1 --mbps=1 ping.pcap
Actual: 16 packets (1568 bytes) sent in 0.012564 seconds
Rated: 124801.0 Bps, 0.998 Mbps, 1273.47 pps
Flows: 2 flows, 159.18 fps, 16 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        16
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l1 --mbps=1 -K ping.pcap
File Cache is enabled
Actual: 16 packets (1568 bytes) sent in 0.012561 seconds
Rated: 124830.8 Bps, 0.998 Mbps, 1273.78 pps
Flows: 2 flows, 159.22 fps, 16 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        16
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l10 --mbps=1 ping.pcap
Actual: 160 packets (15680 bytes) sent in 0.125452 seconds
Rated: 124988.0 Bps, 0.999 Mbps, 1275.38 pps
Flows: 2 flows, 15.94 fps, 160 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        160
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l10 --mbps=1 -K ping.pcap
File Cache is enabled
Actual: 160 packets (15680 bytes) sent in 0.125451 seconds
Rated: 124989.0 Bps, 0.999 Mbps, 1275.39 pps
Flows: 2 flows, 15.94 fps, 16 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        160
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l10 --mbps=1 --unique-ip --unique-ip-loops=3 ping.pcap
Actual: 160 packets (15680 bytes) sent in 0.125451 seconds
Rated: 124989.0 Bps, 0.999 Mbps, 1275.39 pps
Flows: 20 flows, 159.42 fps, 160 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        160
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l10 --mbps=1 --unique-ip --unique-ip-loops=3 -K ping.pcap
File Cache is enabled
Actual: 160 packets (15680 bytes) sent in 0.125457 seconds
Rated: 124983.0 Bps, 0.999 Mbps, 1275.33 pps
Flows: 20 flows, 159.41 fps, 160 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        160
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l10 --mbps=1 --unique-ip --unique-ip-loops=3 ping.pcap
Actual: 160 packets (15680 bytes) sent in 0.125456 seconds
Rated: 124984.0 Bps, 0.999 Mbps, 1275.34 pps
Flows: 8 flows, 63.76 fps, 64 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        160
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

# tcpreplay -i enp0s5 -l10 --mbps=1 --unique-ip --unique-ip-loops=3 -K ping.pcap
File Cache is enabled
Actual: 160 packets (15680 bytes) sent in 0.125450 seconds
Rated: 124990.0 Bps, 0.999 Mbps, 1275.40 pps
Flows: 8 flows, 63.77 fps, 64 unique flow packets, 0 unique non-flow packets
Statistics for network device: enp0s5
        Successful packets:        160
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0
        Retried packets (EAGAIN):  0

```