### PR TITLE
netmap: fail cleanly on unconfigured interfaces with zero TX rings (#113)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,10 @@
 UNRELEASED
+    - netmap: fail cleanly on unconfigured interfaces reporting zero TX rings/slots (#113) - an
+      unattached vale port can register successfully with a non-zero memsize yet report zero
+      nr_tx_rings/nr_tx_slots, in which case the ring setup underflowed 'nr_tx_rings - 1' on a
+      uint16 (walking 65535 phantom rings) instead of producing an error; the existing
+      "not configured" check now also validates ring and slot counts and reports all three
+      values in the error message
     - tcprewrite: preserve nanosecond timestamp resolution (#621) - input files are probed for
       their native precision; nanosecond pcap and pcapng input is now opened and written at
       nanosecond precision (nanosecond pcap output format), instead of silently truncating

--- a/src/common/netmap.c
+++ b/src/common/netmap.c
@@ -358,8 +358,18 @@ sendpacket_open_netmap(const char *device, char *errbuf, void *arg)
         goto NETMAP_IF_FAILED;
     }
 
-    if (!nmr.nr_memsize) {
-        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "Netmap interface '%s' not configured.\n", device);
+    /* an unconfigured interface (e.g. an unattached vale port) can register
+     * successfully yet report no resources; catch it here rather than
+     * underflowing the ring math below or mapping empty rings (#113)
+     */
+    if (!nmr.nr_memsize || !nmr.nr_tx_rings || !nmr.nr_tx_slots) {
+        snprintf(errbuf,
+                 SENDPACKET_ERRBUF_SIZE,
+                 "Netmap interface '%s' not configured: memsize=%u tx_rings=%u tx_slots=%u\n",
+                 device,
+                 nmr.nr_memsize,
+                 nmr.nr_tx_rings,
+                 nmr.nr_tx_slots);
         goto NETMAP_IF_FAILED;
     }
 


### PR DESCRIPTION
## Summary

Completes the long-closed #113 ("vale interfaces does not fail properly when unconfigured"). The original fix validated only `nr_memsize` after `NIOCREGIF`, but the issue's own analysis noted the kernel returns *zero slots, rings **and** memsize* for an unattached vale port — and only one of the three was ever checked.

## The gap

If an unconfigured interface registers with a non-zero `nr_memsize` but zero `nr_tx_rings`/`nr_tx_slots`, `sendpacket_open_netmap()` proceeded into ring setup where `sp->last_tx_ring = nmr.nr_tx_rings - 1` underflows a `uint16_t` to **65535** — the TX loop then walks phantom rings over unmapped memory instead of producing the "proper error message" the issue asked for.

## Change

The existing "not configured" check now validates all three values and reports them, so the actual deficiency is visible:

```
Netmap interface 'vale:igb0' not configured: memsize=4096 tx_rings=0 tx_slots=0
```

## Testing

Compile-tested against a current netmap checkout (`--with-netmap`), full binary builds and reports `Optional injection method: netmap`. Runtime behavior on real vale ports is unchanged for configured interfaces (all three values non-zero); the new rejection path only triggers where the code previously underflowed. Note CI does not build the netmap backend, so this is compile-verified only — same status as the rest of `netmap.c`.

Refs #113 (already closed — this addresses the remaining two of the three zero-value symptoms recorded there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)