### PR TITLE
Bug #977 C23 standard support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,9 +273,15 @@ AC_FUNC_FSEEKO
 
 dnl Check for types.
 AC_CHECK_TYPE(u_int8_t, uint8_t)
+AC_CHECK_TYPE(u_char, uint8_t)
 AC_CHECK_TYPE(u_int16_t, uint16_t)
+AC_CHECK_TYPE(u_short, uint16_t)
+AC_CHECK_TYPE(u_int, uint32_t)
 AC_CHECK_TYPE(u_int32_t, uint32_t)
 AC_CHECK_TYPE(u_int64_t, uint64_t)
+
+# required by C23 standard
+CFLAGS="-D_DEFAULT_SOURCE $CFLAGS"
 
 dnl OS X SDK 10.11 throws lots of unnecessary macro warnings
 wno_format=""

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,5 @@
-07/27/2025 Version 4.5.2 - beta3
+08/25/2025 Version 4.5.2 - beta3
+    - C23 standard support (#977)
     - --fixlen use-after-free (#970)
     - gcc 15 out-of-tree build failure (#967)
     - better error handling for XDP send errors (#956)

--- a/src/common/cidr.c
+++ b/src/common/cidr.c
@@ -21,7 +21,6 @@
 #include "defines.h"
 #include "config.h"
 #include "common.h"
-#include <arpa/inet.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -95,7 +95,7 @@ txring_put(txring_t *txp, const void *data, size_t length)
 
         switch ((volatile uint32_t)ps_header->tp_status) {
         case TP_STATUS_WRONG_FORMAT:
-            warnx("TP_STATUS_WRONG_FORMAT occuries O_o. Frame %d, pkt len %d\n", txp->tx_index, length);
+            warnx("TP_STATUS_WRONG_FORMAT occures O_o. Frame %d, pkt len %d\n", txp->tx_index, length);
             break;
 
         case TP_STATUS_AVAILABLE:

--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -10,6 +10,10 @@
 #include <sys/types.h>
 #endif
 
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
+
 #ifdef WIN32
 #include "msvc_inttypes.h"
 #include "msvc_stdint.h"
@@ -25,7 +29,7 @@
 
 #endif /* WIN32 */
 
-#ifdef HAVE_SYS_SOCKET
+#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
 

--- a/src/fragroute/bget.c
+++ b/src/fragroute/bget.c
@@ -533,9 +533,9 @@ static long numdget = 0, numdrel = 0; /* Number of direct gets and rels */
 
 /* Automatic expansion block management functions */
 
-static int (*compfcn) _((bufsize sizereq, int sequence)) = NULL;
-static void *(*acqfcn) _((bufsize size)) = NULL;
-static void (*relfcn) _((void *buf)) = NULL;
+static int (*compfcn) (size_t sizereq, int sequence) = NULL;
+static void *(*acqfcn) (size_t size) = NULL;
+static void (*relfcn) (void *buf) = NULL;
 
 static bufsize exp_incr = 0;          /* Expansion block size */
 static bufsize pool_len = 0;          /*  0: no bpool calls have been made
@@ -562,8 +562,7 @@ static bufsize pool_len = 0;          /*  0: no bpool calls have been made
 /*  BGET  --  Allocate a buffer.  */
 
 void *
-bget(requested_size)
-bufsize requested_size;
+bget(bufsize requested_size)
 {
     bufsize size = requested_size;
     struct bfhead *b;
@@ -755,8 +754,7 @@ bufsize requested_size;
            region requested by the caller. */
 
 void *
-bgetz(size)
-bufsize size;
+bgetz(bufsize size)
 {
     char *buf = (char *)bget(size);
 
@@ -785,8 +783,7 @@ bufsize size;
            enhanced to allow the buffer to grow into adjacent free
            blocks and to avoid moving data unnecessarily.  */
 
-void *bgetr(buf, size) void *buf;
-bufsize size;
+void *bgetr(void *buf, bufsize size)
 {
     void *nbuf;
     bufsize osize; /* Old size of buffer */
@@ -821,7 +818,7 @@ bufsize size;
 
 /*  BREL  --  Release a buffer.  */
 
-void brel(buf) void *buf;
+void brel(void *buf)
 {
     struct bfhead *b, *bn;
 
@@ -966,11 +963,7 @@ void brel(buf) void *buf;
 
 /*  BECTL  --  Establish automatic pool expansion control  */
 
-void bectl(compact, acquire, release, pool_incr)
-  int (*compact) _((bufsize sizereq, int sequence));
-  void *(*acquire) _((bufsize size));
-  void (*release) _((void *buf));
-  bufsize pool_incr;
+void bectl(int (*compact)(size_t, int), void *(*acquire)(size_t), void (*release)(void*), bufsize pool_incr)
 {
     compfcn = compact;
     acqfcn = acquire;
@@ -981,8 +974,7 @@ void bectl(compact, acquire, release, pool_incr)
 
 /*  BPOOL  --  Add a region of memory to the buffer pool.  */
 
-void bpool(buf, len) void *buf;
-bufsize len;
+void bpool(void *buf, bufsize len)
 {
     struct bfhead *b = BFH(buf);
     struct bhead *bn;
@@ -1280,7 +1272,7 @@ extern long time();
 #endif
 
 extern char *malloc();
-extern int free _((char *));
+extern int free (char *);
 
 static char *bchain = NULL;          /* Our private buffer chain */
 static char *bp = NULL;           /* Our initial buffer pool */

--- a/src/fragroute/bget.h
+++ b/src/fragroute/bget.h
@@ -6,27 +6,17 @@
 
 #pragma once
 
-#ifndef _
-#ifdef PROTOTYPES
-#define  _(x)  x              /* If compiler knows prototypes */
-#else
-#define  _(x)  ()                     /* It it doesn't */
-#endif /* PROTOTYPES */
-#endif
-
 typedef long bufsize;
-void    bpool        _((void *buffer, bufsize len));
-void   *bget        _((bufsize size));
-void   *bgetz        _((bufsize size));
-void   *bgetr        _((void *buffer, bufsize newsize));
-void    brel        _((void *buf));
-void    bectl        _((int (*compact)(bufsize sizereq, int sequence),
-void *(*acquire)(bufsize size),
-void (*release)(void *buf), bufsize pool_incr));
-void    bstats        _((bufsize *curalloc, bufsize *totfree, bufsize *maxfree,
-long *nget, long *nrel));
-void    bstatse     _((bufsize *pool_incr, long *npool, long *npget,
-long *nprel, long *ndget, long *ndrel));
-void    bufdump     _((void *buf));
-void    bpoold        _((void *pool, int dumpalloc, int dumpfree));
-int    bpoolv        _((void *pool));
+void    bpool        (void *buffer, bufsize len);
+void   *bget        (bufsize size);
+void   *bgetz        (bufsize size);
+void   *bgetr        (void *buffer, bufsize newsize);
+void    brel        (void *buf);
+void    bectl        (int (*compact)(size_t sizereq, int sequence),
+                      void *(*acquire)(size_t size),
+                      void (*release)(void *buf), bufsize pool_incr);
+void    bstats        (bufsize *curalloc, bufsize *totfree, bufsize *maxfree, long *nget, long *nrel);
+void    bstatse     (bufsize *pool_incr, long *npool, long *npget, long *nprel, long *ndget, long *ndrel);
+void    bufdump     (void *buf);
+void    bpoold        (void *pool, int dumpalloc, int dumpfree);
+int    bpoolv        (void *pool);


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

Recreate on GCC-14 with `CFLAGS=-std=c23 ../configure`