### PR TITLE
Bug #911 continue on get l2len protcol is zero

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 07/04/2025 Version 4.5.2 - beta1
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)
+    - Continue on get_l2len_protcol() is zero (#911)
     - Fix building on OpenBSD (#907)
     - Fixup the libpcap search loops (#905)
     - support for IPv6 fragment checksums (#897)

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -273,8 +273,10 @@ get_l2len_protocol(const u_char *pktdata,
     assert(l2offset);
     assert(vlan_offset);
 
-    if (!pktdata || !datalen)
-        errx(-1, "get_l2len_protocol: invalid L2 parameters: pktdata=0x%p len=%d", pktdata, datalen);
+    if (!pktdata || !datalen) {
+        err_no_exitx("get_l2len_protocol: invalid L2 parameters: pktdata=0x%p len=%d", pktdata, datalen);
+        return -1;
+    }
 
     *protocol = 0;
     *l2len = 0;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- do not fail on l2len == 0

## Other comments:

...
