### PR TITLE
Bug #896 AF_XDP: default --xdp-batch-size=1

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -2,6 +2,7 @@
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)
     - support for IPv6 fragment checksums (#897)
+    - AF_XDP sends at near full speed (#896)
 
 07/12/2024 Version 4.5.1
     - NULL Pointer Dereference in parse_endpoints (#888)

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -582,7 +582,7 @@ EOText;
 
 flag = {
     name        = unique-ip-loops;
-    flags-must   = unique-ip;
+    flags-must  = unique-ip;
     arg-type    = string;
     max         = 1;
     descrip     = "Number of times to loop before assigning new unique ip";
@@ -721,11 +721,18 @@ EOText;
 flag = {
     ifdef       = HAVE_LIBXDP;
     name        = xdp-batch-size;
-    arg-type    = number;
+    flags-cant  = oneatatime;
+    flags-cant  = pps-multi;
+    flags-must  = xdp;
+    flags-must  = topspeed;
+  arg-type    = number;
     arg-range   = "1->4096";
     descrip     = "The maximum number of packets that can be submitted to the AF_XDP TX ring at once";
-    arg-default = 25;
-    doc         = "Higher values may improve performance at the cost of accuracy";
+    arg-default = 1;
+    doc         = <<- EOText
+Only allowed if sending at top speed. Values higher than 1 may improve
+performance at the cost of accuracy.
+EOText;
 };
 
 flag = {


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

If you use --xdp-batch-size other than 1, cannot control speed. Change default from 25 to 1.
Also require --topspeed if --xdp-batch-size is specified.
