### PR TITLE
Fix Mbps pacing overflow on long replays

### DIFF
--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -63,7 +63,7 @@ static void calc_sleep_time(tcpreplay_t *ctx,
                             sendpacket_t *sp,
                             COUNTER counter,
                             struct timespec *sent_timestamp,
-                            COUNTER start_us,
+                            COUNTER start_ns,
                             COUNTER *skip_length);
 static void tcpr_sleep(tcpreplay_t *ctx, sendpacket_t *sp _U_, struct timespec *nap_this_time, struct timespec *now);
 static u_char *get_next_packet(tcpreplay_opt_t *options,
@@ -1081,14 +1081,16 @@ calc_sleep_time(tcpreplay_t *ctx,
             COUNTER tx_ns = now_ns - start_ns;
 
             /*
-             * bits * 1000000000 divided by bps = nanosecond
-             *
-             * ensure there is no overflow in cases where bits_sent is very high
-             */
-            if (bits_sent > COUNTER_OVERFLOW_RISK)
-                next_tx_ns = (bits_sent * 1000) / bps * 1000000;
-            else
-                next_tx_ns = (bits_sent * 1000000000) / bps;
+            * Calculate:
+            *
+            *   next_tx_ns = bits_sent * 1000000000 / bps
+            *
+            * without multiplying the full bits_sent value by 1e9 first.
+            * That multiplication can overflow COUNTER on long low-rate replays,
+            * making next_tx_ns wrap small and causing skip_length to become huge.
+            */
+            next_tx_ns = (bits_sent / bps) * 1000000000;
+            next_tx_ns += ((bits_sent % bps) * 1000000000) / bps;
 
             if (next_tx_ns > tx_ns) {
                 NANOSEC_TO_TIMESPEC(next_tx_ns - tx_ns, &ctx->nap);


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] The code passes `sudo make test`

Note: I noticed #982 after opening this PR. #982 appears to address the same overflow class and is broader because it touches both `speed_mbpsrate` and `speed_packetrate`.

This PR is a smaller, fix-only alternative focused on the `speed_mbpsrate` path, which I independently reproduced and validated. One difference is that this PR uses quotient/remainder arithmetic, which avoids multiplying the full `bits_sent` value by `1e9` while preserving the fractional remainder after division.

## Changes:

Fixes #974.

This fixes an overflow in the `speed_mbpsrate` timing calculation for long low-rate replays.

Previously, `next_tx_ns` could be calculated as:

```c
(bits_sent * 1000000000) / bps
```

For large captures, `bits_sent * 1000000000` can overflow `COUNTER` before the division. When that happens, `next_tx_ns` can wrap to a much smaller value, which can make `skip_length` become very large. The send loop then skips sleep recalculation and can send the remaining packets too quickly near EOF.

This patch computes the same value using quotient/remainder arithmetic, avoiding multiplication of the full `bits_sent` value by `1e9`.

## Other comments:

Validated with a synthetic 22M-packet UDP pcap at `-M 10`.

Before fix:
- `-T nano`: final average around 10.11 Mbps, with a near-EOF final interval burst
- `-T gtod`: final average around 10.09 Mbps, with a near-EOF final interval burst

After fix:
- `-T nano`: expected 1865.60s, observed 1865.60s, final average 10.00 Mbps
- `-T gtod`: expected 1865.60s, observed 1865.62s, final average 9.99 Mbps

Test environment:
- Ubuntu 24.04.4 LTS under WSL2
- Kernel 6.6.87.2-microsoft-standard-WSL2
- dummy `replay0` interface
- PF_PACKET send()

Also ran `sudo make test` successfully.