### PR TITLE
Update en10mb.c

### DIFF
--- a/src/tcpedit/plugins/dlt_en10mb/en10mb.c
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb.c
@@ -807,7 +807,7 @@ static void dlt_en10mb_ipv6_multicast_mac_update(const struct tcpr_in6_addr *ip6
                                                  uint8_t mac[])
 {
     /* only modify multicast packets */
-    if (ip6->tcpr_s6_addr[0] == 0xff)
+    if (ip6->tcpr_s6_addr[0] != 0xff)
         return;
 
     mac[0] = 0x33;


### PR DESCRIPTION
Fixed expression to detect an ip6 multicast packet. This fix prevents L2 flooding of ipv6 unicast packets when using tcpreplay-edit.