### PR TITLE
fragroute: fix TAILQ_FOREACH_REVERSE portability across queue.h variants

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,6 @@
 Unreleased
+    - fragroute: fix build failure on macOS 13/14 from TAILQ_FOREACH_REVERSE argument-order
+      collision between bundled lib/queue.h and system <sys/queue.h> (#981, #1001)
     - tcpprep: fix buffer overflow in check_dst_port() reading TCP/UDP dest port on truncated
       packets with incomplete L4 headers (#985, #995)
     - tcprewrite: fix --enet-vlan=add silently truncating output packets by 4 bytes when

--- a/src/fragroute/mod.c
+++ b/src/fragroute/mod.c
@@ -177,8 +177,16 @@ mod_close(void)
 {
     struct rule *rule;
 
-    TAILQ_FOREACH_REVERSE(rule, &rules, next, head)
-    {
+    /*
+     * Not using TAILQ_FOREACH_REVERSE: its (field, headname) argument order is
+     * not standardized across BSD queue.h implementations, and this file's
+     * bundled lib/queue.h can lose that macro to a system <sys/queue.h> pulled
+     * in transitively (e.g. via net/if.h on macOS), silently flipping the
+     * argument order tcpreplay was compiled against (#981). TAILQ_LAST/
+     * TAILQ_PREV/TAILQ_END have a consistent signature everywhere, so iterate
+     * with those directly instead.
+     */
+    for (rule = TAILQ_LAST(&rules, head); rule != TAILQ_END(&rules); rule = TAILQ_PREV(rule, head, next)) {
         if (rule->mod->close != NULL)
             rule->data = rule->mod->close(rule->data);
         TAILQ_REMOVE(&rules, rule, next);


### PR DESCRIPTION
## Summary

`mod_close()` in `src/fragroute/mod.c` called `TAILQ_FOREACH_REVERSE(rule, &rules, next, head)`, matching this repo's bundled `lib/queue.h`, which uses a non-standard `(var, head, field, headname)` argument order. Standard BSD `<sys/queue.h>` uses `(var, head, headname, field)` instead.

`mod.c` includes `lib/queue.h` first, but `common.h` pulls in system headers (`net/if.h` and friends) that transitively include the real `<sys/queue.h>` on some platforms — redefining the macro with the opposite argument order and breaking the build. Confirmed via Homebrew's CI on macOS 13/14 (build fails with `fatal error: incomplete definition of type 'struct next'`); macOS 15 and Linux are unaffected because their header graph doesn't pull in `sys/queue.h` from this include chain.

The issue's suggested one-line arg swap just trades one broken platform for the other, since it's still hostage to whichever `queue.h` wins the macro collision — the reporter's own follow-up CI run demonstrated the reversal (macOS 13/14 pass, Linux/macOS 15 fail).

This PR instead drops `TAILQ_FOREACH_REVERSE` for the single call site and iterates manually with `TAILQ_LAST`/`TAILQ_PREV`/`TAILQ_END`, whose signatures are identical across every BSD `queue.h` implementation — no collision possible regardless of which header wins.

Fixes #981

## Test plan

- [x] Built clean out-of-tree on macOS (Darwin, this repo's existing `build/`) — `make` in `src/fragroute` compiles `mod.c` with no warnings, links `tcprewrite`
- [x] CI (Linux) — no macOS runner in this repo's workflows, so macOS 13/14 regression can only be verified via reporter's Homebrew CI or manual confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)