### PR TITLE
Fix UDP checksum recalculation

### DIFF
--- a/src/tcpedit/checksum.c
+++ b/src/tcpedit/checksum.c
@@ -120,7 +120,8 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
         }
         sum += ntohs(IPPROTO_UDP + len);
         sum += do_checksum_math((uint16_t *)udp, len);
-        udp->uh_sum = CHECKSUM_CARRY(sum);
+        sum = CHECKSUM_CARRY(sum);
+        udp->uh_sum = (sum == 0 ? 0xffff : sum);
         break;
 
     case IPPROTO_ICMP:


### PR DESCRIPTION
```
If the computed  checksum  is zero,  it is transmitted  as all ones (the
equivalent  in one's complement  arithmetic).   An all zero  transmitted
checksum  value means that the transmitter  generated  no checksum  (for
debugging or for higher level protocols that don't care).
```
https://www.ietf.org/rfc/rfc768.txt