### PR TITLE
Bug #767 tests: support for out-of-tree tests

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -7,6 +7,7 @@
     - looping inflates some packet counters (#749)
 
 08/28/2022 Version 4.4.2
+    - fix tests when building in a directory outside source tree (#767)
     - remove autogen.sh from distribution tarballs (#745)
     - CVE-2022-37048 heap-overflow in get_l2len_protocol (#735)
     - replaying on a loopback interface is broken (#732)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -68,7 +68,7 @@ standard_prep:
 	$(TCPPREP) -i $(TEST_PCAP) -o test.auto_bridge -a bridge
 	$(TCPPREP) -i $(TEST_PCAP) -o test.auto_client -a client
 	$(TCPPREP) -i $(TEST_PCAP) -o test.auto_server -a server
-	$(TCPPREP) -i test.pcap -o test.auto_first -a first
+	$(TCPPREP) -i $(TEST_PCAP) -o test.auto_first -a first
 	$(TCPPREP) --load-opts config -o test.prep_config
 	$(TCPPREP) -i $(TEST_PCAP) -o test.port -p
 	$(TCPPREP) -i $(TEST_PCAP) -o test.mac -e 00:1f:f3:3c:e1:13
@@ -313,29 +313,29 @@ mac_reverse:
 exclude_packets:
 	$(PRINTF) "%s" "[tcpprep] exclude packets test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] exclude packets test: " >> test.log
-	$(TCPPREP) $(ENABLE_DEBUG) -i test.pcap -o test.$@1 -c '96.17.211.0/24' --exclude 'P:61-65,88-91' >> test.log 2>&1
-	diff test.$@ test.$@1 >> test.log 2>&1
+	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --exclude 'P:61-65,88-91' >> test.log 2>&1
+	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
 	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
 
 include_packets:
 	$(PRINTF) "%s" "[tcpprep] include packets test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] include packets test: " >> test.log
-	$(TCPPREP) $(ENABLE_DEBUG) -i test.pcap -o test.$@1 -c '96.17.211.0/24' --include 'P:61-65,88-91' >> test.log 2>&1
-	diff test.$@ test.$@1 >> test.log 2>&1
+	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --include 'P:61-65,88-91' >> test.log 2>&1
+	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
 	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
 
 include_source:
 	$(PRINTF) "%s" "[tcpprep] include source test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] include source test: " >> test.log
-	$(TCPPREP) $(ENABLE_DEBUG) -i test.pcap -o test.$@1 -c '96.17.211.0/24' --include 'S:96.0.0.0/8' >> test.log 2>&1
-	diff test.$@ test.$@1 >> test.log 2>&1
+	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --include 'S:96.0.0.0/8' >> test.log 2>&1
+	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
 	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
 
 include_dest:
 	$(PRINTF) "%s" "[tcpprep] include destination test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] include destination test: " >> test.log
-	$(TCPPREP) $(ENABLE_DEBUG) -i test.pcap -o test.$@1 -c '96.17.211.0/24' --include 'D:96.0.0.0/8' >> test.log 2>&1
-	diff test.$@ test.$@1 >> test.log 2>&1
+	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --include 'D:96.0.0.0/8' >> test.log 2>&1
+	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
 	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
 
 replay_basic:

--- a/test/config.in
+++ b/test/config.in
@@ -1,24 +1,23 @@
 #  tcpreplay - Replay network traffic stored in pcap files
 #  preset/initialization file
-#  Mon Jan 10 15:19:55 2005
 #
 [TCPREPLAY]
-cachefile           test.auto_bridge
+cachefile           @srcdir@/test.auto_bridge
 intf1               @nic1@
 intf2               @nic2@
 topspeed
 
 [TCPREWRITE]
-infile      test.pcap
-outfile     test.rewrite_config1
-cachefile   test.auto_bridge
+infile           @srcdir@/test.pcap
+outfile          test.rewrite_config1
+cachefile        @srcdir@/test.auto_bridge
 enet-vlan        add
 enet-vlan-tag    45
 enet-vlan-cfi    1
 enet-vlan-pri    5
 
 [TCPPREP]
-pcap        test.pcap
+pcap        @srcdir@/test.pcap
 auto        bridge
 minmask     31
 maxmask     16


### PR DESCRIPTION
e.g.

```
mkdir build
cd build
autoreconf --install --force --verbose ..; ../configure --disable-local-libopts --with-testnic=enp0s5
make
sudo make test
```