### PR TITLE
Sleep based on fixed point in time to avoid time drift when replaying packets

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -34,6 +34,8 @@ typedef struct {
     struct timespec end_time;
     struct timespec pkt_ts_delta;
     struct timespec last_print;
+    struct timespec first_packet_time;
+    struct timespec first_packet_wall_time;
     COUNTER flow_non_flow_packets;
     COUNTER flows;
     COUNTER flows_unique;


### PR DESCRIPTION
Fixes #724 

This is missing the respective changes in send_dual_packets and probably a test. Maybe @fklassen could fill in the last pieces?

---

Create packets (1 second apart):

```
randpkt -t udp -c 100001 test100000.pcap
```

Command:
```
sudo tcpreplay -i lo -K --multiplier=20000 /home/xxx/test100000.pcap
```

Without fixes (5.26 seconds):

```
Actual: 100001 packets (251812433 bytes) sent in 5.26 seconds
Rated: 47836517.5 Bps, 382.69 Mbps, 18997.07 pps
Flows: 94438 flows, 17940.27 fps, 99807 flow packets, 0 non-flow
Statistics for network device: lo
    Successful packets:    100001
    Failed packets:      0
    Truncated packets:     0
    Retried packets (ENOBUFS): 0
    Retried packets (EAGAIN): 0
```

With fixes (5.00 seconds):

```
Actual: 100001 packets (251812433 bytes) sent in 5.00 seconds
Rated: 50362486.6 Bps, 402.89 Mbps, 20000.20 pps
Flows: 94438 flows, 18887.60 fps, 99807 unique flow packets, 0 unique non-flow packets
Statistics for network device: lo
    Successful packets:    100001
    Failed packets:      0
    Truncated packets:     0
    Retried packets (ENOBUFS): 0
    Retried packets (EAGAIN): 0
```