### PR TITLE
Bug #924 TX_RING: Compile issue

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 07/04/2025 Version 4.5.2 - beta1
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)
+    - TX_RING compile errors (#924)
     - Continue on get_l2len_protcol() is zero (#911)
     - Fix building on OpenBSD (#907)
     - Fixup the libpcap search loops (#905)

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -145,3 +145,5 @@ Jason Lue <GitHub jasonlue>
 Brad Smith <GitHub brad0>
     - fix build on OpenBSD
 
+Mark Yang <GitHub markyang92>
+    - TX_RING compile issue


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Change `txring.c`, `txring.h`
- Ensure txring compiles correctly to avoid linker errors.
  - The result of "nm -u txring.o" shows no symbols exist.
  - The config.h has HAVE_TX_RING defined but txring.c is not aware of it.
      txring.c and txring.h include config.h at the beginning.

- Modify the assignment target for the `safe_malloc` return value from `*txp` to `txp`.

- This resulted in a successful build in my build environment.
