### PR TITLE
Nanosec accurate packet processing

### DIFF
--- a/src/bridge.c
+++ b/src/bridge.c
@@ -238,7 +238,7 @@ do_bridge(tcpbridge_opt_t *options, tcpedit_t *tcpedit)
         do_bridge_bidirectional(options, tcpedit);
     }
 
-    if (gettimeofday(&stats.end_time, NULL) < 0)
+    if (get_time_of_day(&stats.end_time) < 0)
         errx(-1, "gettimeofday() failed: %s",  strerror(errno));
     packet_stats(&stats);
 }

--- a/src/bridge.c
+++ b/src/bridge.c
@@ -238,8 +238,8 @@ do_bridge(tcpbridge_opt_t *options, tcpedit_t *tcpedit)
         do_bridge_bidirectional(options, tcpedit);
     }
 
-    if (get_time_of_day(&stats.end_time) < 0)
-        errx(-1, "gettimeofday() failed: %s",  strerror(errno));
+    if (get_current_time(&stats.end_time) < 0)
+        errx(-1, "get_current_time() failed: %s",  strerror(errno));
     packet_stats(&stats);
 }
 

--- a/src/common/timer.c
+++ b/src/common/timer.c
@@ -91,13 +91,13 @@ init_timestamp(struct timespec *timestamp)
     timesclear(timestamp);
 }
 
-int get_time_of_day(struct timespec *ts) {
-    struct timeval tv;
-    int success = gettimeofday(&tv, NULL);
-    TIMEVAL_TO_TIMESPEC(&tv, ts);
-    return success;
-}
-
-int clock_get_time(struct timespec *ts){
-    return clock_gettime(CLOCK_REALTIME, ts);
+int get_current_time(struct timespec *ts){
+    #ifdef _POSIX_C_SOURCE >= 199309L
+        return clock_gettime(CLOCK_REALTIME, ts);
+    #else
+        struct timeval tv;
+        int success = gettimeofday(&tv, NULL);
+        TIMEVAL_TO_TIMESPEC(&tv, ts);
+        return success;
+    #endif
 }

--- a/src/common/timer.c
+++ b/src/common/timer.c
@@ -92,7 +92,7 @@ init_timestamp(struct timespec *timestamp)
 }
 
 int get_current_time(struct timespec *ts){
-    #ifdef _POSIX_C_SOURCE >= 199309L
+    #if defined _POSIX_C_SOURCE  && _POSIX_C_SOURCE >= 199309L
         return clock_gettime(CLOCK_REALTIME, ts);
     #else
         struct timeval tv;

--- a/src/common/timer.c
+++ b/src/common/timer.c
@@ -86,8 +86,18 @@ void timesdiv(struct timespec *tvs, COUNTER div)
 }
 
 void
-init_timestamp(timestamp_t *ctx)
+init_timestamp(struct timespec *timestamp)
 {
-    timerclear(ctx);
+    timesclear(timestamp);
 }
 
+int get_time_of_day(struct timespec *ts) {
+    struct timeval tv;
+    int success = gettimeofday(&tv, NULL);
+    TIMEVAL_TO_TIMESPEC(&tv, ts);
+    return success;
+}
+
+int clock_get_time(struct timespec *ts){
+    return clock_gettime(CLOCK_REALTIME, ts);
+}

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -117,6 +117,35 @@ void timesdiv(struct timespec *tvs, COUNTER div);
     } while (0)
 #endif
 
+/* add tvp and uvp and store in vvp */
+#ifndef timeradd_timespec
+#define timeradd_timespec(tvp, uvp, vvp)                             \
+    do {                                                    \
+        (vvp)->tv_sec = (tvp)->tv_sec + (uvp)->tv_sec;      \
+        (vvp)->tv_nsec = (tvp)->tv_nsec + (uvp)->tv_nsec;   \
+        if ((vvp)->tv_nsec >= 1000000000) {                 \
+            (vvp)->tv_sec++;                                \
+            (vvp)->tv_nsec -= 1000000000;                   \
+        }                                                   \
+    } while (0)
+#endif
+
+
+/* add tvp and uvp and store in vvp */
+#ifndef timeradd_timeval_timespec
+#define timeradd_timeval_timespec(tvp, uvp, vvp)                             \
+    do {                                                         \
+        (vvp)->tv_sec = (tvp)->tv_sec + (uvp)->tv_sec;           \
+        (vvp)->tv_nsec = (tvp)->tv_nsec + (uvp)->tv_usec * 1000; \
+        if ((vvp)->tv_nsec >= 1000000000) {                      \
+            int seconds = (vvp)->tv_nsec % 1000000000;           \
+            (vvp)->tv_sec += seconds;                            \
+            (vvp)->tv_nsec -= 1000000000 * seconds;              \
+        }                                                        \
+    } while (0)
+#endif
+
+
 /* subtract uvp from tvp and store in vvp */
 #ifndef timersub
 #define  timersub(tvp, uvp, vvp)                             \
@@ -170,7 +199,8 @@ void timesdiv(struct timespec *tvs, COUNTER div);
 
     typedef struct timeval timestamp_t;
 
-void init_timestamp(timestamp_t *ctx);
-
+void init_timestamp(struct timespec *timestamp);
+int get_time_of_day(struct timespec *ts);
+int clock_get_time(struct timespec *ts);
 
 #endif /* _TIMER_H_ */

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -200,7 +200,6 @@ void timesdiv(struct timespec *tvs, COUNTER div);
     typedef struct timeval timestamp_t;
 
 void init_timestamp(struct timespec *timestamp);
-int get_time_of_day(struct timespec *ts);
-int clock_get_time(struct timespec *ts);
+int get_current_time(struct timespec *ts);
 
 #endif /* _TIMER_H_ */

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -31,11 +31,11 @@ typedef struct {
     COUNTER bytes_sent;
     COUNTER pkts_sent;
     COUNTER failed;
-    struct timeval start_time;
-    struct timeval time_delta;
-    struct timeval end_time;
-    struct timeval pkt_ts_delta;
-    struct timeval last_print;
+    struct timespec start_time;
+    struct timespec time_delta;
+    struct timespec end_time;
+    struct timespec pkt_ts_delta;
+    struct timespec last_print;
     COUNTER flow_non_flow_packets;
     COUNTER flows;
     COUNTER flows_unique;
@@ -47,7 +47,7 @@ typedef struct {
 
 int read_hexstring(const char *l2string, u_char *hex, const int hexlen);
 void packet_stats(const tcpreplay_stats_t *stats);
-int format_date_time(struct timeval *when, char *buf, size_t len);
+int format_date_time(struct timespec *when, char *buf, size_t len);
 uint32_t tcpr_random(uint32_t *seed);
 void restore_stdin(void);
 

--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -317,7 +317,6 @@ typedef u_int32_t uint32_t
 #define TIMEVAL_TO_MILLISEC(x)  (((x)->tv_sec * 1000) + ((x)->tv_usec / 1000))
 #define TIMEVAL_TO_MICROSEC(x)  (((x)->tv_sec * 1000000) + (x)->tv_usec)
 #define TIMEVAL_TO_NANOSEC(x)   ((u_int64_t)((x)->tv_sec * 1000000000) + ((u_int64_t)(x)->tv_usec * 1000))
-#define TIMSTAMP_TO_MICROSEC(x) (TIMEVAL_TO_MICROSEC(x))
 
 #define MILLISEC_TO_TIMEVAL(x, tv)          \
     do {                                    \

--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -358,6 +358,13 @@ typedef u_int32_t uint32_t
         (a)->tv_nsec = (b)->tv_nsec;        \
     } while(0)
 
+/* libpcap puts nanosec values in tv_usec when pcap file is read with nanosec precision*/
+#define TIMEVAL_AS_TIMESPEC_SET(a, b)       \
+    do {                                    \
+        (a)->tv_sec = (b)->tv_sec;          \
+        (a)->tv_nsec = (b)->tv_usec;        \
+    } while(0)
+
 /* 
  * Help suppress some compiler warnings
  * No problem if variable is actually used 

--- a/src/replay.c
+++ b/src/replay.c
@@ -125,7 +125,7 @@ replay_file(tcpreplay_t *ctx, int idx)
 
     /* read from pcap file if we haven't cached things yet */
     if (!ctx->options->preload_pcap) {
-        if ((pcap = pcap_open_offline(path, ebuf)) == NULL) {
+        if ((pcap = pcap_open_offline_with_tstamp_precision(path, PCAP_TSTAMP_PRECISION_NANO, ebuf)) == NULL) {
             tcpreplay_seterr(ctx, "Error opening pcap file: %s", ebuf);
             return -1;
         }
@@ -140,10 +140,10 @@ replay_file(tcpreplay_t *ctx, int idx)
 
     } else {
         if (!ctx->options->file_cache[idx].cached) {
-            if ((pcap = pcap_open_offline(path, ebuf)) == NULL) {
-                tcpreplay_seterr(ctx, "Error opening pcap file: %s", ebuf);
-                return -1;
-            }
+        if ((pcap = pcap_open_offline_with_tstamp_precision(path, PCAP_TSTAMP_PRECISION_NANO, ebuf)) == NULL) {
+            tcpreplay_seterr(ctx, "Error opening pcap file: %s", ebuf);
+            return -1;
+        }
             ctx->options->file_cache[idx].dlt = pcap_datalink(pcap);
         }
     }
@@ -152,10 +152,10 @@ replay_file(tcpreplay_t *ctx, int idx)
     if (ctx->options->verbose) {
         /* in cache mode, we may not have opened the file */
         if (pcap == NULL)
-            if ((pcap = pcap_open_offline(path, ebuf)) == NULL) {
-               tcpreplay_seterr(ctx, "Error opening pcap file: %s", ebuf);
-               return -1;
-            }
+        if ((pcap = pcap_open_offline_with_tstamp_precision(path, PCAP_TSTAMP_PRECISION_NANO, ebuf)) == NULL) {
+            tcpreplay_seterr(ctx, "Error opening pcap file: %s", ebuf);
+            return -1;
+        }
 
         ctx->options->file_cache[idx].dlt = pcap_datalink(pcap);
         /* init tcpdump */

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -339,7 +339,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
             (options->speed.mode == speed_mbpsrate && options->speed.speed == 0));
     bool now_is_now = true;
 
-    ctx->timefunction.gettime(&now);
+    get_current_time(&now);
     if (!timesisset(&stats->start_time)) {
         TIMESPEC_SET(&stats->start_time, &now);
         if (ctx->options->stats >= 0) {
@@ -448,7 +448,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
 
             if (!top_speed) {
                 now_is_now = true;
-                ctx->timefunction.gettime(&now);
+                get_current_time(&now);
             }
 
             /*
@@ -535,18 +535,18 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
     if (options->netmap && (ctx->abort || options->loop == 1)) {
         while (ctx->intf1 && !netmap_tx_queues_empty(ctx->intf1)) {
             now_is_now = true;
-            ctx->timefunction.gettime(&now);
+            get_current_time(&now);
         }
 
         while (ctx->intf2 && !netmap_tx_queues_empty(ctx->intf2)) {
             now_is_now = true;
-            ctx->timefunction.gettime(&now);
+            get_current_time(&now);
         }
     }
 #endif /* HAVE_NETMAP */
 
     if (!now_is_now)
-        ctx->timefunction.gettime(&now);
+        get_current_time(&now);
 
     TIMESPEC_SET(&stats->end_time, &now);
 
@@ -581,7 +581,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             (options->speed.mode == speed_mbpsrate && options->speed.speed == 0));
     bool now_is_now = true;
 
-    ctx->timefunction.gettime(&now);
+    get_current_time(&now);
     if (!timesisset(&stats->start_time)) {
         TIMESPEC_SET(&stats->start_time, &now);
         if (ctx->options->stats >= 0) {
@@ -723,7 +723,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             }
 
             if (!top_speed) {
-                ctx->timefunction.gettime(&now);
+                get_current_time(&now);
                 now_is_now = true;
             }
 
@@ -814,19 +814,19 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
     /* when completing test, wait until the last packet is sent */
     if (options->netmap && (ctx->abort || options->loop == 1)) {
         while (ctx->intf1 && !netmap_tx_queues_empty(ctx->intf1)) {
-            ctx->timefunction.gettime(&now);
+            get_current_time(&now);
             now_is_now = true;
         }
 
         while (ctx->intf2 && !netmap_tx_queues_empty(ctx->intf2)) {
-            ctx->timefunction.gettime(&now);
+            get_current_time(&now);
             now_is_now = true;
         }
     }
 #endif /* HAVE_NETMAP */
 
     if (!now_is_now)
-        ctx->timefunction.gettime(&now);
+        get_current_time(&now);
 
     TIMESPEC_SET(&stats->end_time, &now);
 

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -65,12 +65,12 @@ extern tcpedit_t *tcpedit;
 extern int debug;
 #endif
 
-static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_time,
-        struct timeval *last, COUNTER len,
-        sendpacket_t *sp, COUNTER counter, timestamp_t *sent_timestamp,
+static void calc_sleep_time(tcpreplay_t *ctx, struct timespec *pkt_time,
+        struct timespec *last, COUNTER len,
+        sendpacket_t *sp, COUNTER counter, struct timespec *sent_timestamp,
         COUNTER start_us, COUNTER *skip_length);
 static void tcpr_sleep(tcpreplay_t *ctx, sendpacket_t *sp _U_,
-        struct timespec *nap_this_time, struct timeval *now);
+        struct timespec *nap_this_time, struct timespec *now);
 static u_char *get_next_packet(tcpreplay_t *ctx, pcap_t *pcap,
         struct pcap_pkthdr *pkthdr,
         int file_idx,
@@ -315,9 +315,9 @@ static void increment_iteration(tcpreplay_t *ctx)
  */
 void
 send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
-{
-
-    struct timeval print_delta, now, last_pkt_ts;
+{   
+    struct timeval last_pkt_ts;
+    struct timespec now, print_delta;
     tcpreplay_opt_t *options = ctx->options;
     tcpreplay_stats_t *stats = &ctx->stats;
     COUNTER packetnum = 0;
@@ -339,9 +339,9 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
             (options->speed.mode == speed_mbpsrate && options->speed.speed == 0));
     bool now_is_now = true;
 
-    gettimeofday(&now, NULL);
-    if (!timerisset(&stats->start_time)) {
-        TIMEVAL_SET(&stats->start_time, &now);
+    ctx->timefunction.gettime(&now);
+    if (!timesisset(&stats->start_time)) {
+        TIMESPEC_SET(&stats->start_time, &now);
         if (ctx->options->stats >= 0) {
             char buf[64];
             if (format_date_time(&stats->start_time, buf, sizeof(buf)) > 0)
@@ -352,7 +352,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
     ctx->skip_packets = 0;
     timerclear(&last_pkt_ts);
     if (options->limit_time > 0)
-        end_us = TIMEVAL_TO_MICROSEC(&stats->start_time) +
+        end_us = TIMESPEC_TO_MICROSEC(&stats->start_time) +
             SEC_TO_MICROSEC(options->limit_time);
     else
         end_us = 0;
@@ -441,14 +441,14 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
                     struct timeval delta;
 
                     timersub(&pkthdr.ts, &last_pkt_ts, &delta);
-                    timeradd(&stats->pkt_ts_delta, &delta, &stats->pkt_ts_delta);
+                    timeradd_timeval_timespec(&stats->pkt_ts_delta, &delta, &stats->pkt_ts_delta);
                     TIMEVAL_SET(&last_pkt_ts, &pkthdr.ts);
                 }
             }
 
             if (!top_speed) {
                 now_is_now = true;
-                gettimeofday(&now, NULL);
+                ctx->timefunction.gettime(&now);
             }
 
             /*
@@ -459,7 +459,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
              */
             calc_sleep_time(ctx, &stats->pkt_ts_delta, &stats->time_delta,
                     pktlen, sp, packetnum, &stats->end_time,
-                    TIMEVAL_TO_MICROSEC(&stats->start_time), &skip_length);
+                    TIMESPEC_TO_NANOSEC(&stats->start_time), &skip_length);
 
             /*
              * Track the time of the "last packet sent".
@@ -467,8 +467,8 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
              * A number of 3rd party tools generate bad timestamps which go backwards
              * in time.  Hence, don't update the "last" unless pkthdr.ts > last
              */
-            if (timercmp(&stats->time_delta, &stats->pkt_ts_delta, <))
-                TIMEVAL_SET(&stats->time_delta, &stats->pkt_ts_delta);
+            if (timescmp(&stats->time_delta, &stats->pkt_ts_delta, <))
+                TIMESPEC_SET(&stats->time_delta, &stats->pkt_ts_delta);
 
             /*
              * we know how long to sleep between sends, now do it.
@@ -493,7 +493,7 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         /*
          * Mark the time when we sent the last packet
          */
-        TIMEVAL_SET(&stats->end_time, &now);
+        TIMESPEC_SET(&stats->end_time, &now);
 
 #ifdef TIMESTAMP_TRACE
         add_timestamp_trace_entry(pktlen, &stats->end_time, skip_length);
@@ -504,14 +504,14 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
 
         /* print stats during the run? */
         if (options->stats > 0) {
-            if (! timerisset(&stats->last_print)) {
-                TIMEVAL_SET(&stats->last_print, &now);
+            if (! timesisset(&stats->last_print)) {
+                TIMESPEC_SET(&stats->last_print, &now);
             } else {
-                timersub(&now, &stats->last_print, &print_delta);
+                timessub(&now, &stats->last_print, &print_delta);
                 if (print_delta.tv_sec >= options->stats) {
-                    TIMEVAL_SET(&stats->end_time, &now);
+                    TIMESPEC_SET(&stats->end_time, &now);
                     packet_stats(stats);
-                    TIMEVAL_SET(&stats->last_print, &now);
+                    TIMESPEC_SET(&stats->last_print, &now);
                 }
             }
         }
@@ -523,33 +523,32 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         }
 #endif
         /* stop sending based on the duration limit... */
-        if ((end_us > 0 && (COUNTER)TIMEVAL_TO_MICROSEC(&now) > end_us) ||
+        if ((end_us > 0 && (COUNTER)TIMESPEC_TO_MICROSEC(&now) > end_us) ||
                 /* ... or stop sending based on the limit -L? */
                 (limit_send > 0 && stats->pkts_sent >= limit_send)) {
             ctx->abort = true;
         }
     } /* while */
 
-
 #ifdef HAVE_NETMAP
     /* when completing test, wait until the last packet is sent */
     if (options->netmap && (ctx->abort || options->loop == 1)) {
         while (ctx->intf1 && !netmap_tx_queues_empty(ctx->intf1)) {
             now_is_now = true;
-            gettimeofday(&now, NULL);
+            ctx->timefunction.gettime(&now);
         }
 
         while (ctx->intf2 && !netmap_tx_queues_empty(ctx->intf2)) {
             now_is_now = true;
-            gettimeofday(&now, NULL);
+            ctx->timefunction.gettime(&now);
         }
     }
 #endif /* HAVE_NETMAP */
 
     if (!now_is_now)
-        gettimeofday(&now, NULL);
+        ctx->timefunction.gettime(&now);
 
-    TIMEVAL_SET(&stats->end_time, &now);
+    TIMESPEC_SET(&stats->end_time, &now);
 
     increment_iteration(ctx);
 }
@@ -561,7 +560,8 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
 void
 send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *pcap2, int cache_file_idx2)
 {
-    struct timeval print_delta, now, last_pkt_ts;
+    struct timeval last_pkt_ts;
+    struct timespec now, print_delta;
     tcpreplay_opt_t *options = ctx->options;
     tcpreplay_stats_t *stats = &ctx->stats;
     COUNTER packetnum = 0;
@@ -581,9 +581,9 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             (options->speed.mode == speed_mbpsrate && options->speed.speed == 0));
     bool now_is_now = true;
 
-    gettimeofday(&now, NULL);
-    if (!timerisset(&stats->start_time)) {
-        TIMEVAL_SET(&stats->start_time, &now);
+    ctx->timefunction.gettime(&now);
+    if (!timesisset(&stats->start_time)) {
+        TIMESPEC_SET(&stats->start_time, &now);
         if (ctx->options->stats >= 0) {
             char buf[64];
             if (format_date_time(&stats->start_time, buf, sizeof(buf)) > 0)
@@ -594,7 +594,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
     ctx->skip_packets = 0;
     timerclear(&last_pkt_ts);
     if (options->limit_time > 0)
-        end_us = TIMEVAL_TO_MICROSEC(&stats->start_time) +
+        end_us = TIMESPEC_TO_MICROSEC(&stats->start_time) +
             SEC_TO_MICROSEC(options->limit_time);
     else
         end_us = 0;
@@ -714,16 +714,16 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
                     struct timeval delta;
 
                     timersub(&pkthdr_ptr->ts, &last_pkt_ts, &delta);
-                    timeradd(&stats->pkt_ts_delta, &delta, &stats->pkt_ts_delta);
+                    timeradd_timeval_timespec(&stats->pkt_ts_delta, &delta, &stats->pkt_ts_delta);
                     TIMEVAL_SET(&last_pkt_ts, &pkthdr_ptr->ts);
                 }
 
-                if (!timerisset(&stats->time_delta))
-                    TIMEVAL_SET(&stats->pkt_ts_delta, &stats->pkt_ts_delta);
+                if (!timesisset(&stats->time_delta))
+                    TIMESPEC_SET(&stats->pkt_ts_delta, &stats->pkt_ts_delta);
             }
 
             if (!top_speed) {
-                gettimeofday(&now, NULL);
+                ctx->timefunction.gettime(&now);
                 now_is_now = true;
             }
 
@@ -735,7 +735,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
              */
             calc_sleep_time(ctx, &stats->pkt_ts_delta, &stats->time_delta,
                     pktlen, sp, packetnum, &stats->end_time,
-                    TIMEVAL_TO_MICROSEC(&stats->start_time), &skip_length);
+                    TIMESPEC_TO_NANOSEC(&stats->start_time), &skip_length);
 
             /*
              * Track the time of the "last packet sent".
@@ -743,8 +743,8 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
              * A number of 3rd party tools generate bad timestamps which go backwards
              * in time.  Hence, don't update the "last" unless pkthdr_ptr->ts > last
              */
-            if (timercmp(&stats->time_delta, &stats->pkt_ts_delta, <))
-                TIMEVAL_SET(&stats->time_delta, &stats->pkt_ts_delta);
+            if (timescmp(&stats->time_delta, &stats->pkt_ts_delta, <))
+                TIMESPEC_SET(&stats->time_delta, &stats->pkt_ts_delta);
 
             /*
              * we know how long to sleep between sends, now do it.
@@ -769,21 +769,21 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
         /*
          * Mark the time when we sent the last packet
          */
-        TIMEVAL_SET(&stats->end_time, &now);
+        TIMESPEC_SET(&stats->end_time, &now);
 
         ++stats->pkts_sent;
         stats->bytes_sent += pktlen;
 
         /* print stats during the run? */
         if (options->stats > 0) {
-            if (! timerisset(&stats->last_print)) {
-                TIMEVAL_SET(&stats->last_print, &now);
+            if (! timesisset(&stats->last_print)) {
+                TIMESPEC_SET(&stats->last_print, &now);
             } else {
-                timersub(&now, &stats->last_print, &print_delta);
+                timessub(&now, &stats->last_print, &print_delta);
                 if (print_delta.tv_sec >= options->stats) {
-                    TIMEVAL_SET(&stats->end_time, &now);
+                    TIMESPEC_SET(&stats->end_time, &now);
                     packet_stats(stats);
-                    TIMEVAL_SET(&stats->last_print, &now);
+                    TIMESPEC_SET(&stats->last_print, &now);
                 }
             }
         }
@@ -803,7 +803,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
         }
 
         /* stop sending based on the duration limit... */
-        if ((end_us > 0 && (COUNTER)TIMEVAL_TO_MICROSEC(&now) > end_us) ||
+        if ((end_us > 0 && (COUNTER)TIMESPEC_TO_MICROSEC(&now) > end_us) ||
                 /* ... or stop sending based on the limit -L? */
                 (limit_send > 0 && stats->pkts_sent >= limit_send)) {
             ctx->abort = true;
@@ -814,21 +814,21 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
     /* when completing test, wait until the last packet is sent */
     if (options->netmap && (ctx->abort || options->loop == 1)) {
         while (ctx->intf1 && !netmap_tx_queues_empty(ctx->intf1)) {
-            gettimeofday(&now, NULL);
+            ctx->timefunction.gettime(&now);
             now_is_now = true;
         }
 
         while (ctx->intf2 && !netmap_tx_queues_empty(ctx->intf2)) {
-            gettimeofday(&now, NULL);
+            ctx->timefunction.gettime(&now);
             now_is_now = true;
         }
     }
 #endif /* HAVE_NETMAP */
 
     if (!now_is_now)
-        gettimeofday(&now, NULL);
+        ctx->timefunction.gettime(&now);
 
-    TIMEVAL_SET(&stats->end_time, &now);
+    TIMESPEC_SET(&stats->end_time, &now);
 
     increment_iteration(ctx);
 }
@@ -965,14 +965,14 @@ cache_mode(tcpreplay_t *ctx, char *cachedata, COUNTER packet_num)
  * calculate the appropriate amount of time to sleep. Sleep time
  * will be in ctx->nap.
  */
-static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_ts_delta,
-        struct timeval *time_delta, COUNTER len,
-        sendpacket_t *sp, COUNTER counter, timestamp_t *sent_timestamp,
-        COUNTER start_us, COUNTER *skip_length)
+static void calc_sleep_time(tcpreplay_t *ctx, struct timespec *pkt_ts_delta,
+        struct timespec *time_delta, COUNTER len,
+        sendpacket_t *sp, COUNTER counter, struct timespec *sent_timestamp,
+        COUNTER start_ns, COUNTER *skip_length)
 {
     tcpreplay_opt_t *options = ctx->options;
-    struct timeval nap_for;
-    COUNTER now_us;
+    struct timespec nap_for;
+    COUNTER now_ns;
 
     timesclear(&ctx->nap);
 
@@ -996,10 +996,10 @@ static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_ts_delta,
          * Replay packets a factor of the time they were originally sent.
          * Make sure the packet is not late.
          */
-        if (timercmp(pkt_ts_delta, time_delta, >)) {
+        if (timescmp(pkt_ts_delta, time_delta, >)) {
             /* pkt_time_delta has increased, so handle normally */
-            timersub(pkt_ts_delta, time_delta, &nap_for);
-            TIMEVAL_TO_TIMESPEC(&nap_for, &ctx->nap);
+            timessub(pkt_ts_delta, time_delta, &nap_for);
+            TIMESPEC_SET(&nap_for, &ctx->nap);
             dbgx(3, "original packet delta time: " TIMESPEC_FORMAT,
                     ctx->nap.tv_sec, ctx->nap.tv_nsec);
             timesdiv_float(&ctx->nap, options->speed.multiplier);
@@ -1013,32 +1013,32 @@ static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_ts_delta,
          * Ignore the time supplied by the capture file and send data at
          * a constant 'rate' (bytes per second).
          */
-        now_us = TIMSTAMP_TO_MICROSEC(sent_timestamp);
-        if (now_us) {
-            COUNTER next_tx_us;
+        now_ns = TIMESPEC_TO_NANOSEC(sent_timestamp);
+        if (now_ns) {
+            COUNTER next_tx_ns;
             COUNTER bps = options->speed.speed;
-            COUNTER bits_sent = ((ctx->stats.bytes_sent + len) * 8);
-            COUNTER tx_us = now_us - start_us;
+            COUNTER bits_sent = ((ctx->stats.bytes_sent + len) * 8); //PB: Ferencol miert bits sent?
+            COUNTER tx_ns = now_ns - start_ns;
 
             /*
-             * bits * 1000000 divided by bps = microseconds
+             * bits * 1000000000 divided by bps = nanosecond
              *
              * ensure there is no overflow in cases where bits_sent is very high
              */
             if (bits_sent > COUNTER_OVERFLOW_RISK && bps > 500000)
-                next_tx_us = (bits_sent * 1000) / bps * 1000;
+                next_tx_ns = (bits_sent * 1000) / bps * 1000000;
             else
-                next_tx_us = (bits_sent * 1000000) / bps;
+                next_tx_ns = (bits_sent * 1000000000) / bps;
 
-            if (next_tx_us > tx_us) {
-                NANOSEC_TO_TIMESPEC((next_tx_us - tx_us) * 1000, &ctx->nap);
-            } else if (tx_us > next_tx_us) {
-                tx_us = now_us - start_us;
-                *skip_length = ((tx_us - next_tx_us) * bps) / 8000000;
+            if (next_tx_ns > tx_ns) {
+                NANOSEC_TO_TIMESPEC(next_tx_ns - tx_ns, &ctx->nap);
+            } else if (tx_ns > next_tx_ns) {
+                tx_ns = now_ns - start_ns;
+                *skip_length = ((tx_ns - next_tx_ns) * bps) / 8000000000;
             }
 
             update_current_timestamp_trace_entry(ctx->stats.bytes_sent +
-                    (COUNTER)len, now_us, tx_us, next_tx_us);
+                    (COUNTER)len, now_ns, tx_ns, next_tx_ns);
         }
 
         dbgx(3, "packet size=" COUNTER_SPEC "\t\tnap=" TIMESPEC_FORMAT, len,
@@ -1050,12 +1050,12 @@ static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_ts_delta,
           * Ignore the time supplied by the capture file and send data at
           * a constant rate (packets per second).
           */
-         now_us = TIMSTAMP_TO_MICROSEC(sent_timestamp);
-         if (now_us) {
-             COUNTER next_tx_us;
+         now_ns = TIMESPEC_TO_NANOSEC(sent_timestamp);
+         if (now_ns) {
+             COUNTER next_tx_ns;
              COUNTER pph = ctx->options->speed.speed;
              COUNTER pkts_sent = ctx->stats.pkts_sent;
-             COUNTER tx_us = now_us - start_us;
+             COUNTER tx_ns = now_ns - start_ns;
              /*
               * packets * 1000000 divided by pps = microseconds
               * packets per sec (pps) = packets per hour / (60 * 60)
@@ -1064,17 +1064,17 @@ static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_ts_delta,
               * When active, adjusted calculation may add a bit of jitter.
               */
              if ((pkts_sent < COUNTER_OVERFLOW_RISK))
-                 next_tx_us = (pkts_sent * 1000000) * (60 * 60) / pph;
+                 next_tx_ns = (pkts_sent * 1000000000) * (60 * 60) / pph;
              else
-                 next_tx_us = ((pkts_sent * 1000000) / pph) * (60 * 60);
+                 next_tx_ns = ((pkts_sent * 1000000) / pph * 1000) * (60 * 60);
 
-             if (next_tx_us > tx_us)
-                 NANOSEC_TO_TIMESPEC((next_tx_us - tx_us) * 1000, &ctx->nap);
+             if (next_tx_ns > tx_ns)
+                 NANOSEC_TO_TIMESPEC(next_tx_ns - tx_ns, &ctx->nap);
              else
                  ctx->skip_packets = options->speed.pps_multi;
 
              update_current_timestamp_trace_entry(ctx->stats.bytes_sent +
-                     (COUNTER)len, now_us, tx_us, next_tx_us);
+                     (COUNTER)len, now_ns, tx_ns, next_tx_ns);
          }
 
          dbgx(3, "packet count=" COUNTER_SPEC "\t\tnap=" TIMESPEC_FORMAT,
@@ -1105,7 +1105,7 @@ static void calc_sleep_time(tcpreplay_t *ctx, struct timeval *pkt_ts_delta,
 }
 
 static void tcpr_sleep(tcpreplay_t *ctx, sendpacket_t *sp,
-        struct timespec *nap_this_time, struct timeval *now)
+        struct timespec *nap_this_time, struct timespec *now)
 {
     tcpreplay_opt_t *options = ctx->options;
     bool flush =

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -35,7 +35,7 @@
 #include "tcpreplay_api.h"
 #include "signal_handler.h"
 
-struct timeval suspend_time;
+struct timeval suspend_time; // PB: do we need to modify this part of the code?
 static struct timeval suspend_start;
 static struct timeval suspend_end;
 

--- a/src/sleep.c
+++ b/src/sleep.c
@@ -91,7 +91,5 @@ ioport_sleep(sendpacket_t *sp _U_, const struct timespec *nap _U_,
     if (flush)
         ioctl(sp->handle.fd, NIOCTXSYNC, NULL);   /* flush TX buffer */
 #endif /* HAVE_NETMAP */
-    struct timeval now_ms;
-    gettimeofday(&now_ms, NULL);
-    TIMEVAL_TO_TIMESPEC(&now_ms, now);
+    get_current_time(now);
 }

--- a/src/sleep.c
+++ b/src/sleep.c
@@ -55,32 +55,32 @@ ioport_sleep_init(void)
 
 void 
 ioport_sleep(sendpacket_t *sp _U_, const struct timespec *nap _U_,
-        struct timeval *now _U_,  bool flush _U_)
+        struct timespec *now _U_,  bool flush _U_)
 {
 #if defined HAVE_IOPORT_SLEEP__
-    struct timeval nap_for;
-    u_int32_t usec;
+    struct timespec nap_for;
+    u_int32_t nsec;
     time_t i;
 
-    TIMESPEC_TO_TIMEVAL(&nap_for, nap);
+    TIMESPEC_SET(&nap_for, nap);
 
     /* 
      * process the seconds, we do this in a loop so we don't have to 
      * use slower 64bit integers or worry about integer overflows.
      */
     for (i = 0; i < nap_for.tv_sec; i ++) {
-        usec = SEC_TO_MICROSEC(nap_for.tv_sec);
+        nsec = nap_for.tv_sec * 1000000000;
         while (usec > 0) {
             usec --;
             outb(ioport_sleep_value, 0x80);
         }
     }
 
-    /* process the usec */
-    usec = nap->tv_nsec / 1000;
-    usec --; /* fudge factor for all the above */
-    while (usec > 0) {
-        usec --;
+    /* process the nsec */
+    nsec = nap->tv_nsec;
+    nsec --; /* fudge factor for all the above */
+    while (nsec > 0) {
+        nsec --;
     	outb(ioport_sleep_value, 0x80);
     }
 #else
@@ -91,6 +91,7 @@ ioport_sleep(sendpacket_t *sp _U_, const struct timespec *nap _U_,
     if (flush)
         ioctl(sp->handle.fd, NIOCTXSYNC, NULL);   /* flush TX buffer */
 #endif /* HAVE_NETMAP */
-
-    gettimeofday(now, NULL);
+    struct timeval now_ms;
+    gettimeofday(&now_ms, NULL);
+    TIMEVAL_TO_TIMESPEC(&now_ms, now);
 }

--- a/src/sleep.h
+++ b/src/sleep.h
@@ -57,9 +57,9 @@ static inline void
 nanosleep_sleep(sendpacket_t *sp _U_, const struct timespec *nap,
         struct timespec *now,  bool flush _U_)
 {
-    #ifdef _POSIX_C_SOURCE >= 200112L
         struct timespec sleep_until;
         timeradd_timespec(now, nap, &sleep_until);
+    #if defined _POSIX_C_SOURCE  && _POSIX_C_SOURCE >= 200112L
         clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &sleep_until, NULL);
     #else
         nanosleep(nap, NULL);

--- a/src/tcpbridge.c
+++ b/src/tcpbridge.c
@@ -98,9 +98,9 @@ main(int argc, char *argv[])
     }
 #endif
 
-    if (get_time_of_day(&stats.start_time) < 0) {
+    if (get_current_time(&stats.start_time) < 0) {
         tcpedit_close(&tcpedit);
-        err(-1, "gettimeofday() failed");
+        err(-1, "get_current_time() failed");
     }
 
     /* process packets */

--- a/src/tcpbridge.c
+++ b/src/tcpbridge.c
@@ -98,7 +98,7 @@ main(int argc, char *argv[])
     }
 #endif
 
-    if (gettimeofday(&stats.start_time, NULL) < 0) {
+    if (get_time_of_day(&stats.start_time) < 0) {
         tcpedit_close(&tcpedit);
         err(-1, "gettimeofday() failed");
     }

--- a/src/tcpreplay.c
+++ b/src/tcpreplay.c
@@ -220,7 +220,7 @@ main(int argc, char *argv[])
  */
 static void flow_stats(const tcpreplay_t *ctx)
 {
-    struct timeval diff;
+    struct timespec diff;
     COUNTER diff_us;
     const tcpreplay_stats_t *stats = &ctx->stats;
     const tcpreplay_opt_t *options = ctx->options;
@@ -232,8 +232,8 @@ static void flow_stats(const tcpreplay_t *ctx)
     COUNTER flows_sec = 0;
     u_int32_t flows_sec_100ths = 0;
 
-    timersub(&stats->end_time, &stats->start_time, &diff);
-    diff_us = TIMEVAL_TO_MICROSEC(&diff);
+    timessub(&stats->end_time, &stats->start_time, &diff);
+    diff_us = TIMESPEC_TO_MICROSEC(&diff);
 
     if (!flows_total || !ctx->iteration)
         return;

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -286,7 +286,7 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
     if (HAVE_OPT(FLOW_EXPIRY)) {
         options->flow_expiry = OPT_VALUE_FLOW_EXPIRY;
     }
-    ctx->timefunction.gettime = &get_time_of_day;
+
     if (HAVE_OPT(TIMER)) {
         if (strcmp(OPT_ARG(TIMER), "select") == 0) {
 #ifdef HAVE_SELECT
@@ -307,7 +307,6 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
             options->accurate = accurate_gtod;
         } else if (strcmp(OPT_ARG(TIMER), "nano") == 0) {
             options->accurate = accurate_nanosleep;
-            ctx->timefunction.gettime = &clock_get_time;
             options->loopdelay_ns = OPT_VALUE_LOOPDELAY_NS;
         } else if (strcmp(OPT_ARG(TIMER), "abstime") == 0) {
             tcpreplay_seterr(ctx, "%s", "abstime is deprecated");
@@ -1155,7 +1154,7 @@ tcpreplay_replay(tcpreplay_t *ctx)
             }
             if (ctx->options->loop > 0) {
                 apply_loop_delay(ctx);
-                ctx->timefunction.gettime(&ctx->stats.end_time);
+                get_current_time(&ctx->stats.end_time);
                 if (ctx->options->stats == 0) {
                     packet_stats(&ctx->stats);
                 }
@@ -1175,7 +1174,7 @@ tcpreplay_replay(tcpreplay_t *ctx)
                 return rcode;
             }
             apply_loop_delay(ctx);
-            ctx->timefunction.gettime(&ctx->stats.end_time);
+            get_current_time(&ctx->stats.end_time);
             if (ctx->options->stats == 0 && !ctx->abort)
                 packet_stats(&ctx->stats);
         }

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -96,6 +96,10 @@ typedef struct {
     char *filename;
 } tcpreplay_source_t;
 
+typedef struct time_function {
+    int (*gettime)(struct timespec*);
+} time_function;
+
 /* run-time options */
 typedef struct tcpreplay_opt_s {
     /* input/output */
@@ -105,6 +109,7 @@ typedef struct tcpreplay_opt_s {
     tcpreplay_speed_t speed;
     COUNTER loop;
     u_int32_t loopdelay_ms;
+    u_int32_t loopdelay_ns;
 
     int stats;
     bool use_pkthdr_len;
@@ -189,6 +194,7 @@ typedef struct tcpreplay_s {
     struct timespec nap;
     uint32_t skip_packets;
     bool first_time;
+    struct time_function timefunction;
 
     /* counter stats */
     tcpreplay_stats_t stats;
@@ -270,13 +276,14 @@ int tcpreplay_set_manual_callback(tcpreplay_t *ctx, tcpreplay_manual_callback);
 COUNTER tcpreplay_get_pkts_sent(tcpreplay_t *ctx);
 COUNTER tcpreplay_get_bytes_sent(tcpreplay_t *ctx);
 COUNTER tcpreplay_get_failed(tcpreplay_t *ctx);
-const struct timeval *tcpreplay_get_start_time(tcpreplay_t *ctx);
-const struct timeval *tcpreplay_get_end_time(tcpreplay_t *ctx);
+const struct timespec *tcpreplay_get_start_time(tcpreplay_t *ctx);
+const struct timespec *tcpreplay_get_end_time(tcpreplay_t *ctx);
 
 int tcpreplay_set_verbose(tcpreplay_t *, bool);
 int tcpreplay_set_tcpdump_args(tcpreplay_t *, char *);
 int tcpreplay_set_tcpdump(tcpreplay_t *, tcpdump_t *);
 
+void apply_loop_delay(tcpreplay_t *ctx);
 /*
  * These functions are seen by the outside world, but nobody should ever use them
  * outside of internal tcpreplay API functions

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -96,10 +96,6 @@ typedef struct {
     char *filename;
 } tcpreplay_source_t;
 
-typedef struct time_function {
-    int (*gettime)(struct timespec*);
-} time_function;
-
 /* run-time options */
 typedef struct tcpreplay_opt_s {
     /* input/output */
@@ -194,7 +190,6 @@ typedef struct tcpreplay_s {
     struct timespec nap;
     uint32_t skip_packets;
     bool first_time;
-    struct time_function timefunction;
 
     /* counter stats */
     tcpreplay_stats_t stats;

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -329,6 +329,19 @@ flag = {
 };
 
 flag = {
+    name        = loopdelay-ns;
+    flags-must  = loop, timer;
+    arg-type    = number;
+    arg-range   = "0->";
+    descrip     = "Delay between loops in nanoseconds";
+    arg-default = 0;
+    doc         = <<- EOText
+By default, tcpreplay will use loop delay with microsecond accuracy (loopdelay-ms).
+In order to use loop delay with nanosecond accuracy you need to use nano packet timing mode.
+EOText;
+};
+
+flag = {
     name        = pktlen;
     max         = 1;
     descrip     = "Override the snaplen and use the actual packet len";

--- a/src/timestamp_trace.h
+++ b/src/timestamp_trace.h
@@ -48,9 +48,9 @@ static inline void update_current_timestamp_trace_entry(COUNTER bytes_sent,
         return;
 
     if (!now_us) {
-        struct timeval now;
-        gettimeofday(&now, NULL);
-        now_us = TIMSTAMP_TO_MICROSEC(&now);
+        struct timespec now;
+        get_current_time(now);
+        now_us = TIMESPEC_TO_MICROSEC(&now);
     }
 
     timestamp_trace_entry_array[trace_num].bytes_sent = bytes_sent;

--- a/src/timestamp_trace.h
+++ b/src/timestamp_trace.h
@@ -29,9 +29,9 @@ struct timestamp_trace_entry {
     COUNTER skip_length;
     COUNTER size;
     COUNTER bytes_sent;
-    COUNTER now_us;
-    COUNTER tx_us;
-    COUNTER next_tx_us;
+    COUNTER now_ns;
+    COUNTER tx_ns;
+    COUNTER next_tx_ns;
     COUNTER sent_bits;
     struct timeval timestamp;
 };
@@ -60,7 +60,7 @@ static inline void update_current_timestamp_trace_entry(COUNTER bytes_sent,
 }
 
 static inline void add_timestamp_trace_entry(COUNTER size,
-        struct timeval *timestamp, COUNTER skip_length)
+        struct timespec *timestamp, COUNTER skip_length)
 {
     if (trace_num >= TRACE_MAX_ENTRIES)
         return;
@@ -68,7 +68,7 @@ static inline void add_timestamp_trace_entry(COUNTER size,
     timestamp_trace_entry_array[trace_num].skip_length = skip_length;
     timestamp_trace_entry_array[trace_num].size = size;
     timestamp_trace_entry_array[trace_num].timestamp.tv_sec = timestamp->tv_sec;
-    timestamp_trace_entry_array[trace_num].timestamp.tv_usec = timestamp->tv_usec;
+    timestamp_trace_entry_array[trace_num].timestamp.tv_nsec = timestamp->tv_nsec;
     ++trace_num;
 }
 
@@ -102,7 +102,7 @@ static inline void dump_timestamp_trace_array(const struct timeval *start,
 #else
 static inline void update_current_timestamp_trace_entry(COUNTER UNUSED(bytes_sent), COUNTER UNUSED(now_us),
         COUNTER UNUSED(tx_us), COUNTER UNUSED(next_tx_us)) { }
-static inline void add_timestamp_trace_entry(COUNTER UNUSED(size), struct timeval *UNUSED(timestamp),
+static inline void add_timestamp_trace_entry(COUNTER UNUSED(size), struct timespec *UNUSED(timestamp),
         COUNTER UNUSED(skip_length)) { }
 static inline void dump_timestamp_trace_array(const struct timeval *UNUSED(start),
         const struct timeval *UNUSED(stop), const COUNTER UNUSED(bps)) { }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -196,7 +196,7 @@ tcprewrite: rewrite_portmap rewrite_range_portmap rewrite_endpoint \
 	rewrite_mac_seed_keep rewrite_l7fuzzing rewrite_sequence rewrite_fixcsum \
 	rewrite_fixlen_pad rewrite_fixlen_trunc rewrite_fixlen_del
 
-tcpreplay: replay_basic replay_cache replay_pps replay_rate replay_top \
+tcpreplay: replay_basic replay_nano_timer replay_cache replay_pps replay_rate replay_top \
 	replay_config replay_multi replay_pps_multi replay_precache \
 	replay_stats replay_dualfile replay_maxsleep
 
@@ -342,6 +342,12 @@ replay_basic:
 	$(PRINTF) "%s" "[tcpreplay] Basic test: "
 	$(PRINTF) "%s\n" "*** [tcpreplay] Basic test: " >> test.log
 	$(TCPREPLAY) $(ENABLE_DEBUG) -i $(nic1) -t $(TEST_PCAP) >> test.log 2>&1
+	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+
+replay_nano_timer:
+	$(PRINTF) "%s" "[tcpreplay] Nano timer test: "
+	$(PRINTF) "%s\n" "*** [tcpreplay] Nano timer test: " >> test.log
+	$(TCPREPLAY) $(ENABLE_DEBUG) -i $(nic1) --loop=2 --timer=nano --loopdelay-ns=125000000 -t $(TEST_PCAP) >> test.log 2>&1
 	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
 
 replay_cache:


### PR DESCRIPTION
The aim of this change is to make packet processing possible with nanosecond accuracy and to handle sub sleep times by only nanosleep()'ing. 

- change struct timeval to struct timespec where it was necessary 
- to have backward compatibility with gettimeofday, get_current_time wrapper function is used to retrieve current time (either using gettimeofday or clock_gettime based on the value of _POSIX_C_SOURCE)
- pcap_open_offline is change to pcap_open_offline_with_tstamp_precision in replay_file function, as a result nanosec accuracy is not lost now directly when pcap file is read
- extend nanosleep_sleep function with clock_nanosleep feature using TIMER_ABSTIME in order to avoid relative sleep when using nanosleep()
- extend loop delay feature with nanosec delaying in case --timer=nano is set, earlier only microsec delay was possible