### PR TITLE
Bug #905 configure libpcap search fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -710,13 +710,9 @@ AC_ARG_WITH(libpcap,
                         LPCAP_LD_LIBRARY_PATH="$(dirname ${sharefile})"
                         LPCAPLIB="-L$LPCAP_LD_LIBRARY_PATH -lpcap"
                         foundpcap=$testdir
-                        break
+                        break 2
                     fi
                 done
-
-                if ! test $foundpcap = no; then
-                    break
-                fi
             done
         else
             dnl
@@ -728,10 +724,9 @@ AC_ARG_WITH(libpcap,
                     if test -n "${staticfile}"; then
                         LPCAPLIB="${staticfile}"
                         foundpcap=${testdir}
-                        break
+                        break 2
                     fi
                 done
-
             done
         fi
 

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 06/30/2025 Version 4.5.2 - beta1
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)
+    - Fixup the libpcap search loops (#905)
     - support for IPv6 fragment checksums (#897)
     - AF_XDP sends at near full speed (#896)
     - TX_RING link errors on some platforms (#732 #904)

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -137,6 +137,7 @@ Chen Qi <GitHub ChenQi1989>
 
 Denis Ovsienko <GitHub infrastation>
     - Haiku support
+    - libpcap search fix
 
 Jason Lue <GitHub jasonlue>
     - tcpreplay -w option


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
