### PR TITLE
Bug #731 #904 various TX_RING link errors

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -3,6 +3,7 @@
     - GitHub Actions CI failure (#933)
     - support for IPv6 fragment checksums (#897)
     - AF_XDP sends at near full speed (#896)
+    - TX_RING link errors on some platforms (#732 #904)
 
 07/12/2024 Version 4.5.1
     - NULL Pointer Dereference in parse_endpoints (#888)

--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -31,6 +31,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "defines.h"
+#include "config.h"
+
 #ifdef HAVE_TX_RING
 
 #include "txring.h"

--- a/src/common/txring.h
+++ b/src/common/txring.h
@@ -33,10 +33,10 @@
 
 #pragma once
 
-#ifdef HAVE_TX_RING
-
 #include "defines.h"
 #include "config.h"
+
+#ifdef HAVE_TX_RING
 
 #if __GLIBC__ >= 2 && __GLIBC_MINOR >= 1
 #include <net/ethernet.h> /* the L2 protocols */


### PR DESCRIPTION
similar issue in gcc 15 build environment.
- See more details at: http://errors.yoctoproject.org/Errors/Details/851800/
```
TOPDIR/tmp/work/core2-64-oe-linux/tcpreplay/4.5.1/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/15.0.1/ld: ./common/libcommon.a(sendpacket.o): in function `sendpacket':
/usr/src/debug/tcpreplay/4.5.1/src/common/sendpacket.c:328:(.text+0x1be): undefined reference to `txring_put'
TOPDIR/tmp/work/core2-64-oe-linux/tcpreplay/4.5.1/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/15.0.1/ld: ./common/libcommon.a(sendpacket.o): in function `sendpacket_open_pf':
/usr/src/debug/tcpreplay/4.5.1/src/common/sendpacket.c:1088:(.text+0x7ea): undefined reference to `txring_init'
TOPDIR/tmp/work/core2-64-oe-linux/tcpreplay/4.5.1/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/15.0.1/ld: ./common/libcommon.a(sendpacket.o): in function `sendpacket':
/usr/src/debug/tcpreplay/4.5.1/src/common/sendpacket.c:328:(.text+0x1be): undefined reference to `txring_put'
TOPDIR/tmp/work/core2-64-oe-linux/tcpreplay/4.5.1/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/15.0.1/ld: ./common/libcommon.a(sendpacket.o): in function `sendpacket_open_pf':
/usr/src/debug/tcpreplay/4.5.1/src/common/sendpacket.c:1088:(.text+0x7ea): undefined reference to `txring_init'
TOPDIR/tmp/work/core2-64-oe-linux/tcpreplay/4.5.1/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/15.0.1/ld: ./common/libcommon.a(sendpacket.o): in function `sendpacket':
/usr/src/debug/tcpreplay/4.5.1/src/common/sendpacket.c:328:(.text+0x1be): undefined reference to `txring_put'
TOPDIR/tmp/work/core2-64-oe-linux/tcpreplay/4.5.1/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/15.0.1/ld: ./common/libcommon.a(sendpacket.o): in function `sendpacket_open_pf':
/usr/src/debug/tcpreplay/4.5.1/src/common/sendpacket.c:1088:(.text+0x7ea): undefined reference to `txring_init'
```
- The result of "nm -u txring.o" shows no symbols exist.

- The config.h has HAVE_TX_RING defined but txring.c is not aware of it. txring.c and txring.h include config.h at the beginning.

- This resulted in a successful build in my build environment.

It may
Fixes appneta#731
Fixes appneta#904

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
