### PR TITLE
dlt_jnpr_ether_cleanup: check config before cleanup

### DIFF
--- a/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.c
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.c
@@ -164,8 +164,9 @@ dlt_jnpr_ether_cleanup(tcpeditdlt_t *ctx)
         jnpr_ether_config_t *config;
 
         config = (jnpr_ether_config_t *)ctx->encoder->config;
-        if (config->subctx != NULL)
+        if (config != NULL && config->subctx != NULL) {
             tcpedit_dlt_cleanup(config->subctx);
+        }
         safe_free(plugin->config);
         plugin->config = NULL;
         plugin->config_size = 0;


### PR DESCRIPTION
Fix #812 
The `ctx->encoder->config` is somehow already cleaned up in `dlt_en10mb_cleanup()` and set as `NULL`, so I add a check in `dlt_jnpr_ether_cleanup()`.

```
(gdb) p & ctx->encoder->config
$1 = (void **) 0x55555559f140
(gdb) watch *0x55555559f140
Hardware watchpoint 2: *0x55555559f140
(gdb) r
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Starting program: /home/ubuntu178/afgen/tcpreplay/4.4.4/bin_normal/bin/tcprewrite -o /dev/null --dlt=enet --enet-dmac=00:12:13:14:15:16,00:22:33:44:55:66 --enet-smac=00:12:13:14:15:16,00:22:33:44:55:66 -i issue-812
Warning: issue-812 was captured using a snaplen of 50 bytes.  This may mean you have truncated packets.

Hardware watchpoint 2: *0x55555559f140

Old value = <unreadable>
New value = 0
__memset_avx2_unaligned_erms () at ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:203
203     ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S: No such file or directory.
(gdb) c
Continuing.

Hardware watchpoint 2: *0x55555559f140

Old value = 0
New value = 1431959872
dlt_en10mb_init (ctx=0x55555559f040) at ../../../code/src/tcpedit/plugins/dlt_en10mb/en10mb.c:114
warning: Source file is more recent than executable.
114         config = (en10mb_config_t *)plugin->config;
(gdb) c
Continuing.

Hardware watchpoint 2: *0x55555559f140

Old value = 1431959872
New value = 0
dlt_en10mb_cleanup (ctx=0x55555559f040) at ../../../code/src/tcpedit/plugins/dlt_en10mb/en10mb.c:151    <- clean up here first
151             plugin->config_size = 0; 
```