### PR TITLE
Bug #956 XDP - fail with a more informative error message

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,5 @@
 07/27/2025 Version 4.5.2 - beta2
+    - better error handling for XDP send errors (#956)
     - stdbool.h not detected correctly (#947)
     - AF_XDP memory leaks (#935)
     - GitHub Actions CI failure (#933)

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -250,8 +250,14 @@ kick_tx(struct xsk_socket_info *xsk)
     if (ret >= 0 || errno == ENOBUFS || errno == EAGAIN || errno == EBUSY || errno == ENETDOWN) {
         return;
     }
-    printf("%s\n", "Packet sending exited with error!");
-    exit (1);
+    if (errno == EINVAL) {
+        printf("%s %s\n", "Send error: XDP is either not supported by this underlying network driver, or it has a bug.\n"
+                          "Try upgrading to a newer kernel version and/or network driver and try again.");
+        exit(0);
+    } else {
+        printf("%s %s\n", "XDP packet sending exited with error!", strerror(errno));
+        exit(1);
+    }
 }
 
 static inline void


### PR DESCRIPTION
In virtio-net it appear to have faulty XDP support, in which case we get EINVAL.

Note that this may have been fixed in July 2025 with this commit. It touches some XDP code.

```
Mon Jul 7 04:14:54 2025 -0400 6aca3dad2145 virtio-net: ensure the received length does not exceed allocated size  [Bui Quang Minh]
``

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

