### PR TITLE
add check for empty cidr

### DIFF
--- a/src/common/cidr.c
+++ b/src/common/cidr.c
@@ -249,6 +249,10 @@ parse_cidr(tcpr_cidr_t **cidrdata, char *cidrin, char *delim)
     char *network;
     char *token = NULL;
 
+    if (cidrin == NULL) {
+        errx(-1, "%s", "Unable to parse empty CIDR");
+    }
+
     mask_cidr6(&cidrin, delim);
 
     /* first iteration of input using strtok */


### PR DESCRIPTION
This causes tcprewrite to exit with an error instead of crashing.

Fixes: #824