### PR TITLE
Bug #844 tap: ignore TUNSETIFF EBUSY errors

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -10,10 +10,13 @@
     - add check for IPv6 extension header length (#827 #842)
     - GitHub template for pull requests (#839)
     - handle IPv6 fragment extension header (#832 #837)
+    - Linux tap interfaces fail intermittently (#828)
     - Infinite loop in tcprewrite at get.c (#827 #842)
+    - SLL incorrect size and protocal when converted to Ethernet (#826)
     - CVE-2023-43279 add check for empty CIDR (#824 #843)
     - AF_XDF socket extension (#822 #823)
     - configure.ac: unify search dirs for pcap and add lib32 (#819)
+    - tcpreplay-edit recomputes IPv4 checksums unnecessarily (#815 #846)
     - CVE-2023-4256 double free in tcprewrite DLT_JUNIPER_ETHER (#813 #851)
     - dlt_jnpr_ether_cleanup: check config before cleanup (#812 #851)
     - SEGV on invalid Juniper Ethernet header length (#811)
@@ -25,7 +28,8 @@
 06/04/2023 Version 4.4.4
     - overflow check fix for parse_mpls (#795)
     - tcpreplay-edit: prevent L2 flooding of ipv6 unicast packets (#793)
-    - CVE-2023-27784 CVE-2023-27785 CVE-2023-27786 CVE-2023-27787 CVE-2023-27788 CVE-2023-27789 bugs caused by strtok_r (#782 #784 #785 #786 #787 #788)
+    - CVE-2023-27784 CVE-2023-27785 CVE-2023-27786 CVE-2023-27787 CVE-2023-27788 CVE-2023-27789
+      bugs caused by strtok_r (#782 #784 #785 #786 #787 #788)
     - CVE-2023-27783 reachable assert in tcpedit_dlt_cleanup (#780)
     - add CI and C/C++ Linter and CodeQL (#773)
     - reachable assert in fast_edit_packet (#772)


### PR DESCRIPTION
This ioctl error suggests that the tap interface has already been set.

Backed out #411 and #651 as they only partially address the issue and introduced new bugs.