### PR TITLE
gitignore: share .claude/skills/, document code-review-graph MCP setup

### DIFF
--- a/.claude/skills/debug-issue/skill.md
+++ b/.claude/skills/debug-issue/skill.md
@@ -1,0 +1,27 @@
+---
+name: Debug Issue
+description: Systematically debug issues using graph-powered code navigation
+---
+
+## Debug Issue
+
+Use the knowledge graph to systematically trace and debug issues.
+
+### Steps
+
+1. Use `semantic_search_nodes` to find code related to the issue.
+2. Use `query_graph` with `callers_of` and `callees_of` to trace call chains.
+3. Use `get_flow` to see full execution paths through suspected areas.
+4. Run `detect_changes` to check if recent changes caused the issue.
+5. Use `get_impact_radius` on suspected files to see what else is affected.
+
+### Tips
+
+- Check both callers and callees to understand the full context.
+- Look at affected flows to find the entry point that triggers the bug.
+- Recent changes are the most common source of new issues.
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/explore-codebase/skill.md
+++ b/.claude/skills/explore-codebase/skill.md
@@ -1,0 +1,28 @@
+---
+name: Explore Codebase
+description: Navigate and understand codebase structure using the knowledge graph
+---
+
+## Explore Codebase
+
+Use the code-review-graph MCP tools to explore and understand the codebase.
+
+### Steps
+
+1. Run `list_graph_stats` to see overall codebase metrics.
+2. Run `get_architecture_overview` for high-level community structure.
+3. Use `list_communities` to find major modules, then `get_community` for details.
+4. Use `semantic_search_nodes` to find specific functions or classes.
+5. Use `query_graph` with patterns like `callers_of`, `callees_of`, `imports_of` to trace relationships.
+6. Use `list_flows` and `get_flow` to understand execution paths.
+
+### Tips
+
+- Start broad (stats, architecture) then narrow down to specific areas.
+- Use `children_of` on a file to see all its functions and classes.
+- Use `find_large_functions` to identify complex code.
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/refactor-safely/skill.md
+++ b/.claude/skills/refactor-safely/skill.md
@@ -1,0 +1,28 @@
+---
+name: Refactor Safely
+description: Plan and execute safe refactoring using dependency analysis
+---
+
+## Refactor Safely
+
+Use the knowledge graph to plan and execute refactoring with confidence.
+
+### Steps
+
+1. Use `refactor_tool` with mode="suggest" for community-driven refactoring suggestions.
+2. Use `refactor_tool` with mode="dead_code" to find unreferenced code.
+3. For renames, use `refactor_tool` with mode="rename" to preview all affected locations.
+4. Use `apply_refactor_tool` with the refactor_id to apply renames.
+5. After changes, run `detect_changes` to verify the refactoring impact.
+
+### Safety Checks
+
+- Always preview before applying (rename mode gives you an edit list).
+- Check `get_impact_radius` before major refactors.
+- Use `get_affected_flows` to ensure no critical paths are broken.
+- Run `find_large_functions` to identify decomposition targets.
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/review-changes/skill.md
+++ b/.claude/skills/review-changes/skill.md
@@ -1,0 +1,29 @@
+---
+name: Review Changes
+description: Perform a structured code review using change detection and impact
+---
+
+## Review Changes
+
+Perform a thorough, risk-aware code review using the knowledge graph.
+
+### Steps
+
+1. Run `detect_changes` to get risk-scored change analysis.
+2. Run `get_affected_flows` to find impacted execution paths.
+3. For each high-risk function, run `query_graph` with pattern="tests_for" to check test coverage.
+4. Run `get_impact_radius` to understand the blast radius.
+5. For any untested changes, suggest specific test cases.
+
+### Output Format
+
+Provide findings grouped by risk level (high/medium/low) with:
+- What changed and why it matters
+- Test coverage status
+- Suggested improvements
+- Overall merge recommendation
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.gitignore
+++ b/.gitignore
@@ -100,8 +100,10 @@ build*/
 # Added by code-review-graph
 .code-review-graph/
 # AI
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 .mcp.json
 .opencode.json
 .qoder/
-.gemini
+.gemini/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,3 +178,17 @@ Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
 2. Use `detect_changes` for code review.
 3. Use `get_affected_flows` to understand impact.
 4. Use `query_graph` pattern="tests_for" to check coverage.
+
+### Setup (one-time, per machine)
+
+The MCP server registration (`.mcp.json`, `.claude/settings.json`) is **not** checked into git —
+`code-review-graph install` writes machine-specific absolute paths (your pipx venv location, your
+local repo path) into those files, so a committed copy would be broken on every other machine.
+`.claude/skills/` *is* checked in — it's portable, so re-running `install` should regenerate it
+identically.
+
+```
+pipx install code-review-graph
+code-review-graph install --platform claude-code --repo .
+code-review-graph build --repo .   # first-time graph population; `update` after that is incremental
+```


### PR DESCRIPTION
## Summary
- `.claude/` was blanket-ignored, silently dropping `.claude/skills/{debug-issue,explore-codebase,refactor-safely,review-changes}/skill.md` even though they're portable project docs (verified: no machine-specific paths) — same category as the already-tracked `CLAUDE.md`/`.cursorrules`/etc. Now carved out via `.claude/*` + negation so they're shared with the team.
- `.claude/settings.json`, `.claude/settings.local.json`, `.claude/worktrees/` stay ignored — verified these do carry per-machine absolute paths (pipx venv location, local repo path) and would break on any other contributor's machine if committed as-is.
- `.mcp.json` stays ignored for the same reason (hardcoded interpreter/cwd paths from `code-review-graph install`).
- Added a "Setup (one-time, per machine)" section to `CLAUDE.md` — previously the doc said "ALWAYS use the code-review-graph MCP tools" with no instructions for a fresh clone to actually get the MCP server registered.
- Minor: `.gemini` → `.gemini/` for consistency with the other AI-tool directory entries (`.claude/`, `.qoder/`).

## Test plan
- [x] `git check-ignore -v` confirms `.claude/skills/**` is no longer ignored while `.claude/settings.json` / `.claude/worktrees` still are.
- [x] `git status --ignored` confirms no unintended files pulled in.
- Docs-only + gitignore change, no build/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)