### PR TITLE
AF_XDP socket extension using libxdp api

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -550,6 +550,10 @@ AC_ARG_ENABLE(force-libdnet,
     AS_HELP_STRING([--enable-force-libdnet],[Force using libdnet for sending packets]),
     [ AC_DEFINE([FORCE_INJECT_LIBDNET], [1], [Force using libdnet for sending packets])])
 
+AC_ARG_ENABLE(force-libxdp,
+    AS_HELP_STRING([--enable-force-libxdp],[Force using libxdp for sending packets]),
+    [ AC_DEFINE([FORCE_INJECT_LIBXDP], [1], [Force using libxdp for sending packets])])
+
 AC_ARG_ENABLE(force-inject,
     AS_HELP_STRING([--enable-force-inject],[Force using libpcap's pcap_inject() for sending packets]),
     [ AC_DEFINE([FORCE_INJECT_PCAP_INJECT],[1], [Force using libpcap's pcap_inject() for sending packets])])
@@ -826,7 +830,13 @@ fi
 
 # libpcap can require libnl
 AC_SEARCH_LIBS([nl_handle_alloc], [nl],
-        [AC_MSG_NOTICE([Unable to find nl library - may be needed by libpcap])])
+        [AC_MSG_NOTICE([Unable to find xdp library - may be needed by libpcap])])
+
+AC_CHECK_LIB(bpf, bpf_object__open_file,,
+        [AC_MSG_NOTICE([Unable to find libbpf library ])])
+
+AC_CHECK_LIB(xdp, xsk_umem__delete,,
+        [AC_MSG_NOTICE([Unable to find libxdp library ])])
 
 ##
 ## If not automatically configured,
@@ -1383,6 +1393,37 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     AC_MSG_RESULT(no)
 ])
 
+have_libxdp=no
+dnl Check for LIBXDP AF_XDP socket support
+AC_MSG_CHECKING(for LIBXDP XDP packet sending support)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <stdlib.h>
+#include <xdp/xsk.h>
+#include <sys/socket.h>
+]], [[
+    struct xsk_socket {
+        struct xsk_ring_cons *rx;
+        struct xsk_ring_prod *tx;
+        struct xsk_ctx *ctx;
+        struct xsk_socket_config config;
+        int fd;
+    };
+    struct xsk_socket *xsk;
+	struct xsk_ring_cons *rxr = NULL;
+	struct xsk_ring_prod *txr = NULL;
+	xsk = (struct xsk_socket*)malloc(sizeof(struct xsk_socket));
+    int queue_id = 0;
+    xsk_socket__create(xsk, "lo", queue_id, NULL, rxr, txr, NULL);
+    socket(AF_XDP, SOCK_RAW, 0);
+]])],[
+    AC_DEFINE([HAVE_LIBXDP], [1],
+            [Do we have LIBXDP AF_XDP socket support?])
+    AC_MSG_RESULT(yes)
+    have_libxdp=yes
+],[
+    AC_MSG_RESULT(no)
+])
+
 have_tx_ring=no
 dnl Check for older Linux TX_RING support
 AC_MSG_CHECKING(for TX_RING socket sending support)
@@ -1404,6 +1445,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     AC_MSG_RESULT(no)
 ])
 
+AC_CHECK_HEADERS([bpf/libbpf.h])
+AC_CHECK_HEADERS([bpf/bpf.h])
+AC_CHECK_HEADERS([xdp/libxdp.h])
 
 AC_CHECK_HEADERS([net/bpf.h], [have_bpf=yes], [have_bpf=no])
 if test $have_bpf = yes ; then
@@ -1923,6 +1967,7 @@ pcap_sendpacket:            ${have_pcap_sendpacket} **
 pcap_netmap                 ${have_pcap_netmap}
 Linux/BSD netmap:           ${have_netmap}
 Tuntap device support:      ${have_tuntap}
+LIBXDP for AF_XDP socket:   ${have_libxdp}
 
 * In order of preference; see configure --help to override
 ** Required for tcpbridge

--- a/configure.ac
+++ b/configure.ac
@@ -830,7 +830,7 @@ fi
 
 # libpcap can require libnl
 AC_SEARCH_LIBS([nl_handle_alloc], [nl],
-        [AC_MSG_NOTICE([Unable to find xdp library - may be needed by libpcap])])
+        [AC_MSG_NOTICE([Unable to find nl library - may be needed by libpcap])])
 
 AC_CHECK_LIB(bpf, bpf_object__open_file,,
         [AC_MSG_NOTICE([Unable to find libbpf library ])])

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -1430,6 +1430,7 @@ static sendpacket_t * sendpacket_open_xsk(const char *device, char *errbuf){
     sp->xsk_info = xsk_info;
     sp->umem_info = umem_info;
     sp->frame_size = frame_size;
+    sp->tx_size = nb_of_tx_queue_desc;
     return sp;
 }
 

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -217,6 +217,7 @@ struct sendpacket_s {
     unsigned int pckt_count;
     int frame_size;
     int tx_idx;
+    int tx_size;
 #endif
     bool abort;
 };

--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -49,6 +49,28 @@
 #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
 #endif
 
+#ifdef HAVE_LIBBPF
+#undef HAVE_BPF
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
+
+struct bpf_program {
+char dummy[0];
+};
+
+#endif
+
+#ifdef HAVE_LIBXDP
+#include <xdp/libxdp.h>
+#endif
+
+
+#ifdef HAVE_BPF
+#include <net/bpf.h>
+#define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
+#endif
+
 #if defined INCLUDE_PCAP_BPF_H_FILE && !defined PCAP_DONT_INCLUDE_PCAP_BPF_H
 #include "@INCLUDE_PCAP_BPF_HEADER@"
 #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1 /* don't re-include it in pcap.h */

--- a/src/send_packets.h
+++ b/src/send_packets.h
@@ -28,5 +28,9 @@ void send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx);
 void send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int idx1, pcap_t *pcap2, int idx2);
 void *cache_mode(tcpreplay_t *ctx, char *cachedata, COUNTER packet_num);
 void preload_pcap_file(tcpreplay_t *ctx, int idx);
-
+#ifdef HAVE_LIBXDP
+static inline void prepare_remaining_elements_of_batch(tcpreplay_t *ctx, COUNTER* packetnum, bool* read_next_packet, pcap_t *pcap, int* idx, struct pcap_pkthdr pkthdr, packet_cache_t **prev_packet);
+static inline void prepare_first_element_of_batch(tcpreplay_t *ctx, COUNTER* packetnum, u_char* pktdata, u_int32_t len);
+static inline void fill_umem_with_data_and_set_xdp_desc(sendpacket_t* sp, int tx_idx, COUNTER umem_index, u_char* pktdata, int len);
+#endif
 #endif

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -1168,6 +1168,14 @@ tcpreplay_replay(tcpreplay_t *ctx)
                 if (ctx->options->stats == 0)
                     packet_stats(&ctx->stats);
             }
+
+            #ifdef HAVE_LIBXDP
+            sendpacket_t* sp = ctx->intf1;
+            if(sp->handle_type == SP_TYPE_LIBXDP){
+                sp->xsk_info->tx.cached_prod = 0;
+                sp->xsk_info->tx.cached_cons = sp->tx_size;
+            }
+            #endif
         }
     } else {
         while (!ctx->abort) { /* loop forever unless user aborts */

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -358,7 +358,9 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
         ret = -1;
         goto out;
     }
-
+#ifdef HAVE_LIBXDP
+    ctx->intf1->batch_size = OPT_VALUE_BATCH_SIZE;
+#endif
 #if defined HAVE_NETMAP
     ctx->intf1->netmap_delay = ctx->options->netmap_delay;
 #endif
@@ -428,6 +430,15 @@ tcpreplay_close(tcpreplay_t *ctx)
     assert(ctx);
     assert(ctx->options);
     options = ctx->options;
+
+#ifdef HAVE_LIBXDP
+    if(ctx->intf1->handle_type == SP_TYPE_LIBXDP){
+        free_umem_and_xsk(ctx->intf1);
+        if(ctx->intf2){
+            free_umem_and_xsk(ctx->intf2);
+        }
+    }
+#endif
 
     safe_free(options->intf1_name);
     safe_free(options->intf2_name);
@@ -1356,3 +1367,35 @@ int tcpreplay_get_flow_expiry(tcpreplay_t *ctx)
 
     return ctx->options->flow_expiry;
 }
+
+#ifdef HAVE_LIBXDP
+void delete_xsk_socket(struct xsk_socket *xsk)
+{
+	size_t desc_sz = sizeof(struct xdp_desc);
+	struct xdp_mmap_offsets off;
+	socklen_t optlen;
+	int err;
+
+	if (!xsk)
+		return;
+
+	optlen = sizeof(off);
+	err = getsockopt(xsk->fd, SOL_XDP, XDP_MMAP_OFFSETS, &off, &optlen);
+	if (!err) {
+		if (xsk->rx) {
+			munmap(xsk->rx->ring - off.rx.desc,
+			       off.rx.desc + xsk->config.rx_size * desc_sz);
+		}
+		if (xsk->tx) {
+			munmap(xsk->tx->ring - off.tx.desc,
+			       off.tx.desc + xsk->config.tx_size * desc_sz);
+		}
+	}
+	close(xsk->fd);
+}
+
+void free_umem_and_xsk(sendpacket_t* sp){
+    xsk_umem__delete(sp->xsk_info->umem->umem);
+    delete_xsk_socket(sp->xsk_info->xsk);
+}
+#endif /*HAVE_LIBXDP*/

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -33,7 +33,10 @@
 #ifdef ENABLE_DMALLOC
 #include <dmalloc.h>
 #endif
-
+#ifdef HAVE_LIBXDP
+#include <xdp/xsk.h>
+#include <sys/mman.h>
+#endif
 
 
 #ifdef __cplusplus
@@ -203,7 +206,6 @@ typedef struct tcpreplay_s {
     bool running;
 } tcpreplay_t;
 
-
 /*
  * manual callback definition:
  * ctx              = tcpreplay context
@@ -286,6 +288,10 @@ int tcpreplay_set_tcpdump(tcpreplay_t *, tcpdump_t *);
 void __tcpreplay_seterr(tcpreplay_t *ctx, const char *func, const int line, const char *file, const char *fmt, ...);
 void tcpreplay_setwarn(tcpreplay_t *ctx, const char *fmt, ...);
 
+#ifdef HAVE_LIBXDP
+void delete_xsk_socket(struct xsk_socket *xsk);
+void free_umem_and_xsk(sendpacket_t* sp);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -664,6 +664,15 @@ EOVersion;
 };
 
 flag = {
+    name        = batch-size;
+    arg-type    = number;
+    arg-range   = "1->4096";
+    descrip     = "The maximum number of packets that can be submitted to the Tx ring at once";
+    arg-default = 25;
+    doc         = "";
+};
+
+flag = {
     name        = less-help;
     value       = "h";
     immediate;


### PR DESCRIPTION
The aim of this change is to extend existing packet sending methods with AF_XDP socket using libxdp api.

By using AF_XDP socket, the time needed for packet sending can be decreased substantially.

- all the relevant changes are inside a #ifdef HAVE_LIBXDP guard 
- --batch-size flag is introduced to tcpreplay interface. AF_XDP socket is used typically with batch of packets, the default value is 25 however the user can set it using --batch-size flag, the maximum value is set to 4096 now (see my reasoning at the very end of this comment). 
- Due to batch processing feature tcpr_sleep will be called only in case --batch-size=1, since it doesn't make sense to sleep the relative time between two packets when batch-size is higher than 1. 
- Due to batch processing feature statistics calculated during packet processing are also updated (e.g. number of packets, sum of bytes sent etc.)
- Due to the hierarchical nature of packet sending selection (if ... else if ... include guards in sendpacket.c), --enable-force-libxdp is introduced which can be used at the configuration step to force libxdp packet sending method
- The dependencies of libxdp is checked at the configuration step and the output table of configuration step is also updated with libxdp information 
- The size of UMEM memory is set to nb_of_frames = 4096   * frame_size = 4096   as a result the current implementation assumes that a packet size is never larger than 4096 byte. The new implementation makes it possible to reuse memory, since packet sending is organized into batches. Each of the batches requires a fixed amount of memory, after each of the batches the program checks whether all the packets in the given batch have been sent, if yes, the program can start working on the next batch.
- This implementation is also compatible with the existing tcpreplay interface e.g. -K (to cache packets), -topspeed, --loop flags are still available

Potential improvement suggestions which are not part of this PR:
- Optimize reserved memory. The minimum reserved memory that is required equals to batch_size * frame_size, since user should copy the packet data to an umem frame as a first step of packet sending. As a result it would be an advantage to let users decide how much memory should be reserved by setting batch_size and frame_size on the interface. Batch size is introduced to the interface however it is not connected to umem creation. As mentioned before this implementation reserves 4096 * 4096 bytes, however it should be customized. In case batch-size is set to 25 then only the first 25 * 4096 bytes of memory is used. 