### PR TITLE
Fix recursive tcpedit cleanup

### DIFF
--- a/src/tcpedit/plugins/dlt_plugins.c
+++ b/src/tcpedit/plugins/dlt_plugins.c
@@ -94,6 +94,12 @@ const char *tcpeditdlt_bit_info[] = {"Missing required Layer 3 protocol.",
  * Public functions
  ********************************************************************/
 
+/*
+ * Ensure init/cleanup are called only once
+ * Assume a single tcpedit struct and return the previously allocated context.
+ */
+static int tcpedit_dlt_is_initialized = 0;
+
 /**
  * initialize our plugin library.  Pass the DLT of the source pcap handle.
  * Actions:
@@ -114,6 +120,9 @@ tcpedit_dlt_init(tcpedit_t *tcpedit, const int srcdlt)
 
     assert(tcpedit);
     assert(srcdlt >= 0);
+
+    if (tcpedit_dlt_is_initialized++ > 0)
+        return tcpedit->dlt_ctx;
 
     ctx = (tcpeditdlt_t *)safe_malloc(sizeof(tcpeditdlt_t));
 
@@ -442,6 +451,9 @@ void
 tcpedit_dlt_cleanup(tcpeditdlt_t *ctx)
 {
     tcpeditdlt_plugin_t *plugin;
+
+    if (--tcpedit_dlt_is_initialized <= 0)
+        return;
 
     assert(ctx);
 


### PR DESCRIPTION
Assume a single tcpedit struct and return the previously allocated context if called twice.

This fixes an issue with the Juniper Encapsulated Ethernet DLT plugin which has an exception in the way the plugins works with regard to the extra buffer in question: tcpreplay works with the assumption that there only ever is a single link layer plugin which is mostly true except here: Juniper has a special call to tcpedit_dlt_copy_decoder_state() which causes the ctx and subctx to share a reference to the decoded_extra buffer, and a double free.

Fixes: #813 #850