### PR TITLE
Bug #970 tcprewrite: --fixlen: do not use realloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl $Id$
 AC_PREREQ([2.69])
 
 dnl Set version info here!
-AC_INIT([tcpreplay],[4.5.2-beta2],[https://github.com/appneta/tcpreplay/issues],[tcpreplay],[http://tcpreplay.sourceforge.net/])
+AC_INIT([tcpreplay],[4.5.2-beta3],[https://github.com/appneta/tcpreplay/issues],[tcpreplay],[http://tcpreplay.sourceforge.net/])
 AC_CONFIG_SRCDIR([src/tcpreplay.c])
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_AUX_DIR(config)

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,5 @@
-07/27/2025 Version 4.5.2 - beta2
+07/27/2025 Version 4.5.2 - beta3
+    - --fixlen use-after-free (#970)
     - better error handling for XDP send errors (#956)
     - stdbool.h not detected correctly (#947)
     - AF_XDP memory leaks (#935)

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -251,7 +251,7 @@ kick_tx(struct xsk_socket_info *xsk)
         return;
     }
     if (errno == EINVAL) {
-        printf("%s %s\n", "Send error: XDP is either not supported by this underlying network driver, or it has a bug.\n"
+        printf("%s\n", "Send error: XDP is either not supported by this underlying network driver, or it has a bug.\n"
                           "Try upgrading to a newer kernel version and/or network driver and try again.");
         exit(0);
     } else {

--- a/src/tcpedit/edit_packet.c
+++ b/src/tcpedit/edit_packet.c
@@ -572,7 +572,6 @@ untrunc_packet(tcpedit_t *tcpedit,
          * which seems like a corrupted pcap
          */
         if (pkthdr->len > pkthdr->caplen) {
-            packet = safe_realloc(packet, pkthdr->len + PACKET_HEADROOM);
             memset(packet + pkthdr->caplen, '\0', pkthdr->len - pkthdr->caplen);
             pkthdr->caplen = pkthdr->len;
         } else if (pkthdr->len < pkthdr->caplen) {

--- a/src/tcprewrite.c
+++ b/src/tcprewrite.c
@@ -292,6 +292,8 @@ rewrite_packets(tcpedit_t *tcpedit_ctx, pcap_t *pin, pcap_dumper_t *pout)
 
         if (pkthdr.caplen > MAX_SNAPLEN)
             errx(-1, "Frame too big, caplen %d exceeds %d", pkthdr.caplen, MAX_SNAPLEN);
+        if (pkthdr.len > MAX_SNAPLEN)
+            errx(-1, "Frame too big, len %d exceeds %d", pkthdr.len, MAX_SNAPLEN);
         /*
          * copy over the packet so we can pad it out if necessary and
          * because pcap_next() returns a const ptr


### PR DESCRIPTION
No need to realloc if buffer is already proven to be big enough.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
