### PR TITLE
Refs #984: sendpacket: avoid endless retries on ENOBUFS/EAGAIN

### DIFF
--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -257,6 +257,8 @@ sendpacket(sendpacket_t *sp, const u_char *data, size_t len, struct pcap_pkthdr 
                                   * prevent page misses on stack
                                   */
     static const size_t buffer_payload_size = sizeof(buffer) + sizeof(struct pcap_pkthdr);
+    size_t retry_count = 0;
+    const size_t max_retry_count = 100;
 
     assert(sp);
 #ifndef HAVE_LIBXDP
@@ -268,6 +270,11 @@ sendpacket(sendpacket_t *sp, const u_char *data, size_t len, struct pcap_pkthdr 
         return -1;
 
 TRY_SEND_AGAIN:
+    
+    // On retries, sleep briefly to avoid busy-looping and putting unnecessary load on the kernel.
+    if (retry_count > 0) usleep(0);
+    if (++retry_count > max_retry_count) goto EXIT_MAX_RETRIES;
+
     sp->attempt++;
 
     switch (sp->handle_type) {
@@ -498,6 +505,7 @@ TRY_SEND_AGAIN:
         errx(-1, "Unsupported sp->handle_type = %d", sp->handle_type);
     } /* end case */
 
+    EXIT_MAX_RETRIES:
     if (retcode < 0) {
         sp->failed++;
     } else if (sp->abort) {


### PR DESCRIPTION
Refs #984.

### Problem
When using the PF_PACKET injection method, `sendpacket()` may enter an endless retry loop if `send()` keeps returning `ENOBUFS` or `EAGAIN` continuously (e.g., with very large frames or under sustained buffer pressure). This results in 100% CPU usage and tcpreplay never progresses to the next packet.

### Change
Introduce a bounded retry loop for transient `ENOBUFS`/`EAGAIN` failures:
- Add a small sleep on retries to avoid busy-looping and unnecessary kernel load.
- Stop retrying after `max_retry_count` attempts and return an error so tcpreplay can continue with the next packet.

### How to test
1. Build tcpreplay from this branch.
2. Replay a pcap that triggers persistent `ENOBUFS`/`EAGAIN` on PF_PACKET.
3. Verify that tcpreplay no longer hangs in an infinite retry loop and instead proceeds (or reports failure) after the retry limit.

Values are currently hard-coded and can be made configurable if maintainers prefer.