### PR TITLE
tcprewrite: rewrite addresses embedded in ICMPv6 error messages

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,10 @@
 Unreleased
+    - tcprewrite: rewrite IPv6 addresses embedded in ICMPv6 error messages (Destination
+      Unreachable, Packet Too Big, Time Exceeded, Parameter Problem) - RFC4443 has these embed the
+      original ("invoking") packet's IP header, which tcprewrite left untouched, leaking the
+      original addresses through capture sanitization/anonymization; also fixed a related
+      pre-existing bug where the ICMPv6 checksum was never fixed up when an outer IPv6 address
+      changed, unless --fixcsum was also passed (#818)
     - sendpacket: fix "zc:<ifname>"-style PF_RING ZC device names failing with "ioctl: No such
       device" - the default PF_PACKET path did a plain SIOCGIFINDEX lookup on the literal "zc:"
       string, which the kernel doesn't recognize; route zc: devices through libpcap instead, which

--- a/src/tcpedit/edit_packet.c
+++ b/src/tcpedit/edit_packet.c
@@ -309,6 +309,14 @@ ipv6_addr_csum_replace(ipv6_hdr_t *ip6_hdr, struct tcpr_in6_addr *old_ip, struct
     switch (protocol) {
     case IPPROTO_UDP:
     case IPPROTO_TCP:
+    case IPPROTO_ICMP6:
+        /*
+         * ICMPv6's checksum covers a pseudo-header (src/dst IP) same as
+         * TCP/UDP, per RFC 4443 2.3 - so it needs the same fixup when an
+         * outer address changes. This case was missing, so rewriting the
+         * IPv6 address on any ICMPv6 packet left a stale checksum unless
+         * --fixcsum was also passed (#818).
+         */
         l4 = get_layer4_v6(ip6_hdr, (u_char *)ip6_hdr + l3len);
         break;
     default:
@@ -908,59 +916,101 @@ rewrite_ipv6l3(tcpedit_t *tcpedit, ipv6_hdr_t *ip6_hdr, tcpr_dir_t direction, in
     }
 
     /* anything else to rewrite? */
-    if (tcpedit->cidrmap1 == NULL)
-        return (0);
+    if (tcpedit->cidrmap1 != NULL) {
+        /* don't play with the main pointers */
+        if (direction == TCPR_DIR_C2S) {
+            cidrmap1 = tcpedit->cidrmap1;
+            cidrmap2 = tcpedit->cidrmap2;
+        } else {
+            cidrmap1 = tcpedit->cidrmap2;
+            cidrmap2 = tcpedit->cidrmap1;
+        }
 
-    /* don't play with the main pointers */
-    if (direction == TCPR_DIR_C2S) {
-        cidrmap1 = tcpedit->cidrmap1;
-        cidrmap2 = tcpedit->cidrmap2;
-    } else {
-        cidrmap1 = tcpedit->cidrmap2;
-        cidrmap2 = tcpedit->cidrmap1;
+        /* loop through the cidrmap to rewrite */
+        do {
+            if ((!diddst) && ip6_in_cidr(cidrmap2->from, &ip6_hdr->ip_dst)) {
+                struct tcpr_in6_addr old_ip6;
+                memcpy(&old_ip6, &ip6_hdr->ip_dst, sizeof(old_ip6));
+                remap_ipv6(tcpedit, cidrmap2->to, &ip6_hdr->ip_dst);
+                ipv6_addr_csum_replace(ip6_hdr, &old_ip6, &ip6_hdr->ip_dst, l3len);
+                dbgx(2, "Remapped dst addr to: %s", get_addr2name6(&ip6_hdr->ip_dst, RESOLVE));
+                diddst = 1;
+            }
+            if ((!didsrc) && ip6_in_cidr(cidrmap1->from, &ip6_hdr->ip_src)) {
+                struct tcpr_in6_addr old_ip6;
+                memcpy(&old_ip6, &ip6_hdr->ip_src, sizeof(old_ip6));
+                remap_ipv6(tcpedit, cidrmap1->to, &ip6_hdr->ip_src);
+                ipv6_addr_csum_replace(ip6_hdr, &old_ip6, &ip6_hdr->ip_src, l3len);
+                dbgx(2, "Remapped src addr to: %s", get_addr2name6(&ip6_hdr->ip_src, RESOLVE));
+                didsrc = 1;
+            }
+
+            /*
+             * loop while we haven't modified both src/dst AND
+             * at least one of the cidr maps have a next pointer
+             */
+            if ((!(diddst && didsrc)) && (!((cidrmap1->next == NULL) && (cidrmap2->next == NULL)))) {
+                /* increment our ptr's if possible */
+                if (cidrmap1->next != NULL)
+                    cidrmap1 = cidrmap1->next;
+
+                if (cidrmap2->next != NULL)
+                    cidrmap2 = cidrmap2->next;
+
+            } else {
+                loop = 0;
+            }
+
+            /* Later on we should support various IP protocols which embed
+             * the IP address in the application layer.  Things like
+             * DNS and FTP.
+             */
+
+        } while (loop);
     }
 
-    /* loop through the cidrmap to rewrite */
-    do {
-        if ((!diddst) && ip6_in_cidr(cidrmap2->from, &ip6_hdr->ip_dst)) {
-            struct tcpr_in6_addr old_ip6;
-            memcpy(&old_ip6, &ip6_hdr->ip_dst, sizeof(old_ip6));
-            remap_ipv6(tcpedit, cidrmap2->to, &ip6_hdr->ip_dst);
-            ipv6_addr_csum_replace(ip6_hdr, &old_ip6, &ip6_hdr->ip_dst, l3len);
-            dbgx(2, "Remapped dst addr to: %s", get_addr2name6(&ip6_hdr->ip_dst, RESOLVE));
-            diddst = 1;
+    /*
+     * RFC4443 ICMPv6 error messages (Destination Unreachable, Packet Too
+     * Big, Time Exceeded, Parameter Problem) embed as much of the
+     * "invoking" packet as fits, including its IPv6 header. Recurse into
+     * it so those addresses get rewritten too - otherwise sanitizing a
+     * capture with tcprewrite silently leaks the original addresses in
+     * every ICMPv6 error response (#818). Informational types (echo,
+     * neighbor discovery, MLD, ...) don't embed a packet and are skipped.
+     *
+     * The embedded header's own checksum fixup piggybacks on whatever this
+     * recursive call does for its own L4 (e.g. a TCP/UDP checksum inside
+     * the embedded packet, if fully present). The outer ICMPv6 checksum
+     * covering the whole message (header + embedded packet) is not
+     * incrementally patched here - use --fixcsum for a fully correct
+     * checksum, same as the reproduction steps in #818.
+     */
+    if (l3len > 0) {
+        const u_char *end_ptr = (const u_char *)ip6_hdr + l3len;
+        uint8_t l4proto = get_ipv6_l4proto(ip6_hdr, end_ptr);
+
+        if (l4proto == IPPROTO_ICMP6) {
+            icmpv6_hdr_t *icmp6 = (icmpv6_hdr_t *)get_layer4_v6(ip6_hdr, end_ptr);
+
+            if (icmp6 != NULL && (const u_char *)icmp6 + sizeof(*icmp6) <= end_ptr) {
+                switch (icmp6->icmp_type) {
+                case ICMP6_UNREACH:
+                case ICMP6_PKTTOOBIG:
+                case ICMP6_TIMXCEED:
+                case ICMP6_PARAMPROB: {
+                    ipv6_hdr_t *embedded = (ipv6_hdr_t *)((u_char *)icmp6 + sizeof(*icmp6));
+                    int embedded_len = (int)(end_ptr - (const u_char *)embedded);
+
+                    if (embedded_len >= (int)sizeof(ipv6_hdr_t) && ((ipv4_hdr_t *)embedded)->ip_v == 6)
+                        rewrite_ipv6l3(tcpedit, embedded, direction, embedded_len);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
         }
-        if ((!didsrc) && ip6_in_cidr(cidrmap1->from, &ip6_hdr->ip_src)) {
-            struct tcpr_in6_addr old_ip6;
-            memcpy(&old_ip6, &ip6_hdr->ip_src, sizeof(old_ip6));
-            remap_ipv6(tcpedit, cidrmap1->to, &ip6_hdr->ip_src);
-            ipv6_addr_csum_replace(ip6_hdr, &old_ip6, &ip6_hdr->ip_src, l3len);
-            dbgx(2, "Remapped src addr to: %s", get_addr2name6(&ip6_hdr->ip_src, RESOLVE));
-            didsrc = 1;
-        }
-
-        /*
-         * loop while we haven't modified both src/dst AND
-         * at least one of the cidr maps have a next pointer
-         */
-        if ((!(diddst && didsrc)) && (!((cidrmap1->next == NULL) && (cidrmap2->next == NULL)))) {
-            /* increment our ptr's if possible */
-            if (cidrmap1->next != NULL)
-                cidrmap1 = cidrmap1->next;
-
-            if (cidrmap2->next != NULL)
-                cidrmap2 = cidrmap2->next;
-
-        } else {
-            loop = 0;
-        }
-
-        /* Later on we should support various IP protocols which embed
-         * the IP address in the application layer.  Things like
-         * DNS and FTP.
-         */
-
-    } while (loop);
+    }
 
     /* return how many changes we require checksum updates
      * (none required - checksum is already updated)


### PR DESCRIPTION
## Summary

Fixes #818 — `tcprewrite` doesn't rewrite IPv6 addresses embedded inside ICMPv6 error messages.

RFC 4443 §3 has Destination Unreachable, Packet Too Big, Time Exceeded, and Parameter Problem messages embed "as much of the invoking packet as possible" — including its IPv6 header. `rewrite_ipv6l3()` only ever ran once per packet, on the outer header, so `--pnat`/`--seed`/`--endpoints` left the embedded original addresses untouched. Two real problems: rewritten captures aren't RFC4443-compliant, and using `tcprewrite` for capture sanitization/anonymization **silently leaked the original addresses** through every ICMPv6 error message in the capture.

## Fix

After rewriting the outer header's addresses, check if the L4 protocol is ICMPv6 and the type is one of the four error types (informational types — echo, neighbor discovery, MLD, etc — don't embed a packet and are left alone). If so, locate the embedded IPv6 header and **recurse `rewrite_ipv6l3()` on it** — reuses the exact same address-rewrite logic, including whatever further recursion the embedded payload itself needs (e.g. a TCP/UDP checksum inside the embedded packet, if fully present rather than truncated). Bounds-checked against the actual captured length throughout; naturally terminates since each recursion level consumes real bytes from a fixed-size input.

Had to restructure one thing to make this correct: the function had an early `return (0)` right after the `--srcipmap`/`--dstipmap` loops whenever no `--pnat` cidrmap was configured, which would've skipped the new ICMPv6 check entirely for ipmap-only usage. Turned that into a conditional block instead so the check always runs regardless of which rewrite mode is active.

**Adjacent pre-existing bug fixed while touching this code**: `ipv6_addr_csum_replace()`'s protocol switch (patches the L4 checksum when an *outer* IPv6 address changes) only handled TCP/UDP — ICMPv6 was missing, even though ICMPv6's checksum covers a pseudo-header (src/dst IP) exactly like TCP/UDP per RFC4443 §2.3. Every ICMPv6 packet's checksum went stale after *any* IPv6 address rewrite unless `--fixcsum` was separately passed. Added the missing case.

**Checksum scope note**: full correctness for the *embedded* header's changes (the outer ICMPv6 checksum, which covers the whole message including the now-edited embedded bytes) relies on `--fixcsum` doing a full recompute — same as this issue's own reproduction steps. Deliberately didn't hand-roll incremental multi-address checksum delta math for that case (`do_checksum()` already does a correct full recompute over current byte content regardless of what's inside, so `--fixcsum` "just works" here).

## Verification

Downloaded the reporter's actual attached `ttl.pcap` and ran their literal reproduction command against both this fix and an unmodified `v4.5.3-beta1` baseline:

```
tcprewrite --pnat=[2001:0DB8:85A3:08D3::/64]:[2001:0db8:FFFF:FFFF::/64] --infile=ttl.pcap --outfile=out.pcap --fixcsum
```

**Baseline** — embedded packet inside the Time Exceeded message still shows the original `2001:0db8:85a3:08d3::666`:
```
0x0030:  6000 0000 0008 3a01 2001 0db8 85a3 08d3   <- leaked
0x0040:  0000 0000 0000 0666 2a00 1450 4009 0827
```

**Fixed** — embedded packet correctly shows the rewritten address:
```
0x0030:  6000 0000 0008 3a01 2001 0db8 ffff ffff   <- rewritten
0x0040:  0000 0000 0000 0666 2a00 1450 4009 0827
```

`tcpdump -v` independently validates both ICMPv6 checksums as `[icmp6 sum ok]` on the fixed output.

## Scope note

This PR only touches IPv6 (`rewrite_ipv6l3`), matching what was reported. ICMPv4 error messages have the analogous RFC 792/1812 embedding behavior and presumably the same gap in `rewrite_ipv4l3()` — didn't touch it here to keep this PR scoped to what was actually reported and verified; flagging as a natural, well-defined follow-up if wanted.

## Test plan

- [x] Real end-to-end verification against the reporter's own pcap and exact command
- [x] Confirmed via `tcpdump -X` byte-level diff: embedded address leak in baseline, fixed in this PR
- [x] Confirmed via `tcpdump -v`: `[icmp6 sum ok]` on both rewritten packets
- [x] Full local test suite: 69/69, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)