### PR TITLE
Bug #933 ci: hexdump failing pcap on test failure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] The code is mine or it's from somewhere with an MIT-compatible license.
 - [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
 - [ ] The code is stable and I have tested it myself, to the best of my abilities.
-- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
+- [ ] The code passes `sudo make test`
 
 ## Changes:
 

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -11,22 +11,24 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - name: List interfaces
-        run: ip a
       - name: Install prereqs
-        run: sudo apt -y install autogen libpcap-dev
+        run: sudo apt -y install autogen libpcap-dev automake autoconf libtool libxdp-dev
+      - name: Create a build directory
+        run: mkdir -p build
       - name: Create configure script
-        run: ./autogen.sh
+        run: pushd build; ../autogen.sh; popd
       - name: configure
-        run: ./configure --with-testnic=eth0 --disable-local-libopts --enable-asan
+        run: pushd build; ../configure --disable-local-libopts --enable-debug --enable-test-hexdump; popd
       - name: make
-        run: make
+        run: pushd build; make; popd
       - name: make dist
-        run: make dist
+        run: pushd build; make dist; popd
       - name: make dist-xz
-        run: make dist-xz
+        run: pushd build; make dist-xz; popd
       - name: List files in the repository
         run: ls ${{ github.workspace }}
+      - name: List interfaces via tcpreplay
+        run: pushd build; sudo src/tcpreplay --listnics; popd
       - name: tests
-        run: sudo make test || (cat test/test.log; false)
+        run: pushd build; sudo make test || (cat test/test.log >&2; false); popd
       - run: echo "This test's status is ${{ job.status }}."

--- a/configure.ac
+++ b/configure.ac
@@ -1934,6 +1934,15 @@ case $host in
     ;;
 esac])
 
+AC_ARG_ENABLE([test_hexdump],
+    AS_HELP_STRING([--enable-test-hexdump],[Enable hexdump pcap on test failure]))
+if test "x$enable_test_hexdump" = "xyes"; then
+        test_hexdump=yes
+else
+        test_hexdump=no
+fi
+AC_SUBST(test_hexdump)
+
 dnl There's a bug in OS X which causes pcap_findalldevs() to make the wifi NIC to disassociate
 dnl so under OSX we disable the interface list feature
 disable_pcap_findalldevs=no

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,5 @@
 06/30/2025 Version 4.5.2 - beta1
+    - GitHub Actions CI failure (#933)
     - support for IPv6 fragment checksums (#897)
 
 07/12/2024 Version 4.5.1

--- a/src/tcpedit/portmap.c
+++ b/src/tcpedit/portmap.c
@@ -249,9 +249,10 @@ map_port(tcpedit_portmap_t *portmap_data, long port)
 
     /* step through the nodes, resetting newport if a match is found */
     while (portmap_ptr != NULL) {
-        if (portmap_ptr->from == port)
+        if (portmap_ptr->from == port) {
             newport = portmap_ptr->to;
-
+            break;
+        }
         portmap_ptr = portmap_ptr->next;
     }
 

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -371,9 +371,13 @@ flag = {
     doc         = "";
     flag-code   = <<- EOFlag
 
-    interface_list_t *list = get_interface_list();
+    interface_list_t *tmp, *list = get_interface_list();
     list_interfaces(list);
-    free(list);
+    while (list != NULL) {
+        tmp = list->next;
+        safe_free(list);
+        list = tmp;
+    }
     exit(0);
 
 EOFlag;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,6 +6,7 @@ TARGET = @target@
 BUILD = @build@
 nic1 = @nic1@
 nic2 = @nic2@
+hexdump = @test_hexdump@
 
 ENABLE_DEBUG = @debug_run_time_flag@
 TCPPREP=../src/tcpprep --no-arg-comment
@@ -61,9 +62,11 @@ check:
 if WORDS_BIGENDIAN
 STANDARD_REWRITE = standard_bigendian
 REWRITE_WARN = "big"
+VARIANT=
 else
 STANDARD_REWRITE = standard_littleendian
 REWRITE_WARN = "little"
+VARIANT="2"
 endif
 
 standard: standard_prep $(STANDARD_REWRITE)
@@ -223,77 +226,111 @@ prep_config:
 	$(PRINTF) "%s" "[tcpprep] Config mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Config mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) --load-opts=config -o test.$@1  >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 auto_router:
 	$(PRINTF) "%s" "[tcpprep] Auto/Router mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Auto/Router mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -a router  >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 auto_bridge:
 	$(PRINTF) "%s" "[tcpprep] Auto/Bridge mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Auto/Bridge mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -a bridge  >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 auto_client:
 	$(PRINTF) "%s" "[tcpprep] Auto/Client mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Auto/Client mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -a client  >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 auto_server:
 	$(PRINTF) "%s" "[tcpprep] Auto/Server mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Auto/Server mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -a server >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 auto_first:
 	$(PRINTF) "%s" "[tcpprep] Auto/First mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Auto/First mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -a first >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 regex:
 	$(PRINTF) "%s" "[tcpprep] Regex mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Regex mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -r '96.17.211.*' >> test.log 2>&1
-	diff  $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 cidr:
 	$(PRINTF) "%s" "[tcpprep] CIDR mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] CIDR mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 port:
 	$(PRINTF) "%s" "[tcpprep] Port mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Port mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -p >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 mac:
 	$(PRINTF) "%s" "[tcpprep] MAC mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] MAC mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -e 00:1f:f3:3c:e1:13 >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 comment:
 	$(PRINTF) "%s" "[tcpprep] Comment mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Comment mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -C "This is a comment" -p >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 print_comment:
 	$(PRINTF) "%s" "[tcpprep] Print comment mode test: "
@@ -312,50 +349,71 @@ regex_reverse:
 	$(PRINTF) "%s" "[tcpprep] Regex reverse mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] Regex reverse mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -r '96.17.211.*' --reverse >> test.log 2>&1
-	diff  $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 cidr_reverse:
 	$(PRINTF) "%s" "[tcpprep] CIDR reverse mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] CIDR reverse mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --reverse >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 mac_reverse:
 	$(PRINTF) "%s" "[tcpprep] MAC reverse mode test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] MAC reverse mode test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -e 00:1f:f3:3c:e1:13 --reverse >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 exclude_packets:
 	$(PRINTF) "%s" "[tcpprep] exclude packets test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] exclude packets test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --exclude 'P:61-65,88-91' >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 include_packets:
 	$(PRINTF) "%s" "[tcpprep] include packets test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] include packets test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --include 'P:61-65,88-91' >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 include_source:
 	$(PRINTF) "%s" "[tcpprep] include source test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] include source test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --include 'S:96.0.0.0/8' >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 include_dest:
 	$(PRINTF) "%s" "[tcpprep] include destination test: "
 	$(PRINTF) "%s\n" "*** [tcpprep] include destination test: " >> test.log
 	$(TCPPREP) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -c '96.17.211.0/24' --include 'D:96.0.0.0/8' >> test.log 2>&1
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 replay_basic:
 	$(PRINTF) "%s" "[tcpreplay] Basic test: "
@@ -375,6 +433,7 @@ replay_cache:
 	$(TCPREPLAY) $(ENABLE_DEBUG) -c $(srcdir)/test.cidr -i $(nic1) -I $(nic2) -t $(TEST_PCAP) >> test.log 2>&1
 	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
 
+
 replay_accurate:
 	$(PRINTF) "%s" "[tcpreplay] Accurate test: "
 	$(PRINTF) "%s\n" "*** [tcpreplay] Accurate test: " >> test.log
@@ -391,58 +450,53 @@ rewrite_portmap:
 	$(PRINTF) "%s" "[tcprewrite] Portmap test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Portmap test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -r 80:8080 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_range_portmap:
 	$(PRINTF) "%s" "[tcprewrite] Portmap range test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Portmap range test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -r 1-100:49148 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_sequence:
 	$(PRINTF) "%s" "[tcprewrite] TCP sequence test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] TCP sequence test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --tcp-sequence 42 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_endpoint:
 	$(PRINTF) "%s" "[tcprewrite] Endpoint test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Endpoint test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -e 10.10.0.1:10.10.0.2 \
 	    -c $(srcdir)/test.auto_router  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_pnat:
 	$(PRINTF) "%s" "[tcprewrite] Pseudo NAT test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Pseudo NAT test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 \
 	    -N 96.17.211.0/24:172.16.0.0/24  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_mac:
 	$(PRINTF) "%s" "[tcprewrite] Src/Dst MAC test: "
@@ -450,12 +504,11 @@ rewrite_mac:
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 \
 		--enet-dmac=00:12:13:14:15:16,00:22:33:44:55:66 \
 		--enet-smac=00:22:33:44:55:66,00:12:13:14:15:16  -c $(srcdir)/test.auto_router  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_enet_subsmac:
 	$(PRINTF) "%s" "[tcprewrite] Substitute Src/Dst MAC test: "
@@ -463,92 +516,84 @@ rewrite_enet_subsmac:
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 \
 		--enet-subsmac=00:1f:f3:3c:e1:13,00:22:33:44:55:66 \
 		--enet-subsmac=f8:1e:df:e5:84:3a,00:66:55:44:33:22  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t%s\n" "FAILED"; else $(PRINTF) "\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_mac_seed:
 	$(PRINTF) "%s" "[tcprewrite] Seeded MAC test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Seeded MAC test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 \
 		--enet-mac-seed=42 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_mac_seed_keep:
 	$(PRINTF) "%s" "[tcprewrite] Seeded Keep MAC test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Seeded Keep MAC test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 \
 		--enet-mac-seed=42 --enet-mac-seed-keep-bytes=3 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_trunc:
 	$(PRINTF) "%s" "[tcprewrite] Truncate test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Truncate test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -F trunc -i $(TEST_PCAP) -o test.$@1 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_pad:
 	$(PRINTF) "%s" "[tcprewrite] Pad test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Pad test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -F pad -i $(TEST_PCAP) -o test.$@1 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_seed:
 	$(PRINTF) "%s" "[tcprewrite] Seed IP test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Seed IP test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -s 55 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_layer2:
 	$(PRINTF) "%s" "[tcprewrite] Layer2 test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Layer2 test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) --dlt=user --user-dlink=00,50,da,5d,46,55,0,7,eb,30,a4,c3,08,0 \
 		-i $(TEST_PCAP) -o test.$@1 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_config:
 	$(PRINTF) "%s" "[tcprewrite] Config/VLAN Add test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Config/VLAN Add test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) --load-opts config  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_skip:
 	$(PRINTF) "%s" "[tcprewrite] Skip bcast test: "
@@ -557,36 +602,33 @@ rewrite_skip:
 	    --skipbroadcast --skipl2broadcast --skip-soft-errors --seed 55 \
 		--enet-dmac=00:12:13:14:15:16,00:22:33:44:55:66 \
 		--enet-smac=00:22:33:44:55:66,00:12:13:14:15:16  -c $(srcdir)/test.auto_router  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_dltuser:
 	$(PRINTF) "%s" "[tcprewrite] DLT User test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] DLT User test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --dlt=user \
 		--user-dlink=0x0f,0x00,0x08,0x00 --user-dlt=104  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_dlthdlc:
 	$(PRINTF) "%s" "[tcprewrite] DLT Cisco HDLC test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] DLT Cisco HDLC test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --dlt=hdlc \
 		--hdlc-control=0 --hdlc-address=0x0F  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_vlan802.1ad:
 	$(PRINTF) "%s" "[tcprewrite] VLAN 802.1ad test: "
@@ -594,178 +636,162 @@ rewrite_vlan802.1ad:
 	$(TCPREWRITE) -i $(TEST_PCAP) -o test.$@1 \
 		--enet-vlan=add --enet-vlan-tag=42 --enet-vlan-cfi=1 \
 		--enet-vlan-pri=2 --enet-vlan-proto=802.1ad
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_vlandel:
 	$(PRINTF) "%s" "[tcprewrite] VLAN Delete test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] VLAN Delete test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(srcdir)/test.rewrite_config -o test.$@1 \
 		--enet-vlan=del  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_efcs:
 	$(PRINTF) "%s" "[tcprewrite] Remove EFCS: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Remove EFCS: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --efcs >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_1ttl:
 	$(PRINTF) "%s" "[tcprewrite] Force TTL: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Force TTL: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --ttl=58  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_2ttl:
 	$(PRINTF) "%s" "[tcprewrite] Increase TTL: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Increase TTL: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --ttl=+58  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_3ttl:
 	$(PRINTF) "%s" "[tcprewrite] Reduce TTL: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Reduce TTL: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --ttl=-58  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_1ttl-hdrfix:
 	$(PRINTF) "%s" "[tcprewrite] Force TTL with header fix: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Force TTL header fix: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --ttl=59 --fixhdrlen >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t%s\n" "FAILED"; else $(PRINTF) "\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_2ttl-hdrfix:
 	$(PRINTF) "%s" "[tcprewrite] Increase TTL with header fix:"
 	$(PRINTF) "%s\n" "*** [tcprewrite] Increase TTL with header fix: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --ttl=+59 --fixhdrlen  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t%s\n" "FAILED"; else $(PRINTF) "\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_3ttl-hdrfix:
 	$(PRINTF) "%s" "[tcprewrite] Reduce TTL with header fix: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Reduce TTL with header fix: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --ttl=-59 --fixhdrlen  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t%s\n" "FAILED"; else $(PRINTF) "\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_tos:
 	$(PRINTF) "%s" "[tcprewrite] TOS test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] TOS test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --tos=50  >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_mtutrunc:
 	$(PRINTF) "%s" "[tcprewrite] MTU Truncate test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] MTU Truncate test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1  --mtu-trunc --mtu=300 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_l7fuzzing:
 	$(PRINTF) "%s" "[tcprewrite] L7 fuzzing test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] L7 fuzzing test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --fuzz-seed=42 --fuzz-factor=2 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_fixcsum:
 	$(PRINTF) "%s" "[tcprewrite] Fix checksum test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Fix checksum test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --fixcsum >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_fixlen_pad:
 	$(PRINTF) "%s" "[tcprewrite] Fix length and pad test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Fix length and pad test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --fixlen=pad >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_fixlen_trunc:
 	$(PRINTF) "%s" "[tcprewrite] Fix length and truncate test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Fix length and truncate test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --fixlen=trunc >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 rewrite_fixlen_del:
 	$(PRINTF) "%s" "[tcprewrite] Fix length and delete test: "
 	$(PRINTF) "%s\n" "*** [tcprewrite] Fix length and delete test: " >> test.log
 	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 --fixlen=del >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 replay_pps:
 	$(PRINTF) "%s" "[tcpreplay] Packets/sec test: "
@@ -832,45 +858,31 @@ replay_include:
 	$(PRINTF) "%s" "[tcpreplay] Include rule test: "
 	$(PRINTF) "%s\n" "*** [tcpreplay] Include rule test: " >> test.log
 	$(TCPREPLAY) $(ENABLE_DEBUG) -w test.$@1 -t --include=7,11,20-23,174- $(TEST_PCAP) >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 replay_exclude:
 	$(PRINTF) "%s" "[tcpreplay] Exclude rule test: "
 	$(PRINTF) "%s\n" "*** [tcpreplay] Exclude rule test: " >> test.log
 	$(TCPREPLAY) $(ENABLE_DEBUG) -w test.$@1 -t --exclude=23-,11-20,2,3 $(TEST_PCAP) >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 replay_unique_ip:
 	$(PRINTF) "%s" "[tcpreplay] Unique IP test: "
 	$(PRINTF) "%s\n" "*** [tcpreplay] Unique IP test: " >> test.log
 	$(TCPREPLAY) $(ENABLE_DEBUG) -w test.$@1 -t --unique-ip --loop=2 $(TEST_PCAP) >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
-
-rewrite_portmap:
-	$(PRINTF) "%s" "[tcprewrite] Portmap test: "
-	$(PRINTF) "%s\n" "*** [tcprewrite] Portmap test: " >> test.log
-	$(TCPREWRITE) $(ENABLE_DEBUG) -i $(TEST_PCAP) -o test.$@1 -r 80:8080 >> test.log 2>&1
-if WORDS_BIGENDIAN
-	diff $(srcdir)/test.$@ test.$@1 >> test.log 2>&1
-else
-	diff $(srcdir)/test2.$@ test.$@1 >> test.log 2>&1
-endif
-	if [ $? ] ; then $(PRINTF) "\t\t\t%s\n" "FAILED"; else $(PRINTF) "\t\t\t%s\n" "OK"; fi
+	if diff $(srcdir)/test$(VARIANT).$@ test.$@1 >> test.log 2>&1; then \
+	    $(PRINTF) "\t\t\t%s\n" "OK"; \
+	else \
+	    $(PRINTF) "\t\t\t%s\n" "FAILED"; od -Ax -tx1 -v test.$@1 >> test.log; false; \
+	fi
 
 clean:
 	rm -f *1 test.log core* *~ primary.data secondary.data


### PR DESCRIPTION
Required to analyse rewrite issues in CI that are not otherwise reproducible.

Format is as per suggestion for Wireshark hex input, but I find it easier to convert to binary, e.g.

```
xxd -r failed_text.hex > failed.pcap
```

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] The code passes `sudo make test`

## Changes:

- [...]

## Other comments:

...
