### PR TITLE
sendpacket: stop inhibiting libbpf's default XDP program load for AF_XDP TX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1476,14 +1476,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <xdp/xsk.h>
 #include <sys/socket.h>
 ]], [[
-    struct xsk_socket {
-        struct xsk_ring_cons *rx;
-        struct xsk_ring_prod *tx;
-        struct xsk_ctx *ctx;
-        struct xsk_socket_config config;
-        int fd;
-    };
-    struct xsk_socket xsk;
+    struct xsk_socket *xsk = NULL;
 	struct xsk_ring_cons *rxr = NULL;
 	struct xsk_ring_prod *txr = NULL;
     int queue_id = 0;

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,8 +1,9 @@
 Unreleased
-    - sendpacket: --xdp AF_XDP zero-copy TX failing with EINVAL on drivers (i40e, ixgbe,
-      virtio_net, ...) that require a native XDP program attached before ndo_xdp_xmit works;
-      let libbpf auto-load its default program instead of inhibiting it (#956) [UNVERIFIED on
-      affected hardware - needs testing before promoting past beta]
+    - sendpacket: fix --xdp AF_XDP zero-copy TX failing with EINVAL on drivers (i40e, ixgbe)
+      that require a native XDP program attached before ndo_xdp_xmit works; let libbpf
+      auto-load its default program instead of inhibiting it (#956, #1002)
+    - configure: fix LIBXDP feature probe rejecting every real libxdp install due to a
+      pointer-indirection mismatch in the xsk_socket__create() compile check (#1002)
     - fragroute: fix build failure on macOS 13/14 from TAILQ_FOREACH_REVERSE argument-order
       collision between bundled lib/queue.h and system <sys/queue.h> (#981, #1001)
     - tcpprep: fix buffer overflow in check_dst_port() reading TCP/UDP dest port on truncated

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,8 @@
 Unreleased
+    - sendpacket: --xdp AF_XDP zero-copy TX failing with EINVAL on drivers (i40e, ixgbe,
+      virtio_net, ...) that require a native XDP program attached before ndo_xdp_xmit works;
+      let libbpf auto-load its default program instead of inhibiting it (#956) [UNVERIFIED on
+      affected hardware - needs testing before promoting past beta]
     - fragroute: fix build failure on macOS 13/14 from TAILQ_FOREACH_REVERSE argument-order
       collision between bundled lib/queue.h and system <sys/queue.h> (#981, #1001)
     - tcpprep: fix buffer overflow in check_dst_port() reading TCP/UDP dest port on truncated

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -1525,7 +1525,17 @@ create_xsk_socket(struct xsk_umem_info *umem_info,
 
     socket_config->rx_size = nb_of_rx_queue_desc;
     socket_config->tx_size = nb_of_tx_queue_desc;
-    socket_config->libbpf_flags = XSK_LIBBPF_FLAGS__INHIBIT_PROG_LOAD;
+    /*
+     * Some NIC drivers (i40e, ixgbe, virtio_net, ...) only set up their XDP TX
+     * datapath (ndo_xdp_xmit) once a native XDP program is attached to the
+     * interface; without one, xsk_socket__create() binds successfully but the
+     * later zero-copy send fails with EINVAL. XSK_LIBBPF_FLAGS__INHIBIT_PROG_LOAD
+     * skips libbpf's default program auto-load, which avoided that trigger.
+     * tcpreplay doesn't need the auto-loaded program's RX behavior, only the
+     * side effect of a program being attached, so let libbpf load its default
+     * one (#956).
+     */
+    socket_config->libbpf_flags = 0;
     socket_config->bind_flags = 0; // XDP_FLAGS_SKB_MODE (1U << 1) or XDP_FLAGS_DRV_MODE (1U << 2)
     xsk_info = xsk_configure_socket(umem_info, socket_config, queue_id, device);
     safe_free(socket_config);


### PR DESCRIPTION
## Summary

Fixes #956 — `--xdp` failing with `EINVAL` ("XDP is either not supported by this underlying network driver, or it has a bug") on real NICs: Intel XL710 (i40e), Intel X520 (ixgbe), and virtio_net, per multiple reporters in the issue thread.

**Root cause**: `sendpacket_open_xsk()` → `create_xsk_socket()` set `XSK_LIBBPF_FLAGS__INHIBIT_PROG_LOAD`, skipping libbpf's default auto-attached XDP program (tcpreplay is TX-only and doesn't need the RX-redirect behavior that program provides). But several drivers only enable their `ndo_xdp_xmit` TX datapath once *some* native XDP program is attached to the interface — without one, `xsk_socket__create()` still succeeds, but the first zero-copy send fails with `EINVAL`.

**Fix**: drop the inhibit flag so libbpf auto-loads its default program. That's enough to trigger the driver's XDP TX setup, even though tcpreplay doesn't use the RX side of it. `xsk_socket__delete()` (already called on close) tears the auto-loaded program down.

This is the same class of workaround `xdp-tools`' `xdp-trafficgen` uses for the same driver behavior, but simpler — uses libbpf's own default program instead of shipping/attaching a custom `xdp_pass` eBPF object.

## Second bug found along the way

While testing this, hit a pre-existing, unrelated bug: `./configure`'s `LIBXDP` feature probe rejected every real libxdp install. It locally redefined `struct xsk_socket` with guessed fields (leftover from the old header-only sample `xsk.h`, predating this project linking the real libxdp shared library) and passed `&xsk` — a `struct xsk_socket *` — to `xsk_socket__create()`, whose first param is `struct xsk_socket **`. Pointer-indirection mismatch → probe always failed to compile → `HAVE_LIBXDP` never got defined → `--xdp` silently compiled out regardless of what was installed. Fixed in the same PR since the #956 fix can't be built or tested without it.

## Verification

Confirmed by @fklassen:
- Compiles cleanly with the fixed `configure` probe (`LIBXDP for AF_XDP socket: yes`)
- `--xdp` works on i40e (XL710) and ixgbe (X520) — the two drivers reported broken in #956
- No regression on veth / virtio_net (previously-working paths)

## Test plan

- [x] Compiles cleanly (CI has `libxdp-dev`)
- [x] Real-hardware verified on i40e (XL710) and ixgbe (X520)
- [x] No regression on veth / virtio_net

🤖 Generated with [Claude Code](https://claude.com/claude-code)