### PR TITLE
Bug #844 PR# 846: fix regression on nanosecond timestamp

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -28,5 +28,5 @@ jobs:
       - name: List files in the repository
         run: ls ${{ github.workspace }}
       - name: tests
-        run: sudo make test || cat test/test.log
+        run: sudo make test
       - run: echo "This test's status is ${{ job.status }}."

--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -359,11 +359,17 @@ typedef u_int8_t uint8_t typedef u_int16_t uint16_t typedef u_int32_t uint32_t
         (a)->tv_nsec = (b)->tv_nsec;                                                                                   \
     } while (0)
 
+#define TIMEVAL_TO_TIMESPEC_SET(a, b)       \
+    do {                                    \
+        (a)->tv_sec = (b)->tv_sec;          \
+        (a)->tv_nsec = (b)->tv_usec * 1000; \
+    } while(0)
+
 /* libpcap puts nanosec values in tv_usec when pcap file is read with nanosec precision*/
 #define TIMEVAL_AS_TIMESPEC_SET(a, b)       \
     do {                                    \
         (a)->tv_sec = (b)->tv_sec;          \
-        (a)->tv_nsec = (b)->tv_usec * 1000; \
+        (a)->tv_nsec = (b)->tv_usec;        \
     } while(0)
 
 /* 

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -388,7 +388,13 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
     while (!ctx->abort && read_next_packet &&
            (pktdata = get_next_packet(options, pcap, &pkthdr, idx, prev_packet)) != NULL) {
         struct timespec pkthdr_ts;
-        TIMEVAL_AS_TIMESPEC_SET(&pkthdr_ts, &pkthdr.ts); // libpcap puts nanosec values in tv_usec
+#ifdef HAVE_PCAP_OPEN_OFFLINE_WITH_TSTAMP_PRECISION
+        // libpcap puts nanosecond values in tv_usec
+        TIMEVAL_AS_TIMESPEC_SET(&pkthdr_ts, &pkthdr.ts);
+#else
+        // libpcap puts microsecond values in tv_usec
+        TIMEVAL_TO_TIMESPEC_SET(&pkthdr_ts, &pkthdr.ts);
+#endif
         now_is_now = false;
         packetnum++;
 #if defined TCPREPLAY || defined TCPREPLAY_EDIT


### PR DESCRIPTION
libpcap nanosec values are reported in tv_usec.

Not so for legacy libpcap which has usec values in tv_usec.