### PR TITLE
CMake: fail configure on stale pre-generated AutoOpts files (#1020)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,11 @@
 UNRELEASED
+    - cmake: fail configure on stale pre-generated AutoOpts files in the source tree (#1020) -
+      a leftover src/*_opts.h (from an earlier in-source build or an unpacked tarball) always
+      shadows the freshly generated build-dir copy because quote-includes search the including
+      file's directory first, breaking the build with 'INDEX_OPT_* undeclared' once a new CLI
+      option is added; configure now uses up-to-date pre-generated copies wholesale (release
+      tarballs keep working) and aborts with removal instructions when they are older than
+      their .def inputs; same guard for tcpedit_stub.h
     - tcpreplay: add Linux io_uring packet injection support (#954) - new --io-uring option
       (detected at build time when liburing-dev and an io_uring-capable kernel are present;
       'liburing for io_uring' in the configure summary) sends packets through the existing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,9 +22,43 @@ set(TCPR_AUTOGEN_OPTS_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 # tcpr_autogen_opts(<base> <def-file> [FLAGS ...] [DEPENDS ...])
 # Defines <base>_SOURCE pointing at the generated (or pre-generated) .c file.
+#
+# A pre-generated ${base}.h in the source directory always shadows the
+# build-dir copy: the C sources include it with #include "..." and the
+# quote-include search looks in the including file's own directory first.
+# So when source-dir copies exist (release tarballs) they are used wholesale
+# and must be up to date vs their .def inputs - generating a second copy in
+# the build dir would mix a fresh .c with a shadowing stale .h and fail with
+# 'INDEX_OPT_* undeclared' errors (#1020).
 function(tcpr_autogen_opts base def)
     cmake_parse_arguments(ARG "" "" "FLAGS;DEPENDS" ${ARGN})
-    if(AUTOGEN_EXECUTABLE)
+    set(_insrc_c ${CMAKE_CURRENT_SOURCE_DIR}/${base}.c)
+    set(_insrc_h ${CMAKE_CURRENT_SOURCE_DIR}/${base}.h)
+    if(EXISTS ${_insrc_c} OR EXISTS ${_insrc_h})
+        set(_stale "")
+        foreach(_f ${_insrc_c} ${_insrc_h})
+            if(NOT EXISTS ${_f})
+                set(_stale ${_f})
+            else()
+                foreach(_dep ${def} ${ARG_DEPENDS})
+                    if(${_dep} IS_NEWER_THAN ${_f})
+                        set(_stale ${_f})
+                    endif()
+                endforeach()
+            endif()
+        endforeach()
+        if(_stale)
+            message(FATAL_ERROR
+                "Stale pre-generated AutoOpts file in the source tree: ${_stale} is missing or "
+                "older than ${def}. Source-dir copies shadow the build-dir copies for "
+                "quote-includes and would break the build with 'INDEX_OPT_* undeclared' errors "
+                "(see issue #1020). Remove them and re-run cmake:\n"
+                "  rm -f ${_insrc_c} ${_insrc_h}\n"
+                "In a git checkout, 'git clean -fx src' removes all leftover generated files.")
+        endif()
+        # up-to-date pre-generated copies (e.g. a release tarball) - use them as-is
+        set(${base}_SOURCE ${_insrc_c} PARENT_SCOPE)
+    elseif(AUTOGEN_EXECUTABLE)
         add_custom_command(
             OUTPUT ${TCPR_AUTOGEN_OPTS_DIR}/${base}.c ${TCPR_AUTOGEN_OPTS_DIR}/${base}.h
             COMMAND ${AUTOGEN_EXECUTABLE}
@@ -37,8 +71,9 @@ function(tcpr_autogen_opts base def)
             COMMENT "Generating ${base}.c with autogen")
         set(${base}_SOURCE ${TCPR_AUTOGEN_OPTS_DIR}/${base}.c PARENT_SCOPE)
     else()
-        # release tarballs ship pre-generated copies next to the .def files
-        set(${base}_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/${base}.c PARENT_SCOPE)
+        message(FATAL_ERROR
+            "No pre-generated ${base}.c and GNU autogen is not installed. "
+            "Install autogen if you are building from a git checkout.")
     endif()
 endfunction()
 

--- a/src/tcpedit/CMakeLists.txt
+++ b/src/tcpedit/CMakeLists.txt
@@ -5,24 +5,44 @@
 # tcpedit_opts.def and plugins/dlt_stub.def (which includes every plugin's
 # *_opts.def).
 file(GLOB DLT_PLUGIN_OPTS_DEFS ${CMAKE_CURRENT_SOURCE_DIR}/plugins/*/*_opts.def)
-set(TCPEDIT_STUB_H ${CMAKE_CURRENT_BINARY_DIR}/tcpedit_stub.h)
-if(AUTOGEN_EXECUTABLE)
+set(TCPEDIT_STUB_DEPS
+    ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_stub.def
+    ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_opts.def
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugins/dlt_stub.def
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugins/dlt_opts.def
+    ${DLT_PLUGIN_OPTS_DEFS})
+# like the *_opts files (see tcpr_autogen_opts in src/CMakeLists.txt), a
+# source-dir tcpedit_stub.h shadows the build-dir copy for quote-includes, so
+# it may only be used if it is current vs every .def it was generated from
+# (#1020)
+set(_insrc_stub ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_stub.h)
+if(EXISTS ${_insrc_stub})
+    foreach(_dep ${TCPEDIT_STUB_DEPS})
+        if(${_dep} IS_NEWER_THAN ${_insrc_stub})
+            message(FATAL_ERROR
+                "Stale pre-generated ${_insrc_stub}: it is older than ${_dep} and shadows the "
+                "build-dir copy (see issue #1020). Remove it and re-run cmake:\n"
+                "  rm -f ${_insrc_stub}\n"
+                "In a git checkout, 'git clean -fx src' removes all leftover generated files.")
+        endif()
+    endforeach()
+    # up-to-date pre-generated copy (e.g. a release tarball) - use it as-is
+    set(TCPEDIT_STUB_H ${_insrc_stub})
+elseif(AUTOGEN_EXECUTABLE)
+    set(TCPEDIT_STUB_H ${CMAKE_CURRENT_BINARY_DIR}/tcpedit_stub.h)
     add_custom_command(
         OUTPUT ${TCPEDIT_STUB_H}
         COMMAND ${AUTOGEN_EXECUTABLE}
                 -L ${CMAKE_CURRENT_SOURCE_DIR}
                 -b tcpedit_stub
                 ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_stub.def
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_stub.def
-                ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_opts.def
-                ${CMAKE_CURRENT_SOURCE_DIR}/plugins/dlt_stub.def
-                ${CMAKE_CURRENT_SOURCE_DIR}/plugins/dlt_opts.def
-                ${DLT_PLUGIN_OPTS_DEFS}
+        DEPENDS ${TCPEDIT_STUB_DEPS}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating tcpedit_stub.h with autogen")
 else()
-    # release tarballs ship a pre-generated copy
-    set(TCPEDIT_STUB_H ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit_stub.h)
+    message(FATAL_ERROR
+        "No pre-generated tcpedit_stub.h and GNU autogen is not installed. "
+        "Install autogen if you are building from a git checkout.")
 endif()
 
 set(TCPEDIT_SOURCES


### PR DESCRIPTION
## Summary

Fixes #1020: a leftover `src/*_opts.h` (from an earlier in-source autotools build or an unpacked release tarball) always shadows the freshly generated build-dir copy — the C sources use `#include "..."` and quote-include search looks in the including file's own directory first. The build then fails with `'INDEX_OPT_* undeclared'` as soon as a `.def` gains a new option (first seen with `INDEX_OPT_IO_URING` after #1019 on an arm64 macOS machine, reproduced identically on Linux).

## Change

`tcpr_autogen_opts()` (and the equivalent `tcpedit_stub.h` rule) now treat source-dir copies as authoritative when they exist:

- **Up to date vs their `.def` inputs** → used wholesale (release-tarball builds keep working, and no build-dir copy is generated that a stale header could partially shadow — this also removes the previous .c/.h version-skew possibility when both autogen and tarball copies were present).
- **Older than any `.def` input** → configure aborts with a clear message and exact removal instructions (`rm -f ...` / `git clean -fx src`).
- No copies and no autogen → explicit configure-time error (previously deferred to a confusing compile failure).

## Testing

- Clean git checkout: configure + full build unchanged, all targets build.
- Stale copies planted in `src/` (regenerated from the pre-#1019 `.def`): configure now fails immediately with the #1020 message instead of the cryptic compile error.
- Fresh valid copies planted (tarball simulation): configure succeeds and the build links the in-source `tcpreplay_opts.c`, verified via `link.txt`.

Known limitation: the staleness check is mtime-based (same as make); a content-stale file with a newer mtime than its `.def` still slips through to the old compile error. That requires deliberately touching a stale file, and the compile error is now at least documented in #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)