### PR TITLE
BUG-974 handle overflow in packet sending for speed_packetrate and speed_mbpsrate

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -1088,7 +1088,7 @@ calc_sleep_time(tcpreplay_t *ctx,
             if (bits_sent > COUNTER_OVERFLOW_RISK)
                 next_tx_ns = (bits_sent * 1000) / bps * 1000000;
             else
-                next_tx_ns = (bits_sent * 1000000000) / bps;
+                next_tx_ns = (bits_sent * 1000000) / bps * 1000;
 
             if (next_tx_ns > tx_ns) {
                 NANOSEC_TO_TIMESPEC(next_tx_ns - tx_ns, &ctx->nap);
@@ -1122,7 +1122,7 @@ calc_sleep_time(tcpreplay_t *ctx,
              * When active, adjusted calculation may add a bit of jitter.
              */
             if ((pkts_sent < COUNTER_OVERFLOW_RISK))
-                next_tx_ns = (pkts_sent * 1000000000) * (60 * 60) / pph;
+                next_tx_ns = (pkts_sent * 1000000) * (60 * 60) / pph * 1000;
             else
                 next_tx_ns = ((pkts_sent * 1000000) / pph * 1000) * (60 * 60);
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] The code passes `sudo make test`

## Changes:

- Convert to nanosec after division 

## Other comments:
Test result: ~8GB pcap file, tcpreplay command using speed_mbpsrate = 10. Speed rate is constant throughout the entire operation. 

tcpreplay -i veth0 -M 10 --stats=1 8GB_test_file.pcap

## Logs
Actual: 1634674 packets (8578746889 bytes) sent in 6862.99 seconds
Rated: 1250000.0 Bps, 10.00 Mbps, 238.18 pps
Actual: 1634916 packets (8579997033 bytes) sent in 6863.99 seconds
Rated: 1250000.1 Bps, 10.00 Mbps, 238.18 pps
Actual: 1635160 packets (8581249984 bytes) sent in 6865.00 seconds
Rated: 1249999.9 Bps, 9.99 Mbps, 238.18 pps
Actual: 1635403 packets (8582503398 bytes) sent in 6866.00 seconds
Rated: 1250000.1 Bps, 10.00 Mbps, 238.18 pps
Actual: 1635646 packets (8583758340 bytes) sent in 6867.00 seconds
Rated: 1250000.1 Bps, 10.00 Mbps, 238.18 pps
Actual: 1635883 packets (8585008943 bytes) sent in 6868.00 seconds
Rated: 1250000.0 Bps, 10.00 Mbps, 238.18 pps
Actual: 1636123 packets (8586262031 bytes) sent in 6869.00 seconds
Rated: 1250000.1 Bps, 10.00 Mbps, 238.18 pps
Actual: 1636353 packets (8587513641 bytes) sent in 6870.01 seconds
Rated: 1249999.9 Bps, 9.99 Mbps, 238.18 pps
Actual: 1636592 packets (8588765064 bytes) sent in 6871.01 seconds
Rated: 1250000.0 Bps, 10.00 Mbps, 238.18 pps
Test complete: 1970-01-01 02:02:32.532258497
Actual: 1636812 packets (8589935953 bytes) sent in 6871.94 seconds
Rated: 1249999.9 Bps, 9.99 Mbps, 238.18 pps
Flows: 1 flows, 0.00 fps, 1636812 unique flow packets, 0 unique non-flow packets
Statistics for network device: veth0
        Successful packets:        1636812
        Failed packets:            0
        Truncated packets:         0
        Retried packets (ENOBUFS): 0


