### PR TITLE
tcpr_random: fix signed left-shift undefined behavior (does not fix #1011 - see comments)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -7,6 +7,10 @@ Unreleased
       (u_char *)(*ip_hdr)); get_layer4_v4()/v6()'s bounds check against that garbage pointer then
       either always passed (silently correct by luck) or always failed (silently rewriting
       nothing), depending on platform-specific stack layout (#1011)
+    - tcpr_random: fix signed left-shift undefined behavior in this "consistent across all
+      platforms" PRNG - left-shifting a signed int such that a set bit crosses the sign bit is
+      undefined behavior in C, which different compiler backends are free to resolve differently;
+      switched the accumulator to unsigned so the shift is well-defined everywhere
     - tcpliveplay: fix catch_alarm() not calling pcap_breakloop(), which left pcap_dispatch()
       blocked for the full buffer timeout (or indefinitely, on libpcap implementations where the
       timeout only starts once a packet arrives) instead of returning promptly when the alarm

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -436,7 +436,18 @@ uint32_t
 tcpr_random(uint32_t *seed)
 {
     unsigned int next = *seed;
-    int result;
+    /*
+     * Must be unsigned: by the third `result <<= 10` below, result can carry
+     * up to ~31 significant bits, close enough to the sign bit that a signed
+     * int here can shift a set bit into (or past) the sign bit - undefined
+     * behavior in C, which different compiler backends are free to resolve
+     * differently. That's exactly what happened: this function produced
+     * different output on macOS arm64 than on macOS Intel/Linux arm64 for
+     * the same seed, despite this function's whole purpose being consistent
+     * output across platforms (see #1011). Unsigned left-shift overflow is
+     * well-defined (mod 2^32 wraparound), which removes the UB entirely.
+     */
+    unsigned int result;
 
     next *= 1103515245;
     next += 12345;

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -436,17 +436,6 @@ uint32_t
 tcpr_random(uint32_t *seed)
 {
     unsigned int next = *seed;
-    /*
-     * Must be unsigned: by the third `result <<= 10` below, result can carry
-     * up to ~31 significant bits, close enough to the sign bit that a signed
-     * int here can shift a set bit into (or past) the sign bit - undefined
-     * behavior in C, which different compiler backends are free to resolve
-     * differently. That's exactly what happened: this function produced
-     * different output on macOS arm64 than on macOS Intel/Linux arm64 for
-     * the same seed, despite this function's whole purpose being consistent
-     * output across platforms (see #1011). Unsigned left-shift overflow is
-     * well-defined (mod 2^32 wraparound), which removes the UB entirely.
-     */
     unsigned int result;
 
     next *= 1103515245;


### PR DESCRIPTION
## Summary

Fixes a real signed left-shift undefined-behavior bug in `tcpr_random()`. **Does NOT fix #1011** — see the correction below and the actual fix in #1013.

`tcpr_random()` (`src/common/utils.c`) is a custom `rand_r()`-alike, explicitly documented as *"consistent across all platforms"* — the entire point of not using libc's `rand()`/`rand_r()`. It declared its accumulator as **signed** `int`:

```c
int result;
...
result <<= 10;   // x2
```

After the first two mixing stages, `result` can carry up to ~21 significant bits. The second `result <<= 10` shifts that up to ~31 bits — close enough to the sign bit that a set bit can be shifted into or past it. Left-shifting a signed `int` such that the result isn't representable in the type is **undefined behavior** in C (C11 6.5.7p4). This is real UB and worth fixing regardless of the outcome below.

## Fix

Declare `result` as `unsigned int` instead. Unsigned left-shift overflow is well-defined (mod 2^32 wraparound) in C, which removes the UB entirely. All five call sites already treat the return value as unsigned, so this doesn't change any calling code.

## ⚠️ Correction — this does not explain #1011

I originally opened this PR believing it fixed the macOS-arm64 divergence in #1011, based on `--tcp-sequence`'s adjustment value using this function and observing a constant per-packet offset. That was wrong. Direct diagnostic instrumentation run on the actual affected arm64 hardware showed:

- `tcp_sequence_adjust` computes to the **identical** value (`2129613237`) on both macOS arm64 and macOS Intel for seed 42 — this function's output was never actually diverging for this input, before or after this fix.
- The real bug is in the rewrite *application* path, not seed derivation — see #1013 for the actual root cause (a wrong end-of-buffer pointer computed from a stack address instead of the packet buffer, in both `rewrite_sequence.c` and `portmap.c`).

Leaving this PR open on its own merits (it's a real, legitimate UB fix, independently useful) but no longer claiming it resolves #1011.

## Testing

- Confirmed this doesn't change output on macOS Intel (full test suite 69/69, byte-identical to before) — consistent with the UB apparently already resolving to the well-defined-equivalent value on this platform's compiler.
- Confirmed via the arm64 hardware (indirectly, through #1011's diagnosis) that this fix also doesn't change `tcp_sequence_adjust`'s output there — the UB never actually manifested as a different value for this specific seed/iteration count on either platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)