### PR TITLE
Bug #94 stop on --portmap syntax error

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,4 @@
-07/04/2025 Version 4.5.2 - beta1
+07/05/2025 Version 4.5.2 - beta1
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)
     - TX_RING compile errors (#924)
@@ -7,8 +7,9 @@
     - Fixup the libpcap search loops (#905)
     - support for IPv6 fragment checksums (#897)
     - AF_XDP sends at near full speed (#896)
-    - TX_RING link errors on some platforms (#732 #904)
+    - TX_RING link errors on some platforms (#731 #904)
     - IPv6 header version check incorrect for flow stats (#899)
+    - tcprewrite --portmap syntax error causes crash (#894)
     - gcc 4.4.4 fails build on FreeBSD (#809)
     - MAC address sometimes corruptly altered on tcprewrite --seed option (#794 #901)
 

--- a/src/tcpedit/portmap.c
+++ b/src/tcpedit/portmap.c
@@ -104,7 +104,7 @@ ports2PORT(char *ports)
         from_begin = strtok_r(from_s, "-", &token2);
         from_end = strtok_r(NULL, "-", &token2);
         long from_b = strtol(from_begin, &badchar, 10);
-        if (strlen(badchar) != 0) {
+        if (!from_begin || !from_end || strlen(badchar) != 0) {
             free(portmap);
             return NULL;
         }


### PR DESCRIPTION
Example of fix:

```
❯ src/tcprewrite -r 1:2 -i ping.pcap -c ping.cache -o out.pcap
❯ src/tcprewrite -r 1-:2 -i ping.pcap -c ping.cache -o out.pcap

Fatal Error in ../../src/tcprewrite.c:main() line 86:
 Unable to parse args: From ../../../src/tcpedit/parse_args.c:tcpedit_post_args() line 189:
Unable to parse --portmap=1-:2
```

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- stop and throw an error on `--portmap` syntax error
