### PR TITLE
Bug #809 workaround for gcc 4.4.4 failure on FreeBSD

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -9,6 +9,7 @@
     - AF_XDP sends at near full speed (#896)
     - TX_RING link errors on some platforms (#732 #904)
     - IPv6 header version check incorrect for flow stats (#899)
+    - gcc 4.4.4 fails build on FreeBSD (#809)
     - MAC address sometimes corruptly altered on tcprewrite --seed option (#794 #901)
 
 07/12/2024 Version 4.5.1

--- a/lib/queue.h
+++ b/lib/queue.h
@@ -36,8 +36,7 @@
  *	@(#)queue.h	8.5 (Berkeley) 8/20/94
  */
 
-#ifndef	_SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+#pragma once
 
 /*
  * This file defines five types of data structures: singly-linked lists, 
@@ -507,5 +506,3 @@ struct {								\
 	else								\
 		(elm2)->field.cqe_prev->field.cqe_next = (elm2);	\
 } while (0)
-
-#endif /* !_SYS_QUEUE_H_ */

--- a/src/fragroute/mod.c
+++ b/src/fragroute/mod.c
@@ -8,11 +8,11 @@
  */
 
 #include "mod.h"
+#include "lib/queue.h"
 #include "defines.h"
 #include "config.h"
 #include "common.h"
 #include "argv.h"
-#include "lib/queue.h"
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/fragroute/pkt.h
+++ b/src/fragroute/pkt.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include "lib/queue.h"
 #include "defines.h"
 #include "config.h"
-#include "lib/queue.h"
 #include <sys/time.h>
 
 #ifdef HAVE_LIBDNET


### PR DESCRIPTION
GCC 4.4.4 requires headers in a specific order to achieve compile on FreeBSD.

Move to `#pragma once` fixes, but also reorder headers as described by others.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- switch queue.h to `#pragma once`
- reorder some include headers
