### PR TITLE
Bug #899 flows: correct IPv6 header version check

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -8,6 +8,7 @@
     - support for IPv6 fragment checksums (#897)
     - AF_XDP sends at near full speed (#896)
     - TX_RING link errors on some platforms (#732 #904)
+    - IPv6 header version check incorrect for flow stats (#899)
 
 07/12/2024 Version 4.5.1
     - NULL Pointer Dereference in parse_endpoints (#888)

--- a/src/common/flows.c
+++ b/src/common/flows.c
@@ -239,7 +239,7 @@ flow_decode(flow_hash_table_t *fht,
             return FLOW_ENTRY_INVALID;
         }
 
-        uint8_t ip6_version = packet[0] >> 4;
+        uint8_t ip6_version = packet[l2len] >> 4;
         if (ip6_version != 6) {
             warnx("flow_decode: packet " COUNTER_SPEC " IPv6 header version should be 6 but instead is %u",
                   packetnum,


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- check IPv6 flow version header with proper offset
