### PR TITLE
docs: document autogen.sh requirement for git checkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,18 @@ for detailed download and installation instructions.
 
 Simple directions for Unix users:
 ---------------------------------
+If you're building from a release tarball, `configure` is already generated:
 ```
 ./configure 
+make
+sudo make install
+```
+
+If you're building from a git checkout, `configure` doesn't exist yet - generate it
+first with `autogen.sh` (requires `autoconf`, `automake`, `libtool`, and `autogen`):
+```
+./autogen.sh
+./configure
 make
 sudo make install
 ```


### PR DESCRIPTION
## Summary

Fixes #568 — README's "Simple directions for Unix users" only showed:
```
./configure
make
sudo make install
```
This only works from a release tarball, where `configure` is pre-generated (`make dist`). A fresh git clone has no `configure` script at all until `autogen.sh` runs — missing that step is the first thing anyone hits building from source, exactly as reported in 2019 and still true today (verified — the file still reads this way on current `v4.5.3-beta1`).

## Fix

Split the section into two cases: release tarball (unchanged) vs. git checkout (new — `autogen.sh` first, with its prereqs noted). Matches the build flow already documented correctly in this repo's `CLAUDE.md`.

Didn't touch `docs/INSTALL` — that's the stock GNU autotools boilerplate template, not project-specific, and not where the report or a typical reader would look first (the issue itself references `README.md` and the wiki page). The wiki page (`tcpreplay.appneta.com/wiki/installation.html`) mentioned in the issue is external and out of scope for a repo PR.

## Test plan

- [x] Doc-only change, nothing to build or test
- [x] Confirmed the gap still exists on current `v4.5.3-beta1` before fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)