### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -27,6 +27,7 @@
 #ifdef __NetBSD__
 #include <net/if_ether.h>
 #elif ! defined(__HAIKU__)
+#include <net/if.h>
 #include <netinet/if_ether.h>
 #endif
 


### PR DESCRIPTION
```
In file included from ../../src/common/sendpacket.h:30: 
/usr/include/netinet/if_ether.h:154:17: fatal error: field has incomplete type 'struct arphdr'
        struct   arphdr ea_hdr;                 /* fixed-size header */
                        ^
/usr/include/netinet/if_ether.h:154:10: note: forward declaration of 'struct arphdr'
        struct   arphdr ea_hdr;                 /* fixed-size header */
                 ^
1 error generated.
```

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.