### PR TITLE
do not exit in get_l2len_protocol() if l2len==0

### DIFF
--- a/src/common/get.c
+++ b/src/common/get.c
@@ -273,8 +273,10 @@ get_l2len_protocol(const u_char *pktdata,
     assert(l2offset);
     assert(vlan_offset);
 
-    if (!pktdata || !datalen)
-        errx(-1, "get_l2len_protocol: invalid L2 parameters: pktdata=0x%p len=%d", pktdata, datalen);
+    if (!pktdata || !datalen) {
+        err_no_exitx("get_l2len_protocol: invalid L2 parameters: pktdata=0x%p len=%d", pktdata, datalen);
+        return -1;
+    }
 
     *protocol = 0;
     *l2len = 0;


### PR DESCRIPTION
When fussing with tcpreplay-edit `--fuzz-seed` option , it's possible to simulate the drop of a packet which causes get_l2len_protocol to see a packet with a l2_len=0.

This does not remove the asserts because I think that those are useful in most cases where debugging the core of tcpreplay. This is just an edge case, and we won't have the asserts when using the released binary anyway.

Instead of aborting the whole process, let's just skip the packet.
You'll still have lots of warnings but I believe this is OK in such a scenario.