### PR TITLE
tcpreplay: fix --multiplier timing drift (takes over #915)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,9 @@
 Unreleased
+    - tcpreplay: fix cumulative timing drift with --multiplier - each packet's sleep was computed
+      from the previous packet's actual send time instead of a fixed start-of-replay anchor, so
+      per-packet scheduling/syscall overhead accumulated over a long replay (100k packets sent in
+      10.37s instead of the targeted 10.00s). Also fixes the same drift in dual-interface (-I)
+      replay, which the original patch didn't cover. (#724, #915)
     - sendpacket (Linux): warn when sending on an interface with no carrier (cable unplugged /
       link down); sendto() on a down interface can report local success even though nothing
       reaches the wire, making "successful packets" stats meaningless (#109)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -34,6 +34,8 @@ typedef struct {
     struct timespec end_time;
     struct timespec pkt_ts_delta;
     struct timespec last_print;
+    struct timespec first_packet_time;
+    struct timespec first_packet_wall_time;
     COUNTER flow_non_flow_packets;
     COUNTER flows;
     COUNTER flows_unique;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -618,6 +618,7 @@ void
 send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *pcap2, int cache_file_idx2)
 {
     struct timespec now, print_delta, last_pkt_ts;
+    bool first_packet = true;
     tcpreplay_opt_t *options = ctx->options;
     tcpreplay_stats_t *stats = &ctx->stats;
     COUNTER packetnum = 0;
@@ -757,26 +758,25 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             skip_length = 0;
             ctx->skip_packets = 0;
 
-            if (options->speed.mode == speed_multiplier) {
-                struct timespec pkthdr_ts;
-                PCAP_TIMEVAL_TO_TIMESPEC_SET(&pkthdr_ptr->ts, &pkthdr_ts);
-                if (!timesisset(&last_pkt_ts)) {
-                    PCAP_TIMEVAL_TO_TIMESPEC_SET(&pkthdr_ptr->ts, &last_pkt_ts);
-                } else if (timescmp(&pkthdr_ts, &last_pkt_ts, >)) {
-                    struct timespec delta;
-
-                    timessub(&pkthdr_ts, &last_pkt_ts, &delta);
-                    timeradd_timespec(&stats->pkt_ts_delta, &delta, &stats->pkt_ts_delta);
-                    TIMESPEC_SET(&last_pkt_ts, &pkthdr_ts);
-                }
-
-                if (!timesisset(&stats->time_delta))
-                    TIMESPEC_SET(&stats->pkt_ts_delta, &stats->pkt_ts_delta);
-            }
-
             if (!top_speed) {
                 get_current_time(&now);
                 now_is_now = true;
+            }
+
+            if (options->speed.mode == speed_multiplier) {
+                struct timespec pkthdr_ts;
+                PCAP_TIMEVAL_TO_TIMESPEC_SET(&pkthdr_ptr->ts, &pkthdr_ts);
+                if (first_packet) {
+                    TIMESPEC_SET(&stats->first_packet_time, &pkthdr_ts);
+                    TIMESPEC_SET(&last_pkt_ts, &pkthdr_ts);
+                    TIMESPEC_SET(&stats->first_packet_wall_time, &now);
+                    first_packet = false;
+                } else if (timescmp(&pkthdr_ts, &last_pkt_ts, >)) {
+                    TIMESPEC_SET(&last_pkt_ts, &pkthdr_ts);
+                    timessub(&pkthdr_ts, &stats->first_packet_time, &stats->pkt_ts_delta);
+                    timessub(&now, &stats->first_packet_wall_time, &stats->time_delta);
+                    timesdiv_float(&stats->pkt_ts_delta, options->speed.multiplier);
+                }
             }
 
             /*
@@ -794,13 +794,6 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
                             &stats->end_time,
                             TIMESPEC_TO_NANOSEC(&stats->start_time),
                             &skip_length);
-
-            /*
-             * Track the time of the "last packet sent".
-             *
-             * A number of 3rd party tools generate bad timestamps which go backwards
-             * in time.  Hence, don't update the "last" unless pkthdr_ptr->ts > last
-             */
 
             /*
              * we know how long to sleep between sends, now do it.


### PR DESCRIPTION
## Summary

Fixes #724 — takes over #915 (thank you @Sup3rGeo for the original patch and root-cause work), retargeted onto `v4.5.3-beta1` and extended to cover `send_dual_packets()`, which the original was missing.

**Root cause**: `speed_multiplier` mode (`-p`/`--multiplier`) computed each packet's sleep duration from a **cumulative running sum** of packet-timestamp deltas (`calc_sleep_time()`, `speed_multiplier` case) rather than from a fixed anchor point. Every `nanosleep`/`select` call oversleeps slightly due to scheduling/syscall overhead, and with no correction those overshoots accumulate over a long replay. `speed_mbpsrate` and `speed_packetrate` (same function) already avoid this by computing a target time from a fixed `start_ns` and comparing against actual elapsed time each iteration (self-correcting) — `speed_multiplier` never got the same treatment.

This was attempted broadly in #631, broke `--multiplier < 1.0` combined with `--loop` (#674 — only the first loop iteration got scaled), and was reverted (#699). #724 is that regression being re-reported since the underlying drift bug came back with the revert.

**Fix** (cherry-picked from #915, `98f6180c`): anchor `first_packet_time`/`first_packet_wall_time` once at the start of replay, then compute both `pkt_ts_delta` (offset from anchor in packet-timestamp space) and `time_delta` (offset from anchor in wall-clock space) every packet, instead of accumulating deltas from the previous packet. Mirrors the pattern already proven in `speed_mbpsrate`/`speed_packetrate`.

**What I added on top of #915**: `send_dual_packets()` (`-I`/dual-interface replay) still had the old cumulative-accumulation code, while `calc_sleep_time()`'s `speed_multiplier` case had its `timesdiv_float(multiplier)` call removed globally by #915 (moved into the per-call-site anchor computation instead). Left as-is, dual-interface replay's `--multiplier` would have silently done nothing at all. Ported the identical anchor-based fix into `send_dual_packets()`.

## Why the maintainer's original performance concern doesn't apply

fklassen shelved #915 citing "introduces a timestamp for every packet... incredible impact on performance." I checked: `get_current_time(&now)` was already called unconditionally for every non-topspeed packet *before* #915 — the PR only moves that existing call a few lines earlier in the same iteration so its result is available to the `speed_multiplier` branch. No new syscalls; just `timessub`/`timesdiv_float` arithmetic already used elsewhere in the same function.

## Verification

Built and tested locally (macOS, on `lo0`/`en0`/`en1` — this environment's testnic), against a baseline build of unmodified `v4.5.3-beta1` for comparison:

**#724 (drift)** — 100,000 synthetic packets, 1ms apart, `--multiplier=10` (target: 10.00s):
```
baseline (unfixed): 10.37s  (3.7% over)
fixed:                9.99s  (0.1% under)
```

**#674 (multiplier<1.0 + --loop regression check)** — 50 packets, 20ms apart, `--multiplier=0.5`, `--loop=1/2/3` (target: 1.96s per loop, linear):
```
                  loop=1   loop=2   loop=3
baseline (unfixed): 1.96s    3.92s    5.88s   (already correct - #699's revert holds)
fixed:               1.96s    3.92s    5.88s   (still correct - no regression)
```

**send_dual_packets (-I) with --multiplier=10** (not covered by #915, added here) — 500 packets, 50ms apart, target 2.495s:
```
fixed: 2.49s, 500/500 successful on each interface
```

- [x] Full local test suite: 69/69 OK, no regressions (includes existing Multiplier, Packets/sec Multiplier, and Dual file tests)
- [x] Drift eliminated (#724): 3.7% error → 0.1% error over 100k packets
- [x] No #674 regression: `--multiplier<1.0` + `--loop` still scales linearly across loop iterations
- [x] `send_dual_packets()` gap closed: dual-interface `--multiplier` verified working (wasn't in #915, would have silently broken)

Closing #915 in favor of this PR, crediting the original patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)