### PR TITLE
configure.ac: do not run conftest in case of cross compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -928,7 +928,7 @@ cat >conftest.c <<EOF
 EOF
 ${CC-cc} -o conftest $CFLAGS $CPPFLAGS $LPCAPLIB \
     conftest.c $LIBS >/dev/null 2>&1
-if test -x conftest ; then
+if test -x conftest -a "$cross_compiling" != "yes"; then
     full_libpcap_version=$(LD_LIBRARY_PATH="$LPCAP_LD_LIBRARY_PATH" ./conftest)
     libpcap_version=$(echo "$full_libpcap_version" | ${CUT} -d' ' -f3)
     pcap_version_ok=yes
@@ -1709,7 +1709,7 @@ case "$host_os" in
 EOF
         ${CC-cc} -o conftest $CFLAGS $CPPFLAGS $LDFLAGS \
             conftest.c $LIBS >/dev/null 2>&1
-        if test ! -x conftest ; then
+        if test ! -x conftest -o "$cross_compiling" = "yes" ; then
             dnl failed to compile for some reason
             unaligned_cv_fail=yes
         else


### PR DESCRIPTION
It'll give us nothing but error like below:

  ./conftest: cannot execute binary file: Exec format error
  ...
  ./configure: line 23950: test: -eq: unary operator expected

The version check only has effect on Apple systems. We'd better avoid error like above when cross compilation.

Also, in case of cross compilation, instead of having the above Exec format error and resulting in unaligned_cv_fail to yes, set it directly to yes.