### PR TITLE
Bug #902 tcprewrite: SEGV on crafted capture

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -8,6 +8,7 @@
     - support for IPv6 fragment checksums (#897)
     - AF_XDP sends at near full speed (#896)
     - TX_RING link errors on some platforms (#731 #904)
+    - tcprewrite crash on Juniper crafted packet (#904)
     - IPv6 header version check incorrect for flow stats (#899)
     - tcprewrite --portmap syntax error causes crash (#894)
     - gcc 4.4.4 fails build on FreeBSD (#809)

--- a/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.h
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/jnpr_ether.h
@@ -33,6 +33,8 @@ extern "C" {
 #define JUNIPER_ETHER_L2PRESENT 0x80
 #define JUNIPER_ETHER_DIRECTION 0x01
 #define JUNIPER_ETHER_EXTLEN_OFFSET 4
+#define JUNIPER_ETHER_EXT_MEDIA_TYPE 3
+#define JUNIPER_ETHER_EXT_ENCAPSULATION 6
 
 int dlt_jnpr_ether_register(tcpeditdlt_t *ctx);
 int dlt_jnpr_ether_init(tcpeditdlt_t *ctx);


### PR DESCRIPTION
Bug #902

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Protect against invalid or unsupported Juniper packets.

## Other comments:

- only Ethernet packets are currently supported
- was unable to recreate the original bug, but areas where hardening was required
