### PR TITLE
Support raw IP (L3-only) interfaces such as WireGuard and tun (#988)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ sudo cmake --install build
 sudo tcpreplay -i eth0 --io-uring test.pcap
 ```
 
+Replaying onto raw IP (L3) interfaces
+-------------------------------------
+On Linux, tcpreplay can replay directly onto layer-3-only interfaces such as
+WireGuard and tun devices — no build option or command line flag needed. Any
+layer 2 header in the input file (Ethernet including VLAN tags, Linux SLL,
+loopback, ...) is stripped automatically and packets are sent as bare
+IPv4/IPv6 with the correct protocol, which drivers like WireGuard require:
+
+```
+sudo tcpreplay -i wg0 test.pcap
+```
+
+Note that non-IP packets (e.g. ARP) cannot be sent on these interfaces and
+are reported as failed, and that `--io-uring` is not supported on them.
+
 Detailed installation instructions are available in the INSTALL document in the tar ball.
 
 Install Tcpreplay from source code

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,13 @@
 UNRELEASED
+    - tcpreplay: support raw IP (L3-only) interfaces such as WireGuard and tun (#988) - interfaces
+      whose hardware type is ARPHRD_NONE/ARPHRD_RAWIP are now detected in the PF_PACKET open path;
+      packets are sent as bare IP with the per-packet protocol (ETH_P_IP/ETH_P_IPV6) taken from
+      the IP version nibble, which drivers like WireGuard require, and any layer 2 header in the
+      source pcap (Ethernet incl. VLAN tags, SLL, loopback, ...) is stripped automatically at
+      send time so both DLT_EN10MB and DLT_RAW captures replay unmodified; non-IP packets (e.g.
+      ARP) fail with a clear per-packet message, the misleading 'Unsupported physical layer
+      type 0xfffe' and DLT-mismatch warnings are suppressed for these interfaces, and --io-uring
+      reports a clean unsupported-combination error instead of failing mid-replay
     - cmake: fail configure on stale pre-generated AutoOpts files in the source tree (#1020) -
       a leftover src/*_opts.h (from an earlier in-source build or an unpacked tarball) always
       shadows the freshly generated build-dir copy because quote-includes search the including

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -181,6 +181,7 @@
 static sendpacket_t *sendpacket_open_pf(const char *, char *);
 static struct tcpr_ether_addr *sendpacket_get_hwaddr_pf(sendpacket_t *);
 static int get_iface_index(int fd, const char *device, char *);
+static int sendpacket_send_raw_ip(sendpacket_t *, const u_char *, size_t);
 
 #endif /* HAVE_PF_PACKET */
 
@@ -372,16 +373,21 @@ TRY_SEND_AGAIN:
     case SP_TYPE_PF_PACKET:
     case SP_TYPE_TX_RING:
 #if defined HAVE_PF_PACKET
+        if (sp->raw_ip) {
+            retcode = sendpacket_send_raw_ip(sp, data, len);
+        } else
 #ifdef HAVE_TX_RING
-        retcode = (int)txring_put(sp->tx_ring, data, len);
+            retcode = (int)txring_put(sp->tx_ring, data, len);
 #else
-        retcode = (int)send(sp->handle.fd, (void *)data, len, 0);
+            retcode = (int)send(sp->handle.fd, (void *)data, len, 0);
 #endif
 
         /* out of buffers, or hit max PHY speed, silently retry
          * as long as we're not told to abort
          */
-        if (retcode < 0 && !sp->abort) {
+        if (retcode == -2) {
+            retcode = -1; /* non-IP packet on a raw IP interface: hard failure, error already set */
+        } else if (retcode < 0 && !sp->abort) {
             switch (errno) {
             case EAGAIN:
                 sp->retry_eagain++;
@@ -1146,6 +1152,7 @@ sendpacket_open_pf(const char *device, char *errbuf)
     struct sockaddr_ll sa;
     int err;
     socklen_t errlen = sizeof(err);
+    bool raw_ip = false;
     unsigned int UNUSED(mtu) = 1500;
 #ifdef SO_BROADCAST
     int n = 1;
@@ -1206,12 +1213,21 @@ sendpacket_open_pf(const char *device, char *errbuf)
         return NULL;
     }
 
-    /* make sure it's not loopback (PF_PACKET doesn't support it) */
-    if (ifr.ifr_hwaddr.sa_family != ARPHRD_ETHER)
+    /* L3-only interfaces (WireGuard, tun, ...) take bare IP packets with no L2 header (#988) */
+    if (ifr.ifr_hwaddr.sa_family == ARPHRD_NONE
+#ifdef ARPHRD_RAWIP
+        || ifr.ifr_hwaddr.sa_family == ARPHRD_RAWIP
+#endif
+    ) {
+        raw_ip = true;
+        dbgx(1, "sendpacket: %s is a raw IP (L3) interface", device);
+    } else if (ifr.ifr_hwaddr.sa_family != ARPHRD_ETHER) {
+        /* make sure it's not loopback (PF_PACKET doesn't support it) */
         warnx("Unsupported physical layer type 0x%04x on %s.  Maybe it works, maybe it won't."
               "  See tickets #123/318",
               ifr.ifr_hwaddr.sa_family,
               device);
+    }
 
 #ifdef SO_BROADCAST
     /*
@@ -1233,30 +1249,67 @@ sendpacket_open_pf(const char *device, char *errbuf)
     sp = (sendpacket_t *)safe_malloc(sizeof(sendpacket_t));
     strlcpy(sp->device, device, sizeof(sp->device));
     sp->handle.fd = mysocket;
+    sp->sa = sa; /* bound address; raw IP sends need the ifindex for per-packet sendto() */
+    sp->raw_ip = raw_ip;
 
 #ifdef HAVE_TX_RING
-    /* Look up for MTU */
-    memset(&ifr, 0, sizeof(ifr));
-    strlcpy(ifr.ifr_name, sp->device, sizeof(ifr.ifr_name));
+    if (!raw_ip) {
+        /* Look up for MTU */
+        memset(&ifr, 0, sizeof(ifr));
+        strlcpy(ifr.ifr_name, sp->device, sizeof(ifr.ifr_name));
 
-    if (ioctl(mysocket, SIOCGIFMTU, &ifr) < 0) {
-        close(mysocket);
-        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "Error getting MTU: %s", strerror(errno));
-        return NULL;
-    }
-    mtu = ifr.ifr_ifru.ifru_mtu;
+        if (ioctl(mysocket, SIOCGIFMTU, &ifr) < 0) {
+            close(mysocket);
+            snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "Error getting MTU: %s", strerror(errno));
+            return NULL;
+        }
+        mtu = ifr.ifr_ifru.ifru_mtu;
 
-    /* Init TX ring for sp->handle.fd socket */
-    if ((sp->tx_ring = txring_init(sp->handle.fd, mtu)) == 0) {
-        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "txring_init: %s", strerror(errno));
-        close(mysocket);
-        return NULL;
+        /* Init TX ring for sp->handle.fd socket */
+        if ((sp->tx_ring = txring_init(sp->handle.fd, mtu)) == 0) {
+            snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "txring_init: %s", strerror(errno));
+            close(mysocket);
+            return NULL;
+        }
+        sp->handle_type = SP_TYPE_TX_RING;
+    } else {
+        /* the TX ring expects L2 frames; raw IP interfaces use plain sendto() */
+        sp->handle_type = SP_TYPE_PF_PACKET;
     }
-    sp->handle_type = SP_TYPE_TX_RING;
 #else
     sp->handle_type = SP_TYPE_PF_PACKET;
 #endif
     return sp;
+}
+
+/**
+ * Send a bare IP packet on a raw IP (L3-only) interface such as WireGuard or
+ * tun (#988).  The kernel needs the correct protocol on each packet (drivers
+ * like WireGuard reject anything that is not ETH_P_IP/ETH_P_IPV6), so it is
+ * taken from the IP version nibble and passed via sendto()'s sockaddr_ll.
+ * Returns bytes sent, -1 on send error (errno valid), or -2 for a non-IP
+ * packet (error message set, no retry).
+ */
+static int
+sendpacket_send_raw_ip(sendpacket_t *sp, const u_char *data, size_t len)
+{
+    struct sockaddr_ll sa;
+    uint8_t version = data[0] >> 4;
+
+    memcpy(&sa, &sp->sa, sizeof(sa));
+    if (version == 4) {
+        sa.sll_protocol = htons(ETH_P_IP);
+    } else if (version == 6) {
+        sa.sll_protocol = htons(ETH_P_IPV6);
+    } else {
+        sendpacket_seterr(sp,
+                          "unable to send non-IP packet on raw IP interface %s (IP version nibble %u)",
+                          sp->device,
+                          version);
+        return -2;
+    }
+
+    return (int)sendto(sp->handle.fd, (const void *)data, len, 0, (struct sockaddr *)&sa, sizeof(sa));
 }
 
 /**
@@ -1461,6 +1514,11 @@ sendpacket_get_dlt(sendpacket_t *sp)
 {
     int dlt = DLT_EN10MB;
 
+    /* L3-only interfaces carry bare IP packets */
+    if (sp->raw_ip) {
+        return DLT_RAW;
+    }
+
     switch (sp->handle_type) {
     case SP_TYPE_KHIAL:
     case SP_TYPE_NETMAP:
@@ -1560,6 +1618,20 @@ sendpacket_abort(sendpacket_t *sp)
     assert(sp);
 
     sp->abort = true;
+}
+
+/**
+ * \brief Is the opened interface L3-only (raw IP, no layer 2 header)?
+ *
+ * True for WireGuard/tun style interfaces; callers must strip any L2 header
+ * before handing packets to sendpacket() (#988)
+ */
+bool
+sendpacket_is_raw_ip(sendpacket_t *sp)
+{
+    assert(sp);
+
+    return sp->raw_ip;
 }
 #ifdef HAVE_LIBXDP
 static struct xsk_socket_info *
@@ -1800,6 +1872,20 @@ sendpacket_open_io_uring(const char *device, char *errbuf)
     if (ioctl(mysocket, SIOCGIFHWADDR, &ifr) < 0) {
         close(mysocket);
         snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "Error getting hardware type: %s", strerror(errno));
+        return NULL;
+    }
+
+    if (ifr.ifr_hwaddr.sa_family == ARPHRD_NONE
+#ifdef ARPHRD_RAWIP
+        || ifr.ifr_hwaddr.sa_family == ARPHRD_RAWIP
+#endif
+    ) {
+        snprintf(errbuf,
+                 SENDPACKET_ERRBUF_SIZE,
+                 "%s is a raw IP (L3) interface, which is not supported with --io-uring. "
+                 "Replay without --io-uring instead.",
+                 device);
+        close(mysocket);
         return NULL;
     }
 

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -252,6 +252,8 @@ struct sendpacket_s {
     unsigned int uring_free_top; /* number of entries in uring_free */
     unsigned int uring_outstanding;
 #endif
+    /* interface is L3-only (WireGuard, tun, ...): send bare IP packets, no L2 header (#988) */
+    bool raw_ip;
     bool abort;
 };
 typedef struct sendpacket_s sendpacket_t;
@@ -316,3 +318,4 @@ struct tcpr_ether_addr *sendpacket_get_hwaddr(sendpacket_t *);
 int sendpacket_get_dlt(sendpacket_t *);
 const char *sendpacket_get_method(sendpacket_t *);
 void sendpacket_abort(sendpacket_t *);
+bool sendpacket_is_raw_ip(sendpacket_t *);

--- a/src/replay.c
+++ b/src/replay.c
@@ -165,13 +165,15 @@ replay_file(tcpreplay_t *ctx, int idx)
                     path, pcap_datalink_val_to_name(pcap_datalink(pcap)),
                     ctx->options->intf1->device, pcap_datalink_val_to_name(ctx->intf1dlt));
 #endif
-        if (ctx->intf1dlt != ctx->options->file_cache[idx].dlt)
+        /* raw IP (L3) interfaces accept any DLT: the L2 header is stripped at send time (#988) */
+        if (ctx->intf1dlt != ctx->options->file_cache[idx].dlt && !sendpacket_is_raw_ip(ctx->intf1)) {
             tcpreplay_setwarn(ctx,
                               "%s DLT (%s) does not match that of the outbound interface: %s (%s)",
                               path,
                               pcap_datalink_val_to_name(pcap_datalink(pcap)),
                               ctx->intf1->device,
                               pcap_datalink_val_to_name(ctx->intf1dlt));
+        }
     }
 
     ctx->stats.active_pcap = ctx->options->sources[idx].filename;
@@ -261,7 +263,8 @@ replay_two_files(tcpreplay_t *ctx, int idx1, int idx2)
 #endif
         if (ctx->intf1dlt == -1)
             ctx->intf1dlt = sendpacket_get_dlt(ctx->intf1);
-        if ((ctx->intf1dlt >= 0) && (ctx->intf1dlt != pcap_datalink(pcap1))) {
+        /* raw IP (L3) interfaces accept any DLT: the L2 header is stripped at send time (#988) */
+        if ((ctx->intf1dlt >= 0) && (ctx->intf1dlt != pcap_datalink(pcap1)) && !sendpacket_is_raw_ip(ctx->intf1)) {
             tcpreplay_setwarn(ctx,
                               "%s DLT (%s) does not match that of the outbound interface: %s (%s)",
                               path1,
@@ -273,7 +276,7 @@ replay_two_files(tcpreplay_t *ctx, int idx1, int idx2)
 
         if (ctx->intf2dlt == -1)
             ctx->intf2dlt = sendpacket_get_dlt(ctx->intf2);
-        if ((ctx->intf2dlt >= 0) && (ctx->intf2dlt != pcap_datalink(pcap2))) {
+        if ((ctx->intf2dlt >= 0) && (ctx->intf2dlt != pcap_datalink(pcap2)) && !sendpacket_is_raw_ip(ctx->intf2)) {
             tcpreplay_setwarn(ctx,
                               "%s DLT (%s) does not match that of the outbound interface: %s (%s)",
                               path2,

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -386,8 +386,10 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
     COUNTER limit_send = options->limit_send;
     struct pcap_pkthdr pkthdr;
     u_char *pktdata = NULL;
+    u_char *send_data;
     sendpacket_t *sp = ctx->intf1;
     COUNTER pktlen;
+    COUNTER send_len;
     packet_cache_t *cached_packet = NULL;
     packet_cache_t **prev_packet = NULL;
 #if defined TCPREPLAY && defined TCPREPLAY_EDIT
@@ -575,8 +577,23 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         }
 #endif
         dbgx(2, "Sending packet #" COUNTER_SPEC, packetnum);
+
+        /* raw IP (L3-only) interfaces like WireGuard take the bare IP packet: strip L2 (#988) */
+        send_data = pktdata;
+        send_len = pktlen;
+        if (sendpacket_is_raw_ip(sp)) {
+            COUNTER l2len = (COUNTER)get_l2len(pktdata, (int)pkthdr.caplen, datalink);
+            if (l2len >= send_len) {
+                warnx("Unable to send packet " COUNTER_SPEC ": no data beyond the layer 2 header", packetnum);
+                ++stats->failed;
+                continue;
+            }
+            send_data += l2len;
+            send_len -= l2len;
+        }
+
         /* write packet out on network */
-        if (sendpacket(sp, pktdata, pktlen, &pkthdr) < (int)pktlen) {
+        if (sendpacket(sp, send_data, send_len, &pkthdr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
             continue;
         }
@@ -592,10 +609,10 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
 
         stats->pkts_sent++;
 #ifndef HAVE_LIBXDP
-        stats->bytes_sent += pktlen;
+        stats->bytes_sent += send_len;
 #else
         if (sp->handle_type != SP_TYPE_LIBXDP)
-            stats->bytes_sent += pktlen;
+            stats->bytes_sent += send_len;
 #endif
         /* print stats during the run? */
         if (options->stats > 0) {
@@ -657,8 +674,10 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
     int cache_file_idx;
     struct pcap_pkthdr pkthdr1, pkthdr2;
     u_char *pktdata1 = NULL, *pktdata2 = NULL, *pktdata = NULL;
+    u_char *send_data;
     sendpacket_t *sp;
     COUNTER pktlen;
+    COUNTER send_len;
     packet_cache_t *cached_packet1 = NULL, *cached_packet2 = NULL;
     packet_cache_t **prev_packet1 = NULL, **prev_packet2 = NULL;
     struct pcap_pkthdr *pkthdr_ptr;
@@ -840,8 +859,23 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
 #endif
 
         dbgx(2, "Sending packet #" COUNTER_SPEC, packetnum);
+
+        /* raw IP (L3-only) interfaces like WireGuard take the bare IP packet: strip L2 (#988) */
+        send_data = pktdata;
+        send_len = pktlen;
+        if (sendpacket_is_raw_ip(sp)) {
+            COUNTER l2len = (COUNTER)get_l2len(pktdata, (int)pkthdr_ptr->caplen, datalink);
+            if (l2len >= send_len) {
+                warnx("Unable to send packet " COUNTER_SPEC ": no data beyond the layer 2 header", packetnum);
+                ++stats->failed;
+                continue;
+            }
+            send_data += l2len;
+            send_len -= l2len;
+        }
+
         /* write packet out on network */
-        if (sendpacket(sp, pktdata, pktlen, pkthdr_ptr) < (int)pktlen) {
+        if (sendpacket(sp, send_data, send_len, pkthdr_ptr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
             continue;
         }
@@ -852,7 +886,7 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
         TIMESPEC_SET(&stats->end_time, &now);
 
         ++stats->pkts_sent;
-        stats->bytes_sent += pktlen;
+        stats->bytes_sent += send_len;
 
         /* print stats during the run? */
         if (options->stats > 0) {

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -78,12 +78,18 @@ EOExplain;
 
 detail = <<- EODetail
 The basic operation of tcpreplay is to resend  all  packets  from  the
-input file(s) at the speed at which they were recorded, or a specified 
+input file(s) at the speed at which they were recorded, or a specified
 data rate, up to as fast as the hardware is capable.
 
 Optionally, the traffic can be split between two interfaces, written to
 files, filtered and edited in various ways, providing the means to test
 firewalls, NIDS and other network devices.
+
+On Linux, raw IP (layer 3 only) interfaces such as WireGuard and tun are
+supported automatically: any layer 2 header in the input file (Ethernet
+including VLAN tags, Linux SLL, loopback, ...) is stripped and packets are
+sent as bare IPv4/IPv6. Non-IP packets such as ARP cannot be sent on these
+interfaces and are reported as failed.
 
 For more details, please see the Tcpreplay Manual at:
 http://tcpreplay.appneta.com


### PR DESCRIPTION
## Summary

Implements #988: tcpreplay can now replay onto L3-only interfaces (WireGuard, tun, ...). Previously every packet failed with `PF_PACKET send() Protocol not supported (errno = 93)` because drivers like WireGuard require `skb->protocol` to be `ETH_P_IP`/`ETH_P_IPV6`, and the replayed data still contained an Ethernet header.

## Design

- **Detection**: `sendpacket_open_pf()` recognizes `ARPHRD_NONE` (and `ARPHRD_RAWIP`) hardware types and marks the handle raw-IP, replacing the misleading `Unsupported physical layer type 0xfffe` warning.
- **Send path**: raw handles use `sendto()` with per-packet `sll_protocol` derived from the IP version nibble, so IPv4 and IPv6 both carry the correct protocol. Non-IP packets (e.g. ARP) fail with a clear per-packet message.
- **Automatic L2 stripping**: `send_packets()`/`send_dual_packets()` strip whatever layer 2 header the source pcap has (Ethernet incl. VLAN tags, SLL, loopback, ...) via the existing `get_l2len()` before sending to a raw handle — so unmodified `DLT_EN10MB` captures replay directly, no tcprewrite step needed. `DLT_RAW` captures pass through untouched.
- **Coherent plumbing**: `sendpacket_get_dlt()` reports `DLT_RAW` for these handles, the DLT-mismatch warnings are suppressed for them, `--io-uring` reports a clean unsupported-combination error at open time, and TX_RING builds fall back to plain `sendto()` (the TX ring expects L2 frames).

## Testing

Against a `tun` interface (`ARPHRD_NONE`, identical hardware type to WireGuard) with a reader process attached (standing in for the VPN daemon):

- `tcpreplay -i tun989 -t test.pcap` (DLT_EN10MB): **176/176 IP packets delivered — 165 IPv4 + 11 IPv6, 0 malformed** — and the 3 ARP packets rejected with `unable to send non-IP packet on raw IP interface tun989 (IP version nibble 0)`.
- Replaying a genuine DLT_RAW capture: **177/177 delivered**, no warnings.
- `--io-uring -i tun989`: fails fast with `tun989 is a raw IP (L3) interface, which is not supported with --io-uring`.
- Full `sudo make test` suite + the io_uring variant pass unchanged (Ethernet/loopback paths untouched: `raw_ip` stays false).

## Note found during testing

`tcprewrite --dlt=raw` writes the output file's link-type as RAW but leaves the Ethernet header in the packet data (tcpdump shows `unknown ip 0`). Pre-existing tcpedit bug, unrelated to this change — can be filed separately.

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)