### PR TITLE
Bug #947 - ensure defines.h is always regenerated

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,7 @@ else
 LIBSTRL = ../lib/libstrl.a
 endif
 
-BUILT_SOURCES = 
+BUILT_SOURCES = defines.h
 
 manpages: tcpprep.1 tcprewrite.1 tcpreplay.1 tcpbridge.1 tcpreplay-edit.1 tcpliveplay.1 tcpcapinfo.1
 


### PR DESCRIPTION
It appears that some versions of automake will not regenerate defines.h unless BUILD_SOURCES is properly set.

Tested on Linux Rhino 2025.3

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
