### PR TITLE
tcprewrite - fix adding vlan tag with missing options

### DIFF
--- a/src/tcpedit/plugins/dlt_en10mb/en10mb.c
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb.c
@@ -364,6 +364,19 @@ dlt_en10mb_parse_opts(tcpeditdlt_t *ctx)
 
                 if (HAVE_OPT(ENET_VLAN_CFI))
                     config->vlan_cfi = OPT_VALUE_ENET_VLAN_CFI;
+
+                /*
+                 * Warn once if priority and/or CFI were not supplied: for
+                 * packets that are not already VLAN tagged there is no
+                 * existing value to preserve, so they default to 0.
+                 */
+                if (!HAVE_OPT(ENET_VLAN_PRI) || !HAVE_OPT(ENET_VLAN_CFI)) {
+                    notice("%s%s%s not specified; previously untagged "
+                           "packets will be tagged with priority 0 and/or CFI 0.",
+                           HAVE_OPT(ENET_VLAN_PRI) ? "" : "--enet-vlan-pri",
+                           (!HAVE_OPT(ENET_VLAN_PRI) && !HAVE_OPT(ENET_VLAN_CFI)) ? " and " : "",
+                           HAVE_OPT(ENET_VLAN_CFI) ? "" : "--enet-vlan-cfi");
+                }
             }
 
             if (HAVE_OPT(ENET_VLAN_PROTO)) {
@@ -495,6 +508,17 @@ dlt_en10mb_encode(tcpeditdlt_t *ctx, u_char *packet, int pktlen, tcpr_dir_t dir)
     extra = (en10mb_extra_t *)ctx->decoded_extra;
     if (ctx->decoded_extra_size < sizeof(*extra))
         return TCPEDIT_ERROR;
+
+    /*
+     * Validate VLAN options *before* mutating the packet buffer below.
+     * A previously untagged packet has no existing VLAN info to fall
+     * back on, so a tag must be supplied by the user in that case
+     * (priority and CFI default to 0).
+     */
+    if (config->vlan == TCPEDIT_VLAN_ADD && !extra->vlan && config->vlan_tag == 65535) {
+        tcpedit_seterr(ctx->tcpedit, "%s", "Non-VLAN tagged packet requires --enet-vlan-tag");
+        return TCPEDIT_ERROR;
+    }
 
     /* figure out the new layer2 length, first for the case: ethernet -> ethernet? */
     if (ctx->decoder->dlt == dlt_value) {
@@ -683,28 +707,25 @@ dlt_en10mb_encode(tcpeditdlt_t *ctx, u_char *packet, int pktlen, tcpr_dir_t dir)
             vlan_hdr->vlan_tci = htons((uint16_t)config->vlan_tag & TCPR_802_1Q_VIDMASK);
         } else if (extra->vlan) {
             vlan_hdr->vlan_tci = htons(extra->vlan_tag);
-        } else {
-            tcpedit_seterr(ctx->tcpedit, "%s", "Non-VLAN tagged packet requires --enet-vlan-tag");
-            return TCPEDIT_ERROR;
         }
+        /* else: a previously-untagged packet without a tag is rejected early
+         * in dlt_en10mb_encode(), before the buffer is mutated */
 
         if (config->vlan_pri < 255) {
             vlan_hdr->vlan_tci += htons((uint16_t)config->vlan_pri << 13);
         } else if (extra->vlan) {
             vlan_hdr->vlan_tci += htons(extra->vlan_pri);
-        } else {
-            tcpedit_seterr(ctx->tcpedit, "%s", "Non-VLAN tagged packet requires --enet-vlan-pri");
-            return TCPEDIT_ERROR;
         }
+        /* else: previously-untagged packet, priority defaults to 0
+         * (warned about once in dlt_en10mb_parse_opts) */
 
         if (config->vlan_cfi < 255) {
             vlan_hdr->vlan_tci += htons((uint16_t)config->vlan_cfi << 12);
         } else if (extra->vlan) {
             vlan_hdr->vlan_tci += htons(extra->vlan_cfi);
-        } else {
-            tcpedit_seterr(ctx->tcpedit, "%s", "Non-VLAN tagged packet requires --enet-vlan-cfi");
-            return TCPEDIT_ERROR;
         }
+        /* else: previously-untagged packet, CFI defaults to 0
+         * (warned about once in dlt_en10mb_parse_opts) */
 
     } else if (config->vlan == TCPEDIT_VLAN_DEL && newl2len > 0) {
         /* all we need for 802.3 is the proto */

--- a/src/tcpedit/plugins/dlt_en10mb/en10mb_opts.def
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb_opts.def
@@ -114,7 +114,10 @@ flag = {
     arg-type    = number;
     flags-must  = enet-vlan;
     arg-range   = "0->4095"; /* VID's are 12bit unsigned int's */
-    doc         = "";
+    doc         = <<- EOText
+Mandatory when @var{--enet-vlan=add} is used on packets that are not already
+VLAN tagged.
+EOText;
 };
 
 flag = {
@@ -124,7 +127,11 @@ flag = {
     arg-type    = number;
     flags-must  = enet-vlan;
     arg-range   = "0->1"; /* one bit */
-    doc         = "";
+    doc         = <<- EOText
+When omitted, the CFI bit of an existing VLAN header is preserved; a newly
+added tag on a previously untagged packet defaults to 0 (a one-time notice
+is printed).
+EOText;
 };
 
 flag = {
@@ -134,7 +141,11 @@ flag = {
     flags-must  = enet-vlan;
     arg-type    = number;
     arg-range   = "0->7"; /* one byte */
-    doc         = "";
+    doc         = <<- EOText
+When omitted, the priority of an existing VLAN header is preserved; a newly
+added tag on a previously untagged packet defaults to 0 (a one-time notice
+is printed).
+EOText;
 };
 
 flag = {


### PR DESCRIPTION
Fix an issue where using tcprewrite to add a vlan tag to untagged packets, and omitting either the `--enet-vlan-cfi`, or the `--enet-vlan-pri` option, the resulting pcap is truncated by 4 bytes (size of vlan header).

This also changes the following so that the vlan tag value is manatory, but the priority and the format are optional:
* Both options `--enet-vlan-pri`/`--enet-vlan-cfi` now explicitly default to 0
* Add a one-time warning if either option is missing, then proceed and use default
* update the doc so that `--enet-vlan-tag` option is marked as mandatory when adding a vlan tag.

The conditions for the issue to happen are a tiny bit more narrow than in the linked issue: for example if the packet is already vlan-tagged, we're not taking the same branch and have no issue (eg. feed the output of the buggy tcprewrite command to itself). Because of this (and following LLM-assisted review advice) I added comments on the branch to explicit the else branches to make it clear this branch is already handled and a warning has been sent during option parsing.

Fixes: https://github.com/appneta/tcpreplay/issues/990
Assisted-by: Claude Opus 4.8
