### PR TITLE
feature: fix/recalculate header checksum for ipv6-frag(mentation) pac…

### DIFF
--- a/src/tcpedit/checksum.c
+++ b/src/tcpedit/checksum.c
@@ -78,6 +78,7 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
 
     switch (proto) {
     case IPPROTO_TCP:
+    case IPPROTO_TCP_V6FRAG:
         if (len < (int)sizeof(tcp_hdr_t)) {
             tcpedit_setwarn(tcpedit, "%s", "Unable to checksum TCP with insufficient L4 data");
             return TCPEDIT_WARN;
@@ -98,6 +99,7 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
         } else {
             sum = do_checksum_math((uint16_t *)&ipv4->ip_src, 8);
         }
+
         sum += ntohs(IPPROTO_TCP + len);
         sum += do_checksum_math((uint16_t *)tcp, len);
         tcp->th_sum = CHECKSUM_CARRY(sum);

--- a/src/tcpedit/plugins/dlt_en10mb/en10mb.c
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb.c
@@ -185,6 +185,7 @@ dlt_en10mb_parse_subsmac(tcpeditdlt_t *ctx, en10mb_config_t *config, const char 
     size_t input_len = strlen(input);
     size_t possible_entries_number = (input_len / (SUBSMAC_ENTRY_LEN + 1)) + 1;
     size_t entry;
+    unsigned int entry;
 
     en10mb_sub_entry_t *entries = safe_malloc(possible_entries_number * sizeof(en10mb_sub_entry_t));
 

--- a/src/tcpedit/tcpedit.c
+++ b/src/tcpedit/tcpedit.c
@@ -320,11 +320,13 @@ again:
     /* do we need to fix checksums? -- must always do this last! */
     if (tcpedit->fixhdrlen) {
         /* ensure IP header length is correct */
+        /* when packet change? then needtorecalc checksum */
         int changed = 0;
         if (ip_hdr != NULL) {
+            /* did the packet change? if so, checksum */
             changed = fix_ipv4_length(*pkthdr, ip_hdr, l2len);
         } else if (ip6_hdr != NULL) {
-            changed = fix_ipv6_length(*pkthdr, ip6_hdr, l2len);
+            changed |= fix_ipv6_length(*pkthdr, ip6_hdr, l2len);
         }
         /* did the packet change? then needtorecalc checksum */
         if (changed > 0) {

--- a/src/tcpr.h
+++ b/src/tcpr.h
@@ -652,6 +652,9 @@ struct tcpr_gre_hdr {
 #ifndef IPPROTO_GRE
 #define IPPROTO_GRE 47
 #endif
+#ifndef IPPROTO_TCP_V6FRAG
+#define IPPROTO_TCP_V6FRAG 0x2c
+#endif
 
 /*
  * Source Route Entries (SRE)


### PR DESCRIPTION
**Overview**

The tcpreplay program `tcprewrite` does not support IPv6 FRAG(mented) header checksum recalculation. The protocol `0x2c` is not included in the switch statement, and thus a `TCPEDIT_WARN` is generated and the header checksum is not recalculated.

The option `--fixcsum` does not work against the original `redacted-v6.pcap` pcap (and others) due to how the protocol value supplied to `do_checksum()` is handled. The protocol is IPV6-FRAG(mented). There is a switch statement where the protocol value `(== 0x2c)` is not one of the recognized values. The `tcprewrite` code explicitly returns indication (`TCPEDIT_WARN`) that certain packets (both TCP and HTTP) do not have their checksum recalculated.
Since the checksum needs to be correctly calculated, this incorrect checksum causes the pcap to fail testing.

**Expected Behavior**

An IPV6 FRAGmented packet should have correct checksum calculated when packet is rewritten.

**Description of desired solution**

Since tcpreplay does not support IPv6-FRAG(ment) header checksum recalculation. The protocol `0x2c` is not included in the switch statement, and thus a `TCPEDIT_WARN` is generated and the header checksum is not recalculated.

What is desired is that the protocol `0x2c` be recognized and the correct header checksum be calculated and replaced, rather than the warning `TCPEDIT_WARN` generated, and the generated pcap file not be corrupted with an invalid checksum.

Add the protocol `0x2c` to the constants `src/tcpr.h`

```
#ifndef IPPROTO_TCP_V6FRAG
#define IPPROTO_TCP_V6FRAG 0x2c
#endif
#ifndef IPPROTO_HTTP_V6FRAG
#define IPPROTO_HTTP_V6FRAG 0x2c
#endif
```

And the protocol added to the switch statement in `src/tcpedit/checksum.c`

```
        case IPPROTO_TCP:
        case IPPROTO_TCP_V6FRAG:
        // case IPPROTO_HTTP_V6FRAG:
protoname = "IPPROTO_TCP";
            if (len < (int)sizeof(tcp_hdr_t)) {
                tcpedit_setwarn(tcpedit, "%s", "Unable to checksum TCP with insufficient L4 data");
                return TCPEDIT_WARN;
            }

            tcp = (tcp_hdr_t *)(data + ip_hl);
#ifdef STUPID_SOLARIS_CHECKSUM_BUG
            tcp->th_sum = tcp->th_off << 2;
            return (TCPEDIT_OK);
#endif
            tcp->th_sum = 0;

            /* Note, we do both src & dst IP's at the same time, that's why the
             * length is 2x a single IP
             */
            if (ipv6 != NULL) {
                sum = do_checksum_math((uint16_t *)&ipv6->ip_src, 32);
            } else {
                sum = do_checksum_math((uint16_t *)&ipv4->ip_src, 8);
            }
            sum += ntohs(IPPROTO_TCP + len);
            sum += do_checksum_math((uint16_t *)tcp, len);
            tcp->th_sum = CHECKSUM_CARRY(sum);
            break;
```

see: <redacted>

**To Reproduce**
Steps to reproduce the behavior:
1. have pcap with `protocol == 0x2c` (`IPV6 FRAG`(mented))
2. run `tcpprep` on pcap
3. run `tcprewrite` on pcap (change src/dest ip address to precipitate checksum recalculation)
4. examine rewritten pcap in wireshark, observe that checksum is incorrect

**Describe alternatives you've considered**

The header checksum is not correctly rewritten by tcpreplay in this situation.
Either:

a) do nothing (unacceptable),
b) rewrite checksum using some external program,
c) recalculate header checksum for these packets (this solution)
d) ideas? suggestions? how else can we recalculate header checksums?

**Additional context**
The TCP case can be fixed with a patch to allow protocol value `0x2c` to be handled the same way as `IPPROTO_TCP`, but this patch does not work for (HTTP protocol). *Further investigation is needed.*
**Screenshots**
If applicable, add screenshots to help explain your problem.

**System (please complete the following information):**
 - OS: Ubuntu Linux
 - OS version
 - Tcpreplay Version [e.g. 4.4.4]

**Additional context**
Add any other context about the problem here.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
