### PR TITLE
Bug #792 avoid assertion and other fixes

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -16,7 +16,9 @@
     - configure.ac: unify search dirs for pcap and add lib32 (#819)
     - CVE-2023-4256 double free in tcprewrite DLT_JUNIPER_ETHER (#813 #851)
     - dlt_jnpr_ether_cleanup: check config before cleanup (#812 #851)
-    - nanosecond timestamps (#796)
+    - SEGV on invalid Juniper Ethernet header length (#811)
+    - nanosecond timestamps support (#796)
+    - Linux cooked packet fatal error (#792)
     - low PPS values run at full speed after several days (#779)
     - create DLT_LINUX_SLL2 plugin (#727)
 


### PR DESCRIPTION
SLL (Linux cooked packets v1) caused a crash due to an overly aggressive assert.

While here, fixed an issue where resultant packets were corrupt (wrong size, incorrect protocol)