### PR TITLE
Bug #907 fix build open bsd

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
-06/30/2025 Version 4.5.2 - beta1
+07/04/2025 Version 4.5.2 - beta1
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)
+    - Fix building on OpenBSD (#907)
     - Fixup the libpcap search loops (#905)
     - support for IPv6 fragment checksums (#897)
     - AF_XDP sends at near full speed (#896)

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -141,3 +141,7 @@ Denis Ovsienko <GitHub infrastation>
 
 Jason Lue <GitHub jasonlue>
     - tcpreplay -w option
+
+Brad Smith <GitHub brad0>
+    - fix build on OpenBSD
+

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -27,6 +27,7 @@
 #ifdef __NetBSD__
 #include <net/if_ether.h>
 #elif ! defined(__HAIKU__)
+#include <net/if.h>
 #include <netinet/if_ether.h>
 #endif
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

```
In file included from ../../src/common/sendpacket.h:30: 
/usr/include/netinet/if_ether.h:154:17: fatal error: field has incomplete type 'struct arphdr'
        struct   arphdr ea_hdr;                 /* fixed-size header */
                        ^
/usr/include/netinet/if_ether.h:154:10: note: forward declaration of 'struct arphdr'
        struct   arphdr ea_hdr;                 /* fixed-size header */
                 ^
1 error generated.
```
...
