### PR TITLE
Bug #967 gcc15: fix out-of-tree build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ DIST_SUBDIRS = scripts lib libopts src docs test
 
 
 dist-hook: version manpages
+	rm $(distdir)/src/defines.h
 
 DOCS_DIR = $(top_builddir)/docs
 

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,6 @@
 07/27/2025 Version 4.5.2 - beta3
     - --fixlen use-after-free (#970)
+    - gcc 15 out-of-tree build failure (#967)
     - better error handling for XDP send errors (#956)
     - stdbool.h not detected correctly (#947)
     - AF_XDP memory leaks (#935)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Other comments:

Was able to compile in-tree, but failed out-of-tree with gcc 14 & 15