### PR TITLE
tcpedit: fix wrong end-of-buffer pointer in TCP-sequence/portmap rewrite

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,12 @@
 Unreleased
+    - tcpedit: fix --tcp-sequence and --portmap/-r silently having zero effect on some platforms
+      (confirmed on macOS arm64) - rewrite_ipv4_tcp_sequence()/rewrite_ipv6_tcp_sequence()
+      (rewrite_sequence.c) and rewrite_ipv4_ports()/rewrite_ipv6_ports() (portmap.c) computed the
+      L4 "end of buffer" bounds pointer from the address of their own ipv4_hdr_t**/ipv6_hdr_t**
+      parameter instead of the packet buffer address it pointed to ((u_char *)ip_hdr instead of
+      (u_char *)(*ip_hdr)); get_layer4_v4()/v6()'s bounds check against that garbage pointer then
+      either always passed (silently correct by luck) or always failed (silently rewriting
+      nothing), depending on platform-specific stack layout (#1011)
     - tcpliveplay: fix catch_alarm() not calling pcap_breakloop(), which left pcap_dispatch()
       blocked for the full buffer timeout (or indefinitely, on libpcap implementations where the
       timeout only starts once a packet arrives) instead of returning promptly when the alarm

--- a/src/tcpedit/portmap.c
+++ b/src/tcpedit/portmap.c
@@ -339,7 +339,7 @@ rewrite_ipv4_ports(tcpedit_t *tcpedit, ipv4_hdr_t **ip_hdr, int l3len)
         tcpedit_seterr(tcpedit, "rewrite_ipv4_ports: NULL IP header: l3 len=%d", l3len);
         return TCPEDIT_ERROR;
     } else if ((*ip_hdr)->ip_p == IPPROTO_TCP || (*ip_hdr)->ip_p == IPPROTO_UDP) {
-        l4 = get_layer4_v4(*ip_hdr, (u_char *)ip_hdr + l3len);
+        l4 = get_layer4_v4(*ip_hdr, (u_char *)(*ip_hdr) + l3len);
         if (l4)
             return rewrite_ports(tcpedit, (*ip_hdr)->ip_p, l4, l3len - (l4 - (u_char *)*ip_hdr));
 
@@ -360,7 +360,7 @@ rewrite_ipv6_ports(tcpedit_t *tcpedit, ipv6_hdr_t **ip6_hdr, int l3len)
         tcpedit_seterr(tcpedit, "rewrite_ipv6_ports: NULL IPv6 header: l3 len=%d", l3len);
         return TCPEDIT_ERROR;
     } else if ((*ip6_hdr)->ip_nh == IPPROTO_TCP || (*ip6_hdr)->ip_nh == IPPROTO_UDP) {
-        l4 = get_layer4_v6(*ip6_hdr, (u_char *)ip6_hdr + l3len);
+        l4 = get_layer4_v6(*ip6_hdr, (u_char *)(*ip6_hdr) + l3len);
         if (l4)
             return rewrite_ports(tcpedit, (*ip6_hdr)->ip_nh, l4, l3len - (l4 - (u_char *)*ip6_hdr));
 

--- a/src/tcpedit/rewrite_sequence.c
+++ b/src/tcpedit/rewrite_sequence.c
@@ -60,7 +60,7 @@ rewrite_ipv4_tcp_sequence(tcpedit_t *tcpedit, ipv4_hdr_t **ip_hdr, int l3len)
     assert(*ip_hdr && ip_hdr);
 
     if (*ip_hdr && (*ip_hdr)->ip_p == IPPROTO_TCP) {
-        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v4(*ip_hdr, (u_char *)ip_hdr + l3len);
+        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v4(*ip_hdr, (u_char *)(*ip_hdr) + l3len);
         if (!tcp_hdr) {
             tcpedit_setwarn(tcpedit, "caplen to small to set TCP sequence for IP packet: l3 len=%d", l3len);
             return TCPEDIT_WARN;
@@ -79,7 +79,7 @@ rewrite_ipv6_tcp_sequence(tcpedit_t *tcpedit, ipv6_hdr_t **ip6_hdr, int l3len)
     assert(*ip6_hdr && ip6_hdr);
 
     if (*ip6_hdr && (*ip6_hdr)->ip_nh == IPPROTO_TCP) {
-        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v6(*ip6_hdr, (u_char *)ip6_hdr + l3len);
+        tcp_hdr_t *tcp_hdr = (tcp_hdr_t *)get_layer4_v6(*ip6_hdr, (u_char *)(*ip6_hdr) + l3len);
         if (!tcp_hdr) {
             tcpedit_setwarn(tcpedit, "caplen to small to set TCP sequence for IP packet: l3 len=%d", l3len);
             return TCPEDIT_WARN;


### PR DESCRIPTION
## Summary

Fixes #1011 — `--tcp-sequence` and `--portmap`/`-r` have zero effect on macOS arm64 while working correctly on macOS Intel and Linux arm64, for byte-identical compiled logic and configuration (confirmed via diagnostic instrumentation run on the actual affected hardware — see #1011 for the full trail, including two earlier wrong turns).

## Root cause

`rewrite_ipv4_tcp_sequence()`/`rewrite_ipv6_tcp_sequence()` (`src/tcpedit/rewrite_sequence.c`) and `rewrite_ipv4_ports()`/`rewrite_ipv6_ports()` (`src/tcpedit/portmap.c`) all take an `ipv4_hdr_t**`/`ipv6_hdr_t**` parameter and call `get_layer4_v4()`/`get_layer4_v6()` to locate the L4 header, passing an "end of buffer" bounds pointer computed as:

```c
(u_char *)ip_hdr + l3len
```

`ip_hdr` here is the `ipv4_hdr_t**` parameter itself — a pointer to the caller's local variable. Casting it straight to `u_char*` and adding `l3len` computes an address relative to wherever the compiler happened to place that parameter (typically the stack), which has **no relationship whatsoever** to the actual packet buffer (typically heap). Should have been:

```c
(u_char *)(*ip_hdr) + l3len
```

i.e. dereference first to get the real packet buffer address — matching every other caller of `get_layer4_v4()`/`v6()` in this codebase (checked: all of them already do this correctly; only these four call sites, across two files, had the bug).

`get_layer4_v4()`/`v6()` bounds-check the computed L4 pointer against this `end_ptr` (`if (ptr > end_ptr) return NULL;`) and return `NULL` — a benign, handled "not enough data" outcome — if it's ever exceeded. Since the garbage `end_ptr` here bears no relation to the real buffer, whether that check spuriously *passes* (rewrite works, by luck) or spuriously *fails* (rewrite silently no-ops for every packet) depends entirely on the relative addresses of stack vs. heap at runtime — stack layout, allocator behavior, ASLR — all platform/ABI/compiler dependent. Exactly the reported symptom.

## How this was found

Two wrong turns first, both documented in #1011 for the record:
1. A real but practically-inert signed left-shift UB in `tcpr_random()` (#1012) — fixed real UB, but confirmed (via the same arm64 hardware) to compute the *identical* value on both platforms for this input, so it wasn't the cause.
2. A theory that AutoOpts wasn't parsing `--tcp-sequence`/`--portmap` correctly on arm64 — disproven directly: temporary diagnostic `warnx()` prints run on the actual affected machine showed `tcp_sequence_adjust` and the parsed portmap chain were both already 100% correct at configure-time.

That ruled out configuration and pointed squarely at the rewrite *application* path, which is where this bug was found.

## Verified

- Confirmed via grep that this exact pattern (`(u_char *)ip_hdr + ...`/`(u_char *)ip6_hdr + ...`) appears at exactly these 4 sites with a double-pointer parameter; every other occurrence in the codebase is a single pointer where the direct cast is correct.
- Full local test suite: 69/69 on macOS Intel, no regression — consistent with this platform's stack layout having made the old, buggy bounds check pass by chance rather than by correctness.
- **Cannot verify this actually fixes the arm64 divergence directly** — no such hardware in this environment. The mechanism is now fully explained (not inferred), and directly addresses the "some platforms zero effect, others correct" pattern confirmed live on the reporter's machine in #1011. Would very much appreciate a test run on that hardware before merge.

## Test plan

- [x] Full local test suite: 69/69, no regression (macOS Intel)
- [x] Confirmed no other instances of this bug pattern exist elsewhere in the codebase
- [ ] Confirm on macOS arm64 that `rewrite_sequence`, `rewrite_portmap`, and `rewrite_range_portmap` now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)