### PR TITLE
autotools - AC_HELP_STRING is obsolete in 2.70

### DIFF
--- a/libopts/m4/libopts.m4
+++ b/libopts/m4/libopts.m4
@@ -478,7 +478,7 @@ AC_DEFUN([LIBOPTS_CHECK_COMMON],[
   m4_pushdef([AO_Libopts_Dir],
 	    [ifelse($1, , [libopts], [$1])])
   AC_ARG_ENABLE([local-libopts],
-    AC_HELP_STRING([--enable-local-libopts],
+    AS_HELP_STRING([--enable-local-libopts],
        [Use the supplied libopts tearoff code]),[
     if test x$enableval = xyes ; then
        AC_MSG_NOTICE([Using supplied libopts tearoff])
@@ -488,14 +488,14 @@ AC_DEFUN([LIBOPTS_CHECK_COMMON],[
     fi])
 
   AC_ARG_ENABLE([libopts-install],
-    AC_HELP_STRING([--enable-libopts-install],
+    AS_HELP_STRING([--enable-libopts-install],
        [Install libopts with client installation]))
   AM_CONDITIONAL([INSTALL_LIBOPTS],[test "X${enable_libopts_install}" = Xyes])
 
   [if test -z "${NEED_LIBOPTS_DIR}" ; then]
      AC_MSG_CHECKING([whether autoopts-config can be found])
      AC_ARG_WITH([autoopts-config],
-        AC_HELP_STRING([--with-autoopts-config],
+        AS_HELP_STRING([--with-autoopts-config],
              [specify the config-info script]),
         [lo_cv_with_autoopts_config=${with_autoopts_config}],
         AC_CACHE_CHECK([whether autoopts-config is specified],


### PR DESCRIPTION
Autoconf flagged AC_HELP_STRING as obsolete [1]
Replace with AS_HELP_STRING [2] which was introduced in 2.69 which is the current PREREQ.

[1] https://www.gnu.org/software/autoconf//manual/autoconf-2.69/html_node/Obsolete-Macros.html#Obsolete-Macros
[2] https://www.gnu.org/software/autoconf//manual/autoconf-2.69/html_node/Pretty-Help-Strings.html#AS%5fHELP%5fSTRING