### PR TITLE
sendpacket: route "zc:" PF_RING ZC device names through libpcap

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,8 @@
 Unreleased
+    - sendpacket: fix "zc:<ifname>"-style PF_RING ZC device names failing with "ioctl: No such
+      device" - the default PF_PACKET path did a plain SIOCGIFINDEX lookup on the literal "zc:"
+      string, which the kernel doesn't recognize; route zc: devices through libpcap instead, which
+      is PF_RING-aware when built against PF_RING's patched libpcap (#913)
     - netmap: fix --netmap failing to switch the driver to bypass mode with a bogus "nm_do_ioctl:
       No such file or directory" error on real NICs (not VALE ports); a stray switch default case
       made nm_do_ioctl() report failure - and leak the ioctl socket fd - for SIOCSIFFLAGS/ethtool

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -213,7 +213,7 @@ static struct tcpr_ether_addr *sendpacket_get_hwaddr_libdnet(sendpacket_t *) _U_
 #endif /* HAVE_LIBDNET */
 
 #if (defined HAVE_PCAP_INJECT || defined HAVE_PCAP_SENDPACKET) &&                                                      \
-        !(defined HAVE_PF_PACKET || defined BPF || defined HAVE_LIBDNET)
+        (defined HAVE_PF_RING_PCAP || !(defined HAVE_PF_PACKET || defined BPF || defined HAVE_LIBDNET))
 static sendpacket_t *sendpacket_open_pcap(const char *, char *) _U_;
 static struct tcpr_ether_addr *sendpacket_get_hwaddr_pcap(sendpacket_t *) _U_;
 #endif /* HAVE_PCAP_INJECT || HAVE_PACKET_SENDPACKET */
@@ -626,6 +626,21 @@ sendpacket_open(const char *device,
             sp = sendpacket_open_tuntap(device, errbuf);
 #endif
         } else {
+#if defined HAVE_PF_RING_PCAP && (defined HAVE_PCAP_INJECT || defined HAVE_PCAP_SENDPACKET)
+            /*
+             * "zc:<ifname>"-style device names are PF_RING ZC's own virtual
+             * device addressing, resolved by PF_RING's patched libpcap - not
+             * by the kernel. The PF_PACKET path below does a plain
+             * SIOCGIFINDEX lookup on the literal device string, which always
+             * fails with ENODEV for these ("ioctl: No such device"), even
+             * though the interface itself is working (confirmed via
+             * PF_RING's own pfsend utility - see #913). Route zc: devices
+             * through libpcap instead, which is PF_RING-aware in this build.
+             */
+            if (strncmp(device, "zc:", 3) == 0)
+                sp = sendpacket_open_pcap(device, errbuf);
+            else
+#endif
 #ifdef HAVE_NETMAP
             if (sendpacket_type == SP_TYPE_NETMAP)
                 sp = (sendpacket_t *)sendpacket_open_netmap(device, errbuf, arg);
@@ -759,9 +774,7 @@ sendpacket_close(sendpacket_t *sp)
         break;
 
     case SP_TYPE_LIBPCAP:
-#ifdef HAVE_LIBPCAP
         pcap_close(sp->handle.pcap);
-#endif
         break;
 
     case SP_TYPE_LIBPCAP_DUMP:
@@ -867,7 +880,7 @@ sendpacket_seterr(sendpacket_t *sp, const char *fmt, ...)
 }
 
 #if (defined HAVE_PCAP_INJECT || defined HAVE_PCAP_SENDPACKET) &&                                                      \
-        !(defined HAVE_PF_PACKET || defined BPF || defined HAVE_LIBDNET)
+        (defined HAVE_PF_RING_PCAP || !(defined HAVE_PF_PACKET || defined BPF || defined HAVE_LIBDNET))
 /**
  * Inner sendpacket_open() method for using libpcap
  */


### PR DESCRIPTION
## Summary

Fixes #913 — `tcpreplay -i zc:ens160` (PF_RING ZC device naming) fails with `ioctl: No such device`, even though PF_RING itself is working correctly on that interface.

**Root cause**: `sendpacket_open()` always prefers `PF_PACKET` over libpcap on Linux, regardless of what libpcap was actually compiled against. `"zc:<ifname>"`-style device names are PF_RING ZC's own virtual device addressing, resolved by PF_RING's patched libpcap — not by the kernel. The `PF_PACKET` path's `get_iface_index()` does a plain `SIOCGIFINDEX` ioctl on the literal device string `"zc:ens160"`; the kernel has no interface actually named that, so it always fails with `ENODEV` → `"ioctl: No such device"`, matching the report exactly.

The reporter already proved this is tcpreplay-side, not a PF_RING problem: PF_RING's own `pfsend` utility sends fine on the identical `zc:ens160` device string.

tcpreplay already *knows about* `zc:` devices — `interface.c` formats them that way for `--listnics` under `HAVE_PF_RING_PCAP` — it just never routed `sendpacket_open()` to the one backend that understands the naming (libpcap, PF_RING-aware when built against PF_RING's patched libpcap).

**Fix**: route `"zc:"`-prefixed device names to `sendpacket_open_pcap()`. That function's build guard previously only allowed it when *no* native method (PF_PACKET/BPF/libdnet) was available at all — widened it to also compile when `HAVE_PF_RING_PCAP` is set, since a typical PF_RING-enabled Linux build has PF_PACKET too.

**Adjacent fix, same file**: `sendpacket_close()`'s `SP_TYPE_LIBPCAP` case was guarded by `#ifdef HAVE_LIBPCAP` — a macro `configure.ac` never actually defines (confirmed via `config.h`). `pcap_close()` was dead code on *every* build configuration. Newly reachable now that `SP_TYPE_LIBPCAP` compiles in alongside `PF_PACKET`; removed the bogus guard.

**Explicitly not fixed (out of scope)**: `tcpbridge`'s `sendpacket_get_hwaddr()` dispatches by compile-time `#elif` on which native method is available, not by the `sendpacket_t`'s actual runtime `handle_type` — so a `zc:` interface opened via libpcap would still hit `sendpacket_get_hwaddr_pf()` there and read the wrong union member. Pre-existing architectural issue, not part of #913's report (plain `tcpreplay`, not `tcpbridge`), and riskier to change without a clearer motivating case.

## Verification

Better than usual for a niche-dependency fix: **force-compiled** `sendpacket.c` with `-DHAVE_PF_RING_PCAP=1` added to this build's real flags (which already has `BPF`+libpcap, structurally equivalent gating to the reporter's `PF_PACKET`+PF_RING Linux setup) — compiles clean with `-Wall -Wextra`, zero warnings. `nm` on the resulting object confirms `pcap_open_live`/`pcap_inject`/`pcap_get_selectable_fd` are referenced, i.e. `sendpacket_open_pcap()` actually got compiled in, not eliminated.

Could not test actual PF_RING ZC runtime behavior — no PF_RING install available (niche dependency: patched libpcap + numa/pthread prereqs).

## Test plan

- [x] Force-compiled with `HAVE_PF_RING_PCAP` defined — clean, `-Wall -Wextra`, confirmed via `nm` the new code path is actually compiled in
- [x] Normal (no PF_RING) build unaffected — full local test suite still 69/69
- [ ] Real PF_RING ZC install — confirm `-i zc:ens160` actually opens and sends
- [ ] `--listnics` still lists `zc:` devices as before (unaffected by this change, but worth double-checking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)