### PR TITLE
fix fragroute overflow on packets with too many MPLS labels

### DIFF
--- a/src/fragroute/fragroute.c
+++ b/src/fragroute/fragroute.c
@@ -52,6 +52,14 @@ fragroute_process(fragroute_t *ctx, void *buf, size_t len)
     ctx->first_packet = 0;
     /* save the l2 header of the original packet for later */
     ctx->l2len = get_l2len(buf, (int)len, ctx->dlt);
+    if (ctx->l2len < 0 || (size_t)ctx->l2len > len || (size_t)ctx->l2len > sizeof(ctx->l2header)) {
+        snprintf(ctx->errbuf,
+                 sizeof(ctx->errbuf),
+                 "invalid L2 header length %d for packet length %zu",
+                 ctx->l2len,
+                 len);
+        return -1;
+    }
     memcpy(ctx->l2header, buf, ctx->l2len);
 
     if ((pkt = pkt_new(len)) == NULL) {


### PR DESCRIPTION
l2len has a hardcoded maximum of 50 Bytes in struct fragroute_s. This does not change the maximum value of 50 (12 MPLS labels) and only adds a check to make sure we don't copy over the maximum.

Some thoughts:
* Dynamically allocate enough space to allow an arbitrary number of MPLS labels does not seems like a good idea. In the linked issue, 3000 labels is probably here just to show the issue, and not linked to a real use case?
* This proposed fix does not fix the command in the issue but only the heap buffer overflow it caused: the command will still fail, but this time the error will be raised instead.
* There could be an argument made to change the hardcoded 50 value (which this PR does not do) to allow for 16 labels which is a maximum value I found in some routers. Most have a lower maximum. I believe 12 is enough.

Fixes: https://github.com/appneta/tcpreplay/issues/992
