### PR TITLE
dlt_jnpr_ether_cleanup: check subctx before cleanup

### DIFF
--- a/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.c
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.c
@@ -168,7 +168,8 @@ dlt_jnpr_ether_cleanup(tcpeditdlt_t *ctx)
         jnpr_ether_config_t *config;
 
         config = (jnpr_ether_config_t *)ctx->encoder->config;
-        tcpedit_dlt_cleanup(config->subctx);
+        if (config->subctx != NULL)
+            tcpedit_dlt_cleanup(config->subctx);
         safe_free(plugin->config);
         plugin->config = NULL;
         plugin->config_size = 0;


### PR DESCRIPTION
Fix #780 