### PR TITLE
Handle IPv6 fragment extension header

### DIFF
--- a/src/common/get.c
+++ b/src/common/get.c
@@ -599,7 +599,7 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr)
             // next points to l4 data
             dbgx(3, "Go deeper due to fragment extension header 0x%02X", proto);
             exthdr = get_ipv6_next(next, end_ptr);
-            if ((NULL == exthdr) || (exthdr > end_ptr)) {
+            if ((NULL == exthdr) || ((u_char *)exthdr > end_ptr)) {
                 next = NULL;
                 done = true;
                 break;

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -599,7 +599,7 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr)
             // next points to l4 data
             dbgx(3, "Go deeper due to fragment extension header 0x%02X", proto);
             exthdr = get_ipv6_next(next, end_ptr);
-            if ((NULL == exthdr) || ((u_char *)exthdr > end_ptr)) {
+            if ((exthdr == NULL) || ((u_char *)exthdr > end_ptr)) {
                 next = NULL;
                 done = true;
                 break;

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -593,9 +593,25 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr)
             break;
 
         /*
-         * Can't handle.  Unparsable IPv6 fragment/encrypted data
+         * handle (unparsable) IPv6 fragment data
          */
         case TCPR_IPV6_NH_FRAGMENT:
+            // next points to l4 data
+            dbgx(3, "Go deeper due to fragment extension header 0x%02X", proto);
+            exthdr = get_ipv6_next(next, end_ptr);
+            if (exthdr > end_ptr) {
+                next = NULL;
+                done = true;
+                break;
+            }
+            proto = exthdr->ip_nh;
+            next = exthdr;
+            // done = true;
+            break;
+
+        /*
+         * Can't handle.  Unparsable IPv6 encrypted data
+         */
         case TCPR_IPV6_NH_ESP:
             next = NULL;
             done = true;

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -599,7 +599,7 @@ get_layer4_v6(const ipv6_hdr_t *ip6_hdr, const u_char *end_ptr)
             // next points to l4 data
             dbgx(3, "Go deeper due to fragment extension header 0x%02X", proto);
             exthdr = get_ipv6_next(next, end_ptr);
-            if (exthdr > end_ptr) {
+            if ((NULL == exthdr) || (exthdr > end_ptr)) {
                 next = NULL;
                 done = true;
                 break;


### PR DESCRIPTION
**Description:**
Handle IPv6 fragment extension header
only return NULL when reached end of packet (no data)

**Explanation:**
When issue #488 was fixed (pr #496) (version=4.3.0, and carried forward to version=4.4.0), the fix prevented IPv6
fragment extension header handling. The need was to prevent addressing headers beyond packet length (to avoid
heap corruption). However, the fix prevents any further processing of the packet after fragment extension header found.
When the extension header `proto=TCPR_IPV6_NH_FRAGMENT`, we can skip that header (fixed length=32 bits),
process any further extension headers, and return a pointer to packet data.

When issue #611 was fixed (pr #613), the solution was to leave any IPv6 packets with fragment extension header
untouched (and generate `TCPEDIT_SOFT_ERROR`). This change allowed tcprewrite to continue, and these packets
could be skipped (use option `--skip-soft-errors`). This was to avoid abort/failure of the code to run on pcap having
any fragment headers.

Both of these issues are handled by this PR.
- resolves issue #496 by avoiding addressing headers beyond packet length
- resolves issue #611 by enabling tcprewrite to continue after encountering fragment packets.

**Reference:**
- see: [tcprewrite fails to change addresses for ipv6 fragment packets](https://github.com/appneta/tcpreplay/issues/831)
- see: [tcprewrite fails on IPv6 fragment extension header](https://github.com/appneta/tcpreplay/issues/611)
- see: [Heap overflow in csum_replace4](https://github.com/appneta/tcpreplay/issues/488)
