### PR TITLE
configure.ac: Fixup the libpcap search loops.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -710,13 +710,9 @@ AC_ARG_WITH(libpcap,
                         LPCAP_LD_LIBRARY_PATH="$(dirname ${sharefile})"
                         LPCAPLIB="-L$LPCAP_LD_LIBRARY_PATH -lpcap"
                         foundpcap=$testdir
-                        break
+                        break 2
                     fi
                 done
-
-                if ! test $foundpcap = no; then
-                    break
-                fi
             done
         else
             dnl
@@ -728,10 +724,9 @@ AC_ARG_WITH(libpcap,
                     if test -n "${staticfile}"; then
                         LPCAPLIB="${staticfile}"
                         foundpcap=${testdir}
-                        break
+                        break 2
                     fi
                 done
-
             done
         fi
 


### PR DESCRIPTION
- [X] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions. — _does not exist_
- [ ] The code follows the code style guide detailed in the wiki. — _does not exist_
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.