### PR TITLE
fix compile, linker error for txring

### DIFF
--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -197,7 +197,7 @@ txring_init(int fd, unsigned int mtu)
     txring_t *txp;
 
     /* allocate memory for structure and fill it with different stuff*/
-    *txp = (txring_t *)safe_malloc(sizeof(txring_t));
+    txp = (txring_t *)safe_malloc(sizeof(txring_t));
     txp->treq = (struct tpacket_req *)safe_malloc(sizeof(struct tpacket_req));
 
     txring_mkreq(txp->treq, mtu);

--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -31,6 +31,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "defines.h"
+#include "config.h"
+
 #ifdef HAVE_TX_RING
 
 #include "txring.h"

--- a/src/common/txring.h
+++ b/src/common/txring.h
@@ -33,10 +33,10 @@
 
 #pragma once
 
-#ifdef HAVE_TX_RING
-
 #include "defines.h"
 #include "config.h"
+
+#ifdef HAVE_TX_RING
 
 #if __GLIBC__ >= 2 && __GLIBC_MINOR >= 1
 #include <net/ethernet.h> /* the L2 protocols */


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Change `txring.c`, `txring.h`
- Ensure txring compiles correctly to avoid linker errors.
  - The result of "nm -u txring.o" shows no symbols exist.
  - The config.h has HAVE_TX_RING defined but txring.c is not aware of it.
      txring.c and txring.h include config.h at the beginning.

- Modify the assignment target for the `safe_malloc` return value from `*txp` to `txp`.

- This resulted in a successful build in my build environment.

