### PR TITLE
Install the replay engine as libtcpreplay, a static C library (#133)

### DIFF
--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -9,9 +9,9 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           echo "Build Application"
-          sudo apt-get -y install libpcap-dev autogen
-          ./autogen.sh
-          ./configure --disable-local-libopts
+          sudo apt-get -y install libpcap-dev autogen cmake liburing-dev libxdp-dev libbpf-dev
+          cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          cmake --build build -j 4
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:
@@ -22,6 +22,7 @@ jobs:
           lines-changed-only: true
           files-changed-only: false
           ignore: .github|docs|scripts
+          database: build
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,7 @@ set(LIBOPTS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/libopts)
 add_subdirectory(lib)
 add_subdirectory(libopts)
 add_subdirectory(src)
+add_subdirectory(examples)
 
 # ---------------------------------------------------------------------------
 # Configuration summary (mirrors the configure.ac results banner)

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,12 +2,12 @@
 ACLOCAL_AMFLAGS = -I m4 -I libopts/m4
 
 if NEED_LIBOPTS
-SUBDIRS = scripts lib $(LIBOPTS_DIR) src
+SUBDIRS = scripts lib $(LIBOPTS_DIR) src examples
 else
-SUBDIRS = scripts lib src
+SUBDIRS = scripts lib src examples
 endif
 
-DIST_SUBDIRS = scripts lib libopts src docs test
+DIST_SUBDIRS = scripts lib libopts src examples docs test
 .PHONY: manpages docs test man2html
 
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ sudo make install
 Building with CMake
 -------------------
 As of version 4.6, the suite can also be built with [CMake](https://cmake.org) (3.16+).
-This is aimed at IDE users (VS Code, CLion) and fast out-of-tree developer
-builds; autotools remains the canonical release build. Building from a git
-checkout requires `autogen` (GNU AutoGen) to generate the CLI option parsers;
+**CMake is the recommended and primary way to compile Tcpreplay** — the
+autotools build (`./configure` / automake) is still provided and used for
+release tarballs, but it will be retired in a future release, so new
+scripts and packaging should use CMake. Building from a git checkout
+requires `autogen` (GNU AutoGen) to generate the CLI option parsers;
 release tarballs build without it.
 
 ```

--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ sudo tcpreplay -i wg0 test.pcap
 Note that non-IP packets (e.g. ARP) cannot be sent on these interfaces and
 are reported as failed, and that `--io-uring` is not supported on them.
 
+libtcpreplay C library
+----------------------
+Since version 4.6 the suite installs **libtcpreplay**, a static library
+exposing the same replay engine the `tcpreplay` binary uses via
+`tcpreplay_api.h`. Applications can replay pcap files and read live
+statistics programmatically instead of forking the binary and scraping its
+output:
+
+```
+cc myapp.c $(pkg-config --cflags --libs --static libtcpreplay) -o myapp
+```
+
+Headers install under `include/tcpreplay/` and both the autotools and CMake
+builds install the library and its `libtcpreplay.pc`. See the
+[examples](examples/) directory for a complete program.
+
 Detailed installation instructions are available in the INSTALL document in the tar ball.
 
 Install Tcpreplay from source code

--- a/configure.ac
+++ b/configure.ac
@@ -2069,15 +2069,26 @@ if test "x$NETMAP_CFLAGS" != "x"; then
     CFLAGS="$CFLAGS $NETMAP_CFLAGS"
 fi
 
+dnl libtcpreplay.pc: when the libopts tearoff is in use it is folded into
+dnl the installed archive, so consumers only need -lopts for system libopts
+if test -n "${NEED_LIBOPTS_DIR}" ; then
+    LIBTCPREPLAY_PCLIBS=""
+else
+    LIBTCPREPLAY_PCLIBS="${LIBOPTS_LDADD}"
+fi
+AC_SUBST(LIBTCPREPLAY_PCLIBS)
+
 AC_CONFIG_FILES([Makefile
            doxygen.cfg
            lib/Makefile
            docs/Makefile
            src/Makefile
+           src/libtcpreplay.pc
            src/tcpedit/Makefile
            src/fragroute/Makefile
            src/common/Makefile
            src/defines.h
+           examples/Makefile
            test/Makefile
            test/config
            scripts/Makefile])

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,12 @@
 UNRELEASED
+    - libtcpreplay: install the replay engine as a static C library (#133) - both build systems
+      now install libtcpreplay.a, the tcpreplay_api.h header set (under include/tcpreplay/) and
+      a libtcpreplay.pc pkg-config file, so applications can replay pcap files and read live
+      statistics programmatically (tcpreplay_init/set_*/add_pcapfile/prepare/replay/get_stats)
+      instead of forking the tcpreplay binary and scraping its output; the archive is
+      self-contained apart from libpcap and system libopts (the libopts tearoff is folded in
+      when used); a compiled example lives in examples/replay_stats.c and builds as part of
+      'make' so it always matches the API
     - netmap: fail cleanly on unconfigured interfaces reporting zero TX rings/slots (#113) - an
       unattached vale port can register successfully with a non-zero memsize yet report zero
       nr_tx_rings/nr_tx_slots, in which case the ring setup underflowed 'nr_tx_rings - 1' on a

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -196,6 +196,18 @@ example:
 If you want to compile a version that only uses io_uring, use the
 `--enable-force-liburing` configure option.
 
+4) libtcpreplay C library
+   ----------------------
+
+Both build systems install libtcpreplay.a, the tcpreplay_api.h headers
+(under include/tcpreplay/) and a libtcpreplay.pc pkg-config file, letting
+applications embed the replay engine directly:
+
+    $ cc myapp.c $(pkg-config --cflags --libs --static libtcpreplay) -o myapp
+
+See examples/replay_stats.c for a complete program and examples/README.md
+for details.
+
 CMake Installation
 ==================
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,8 @@
+# examples/CMakeLists.txt — libtcpreplay usage examples (#133); built always,
+# never installed (mirrors examples/Makefile.am's noinst_PROGRAMS).
+
+add_executable(replay_stats replay_stats.c)
+target_link_libraries(replay_stats PRIVATE tcpreplay_static
+    ${PCAP_LIBRARIES} ${DNET_LIBRARIES} ${TCPR_SYSTEM_LIBS} ${LNAV_LIBRARIES})
+target_include_directories(replay_stats PRIVATE
+    ${TCPR_GENERATED_INCLUDE_DIRS} ${TCPR_SOURCE_INCLUDE_DIRS})

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,0 +1,13 @@
+# libtcpreplay usage examples (#133)
+#
+# Built as noinst so every build proves the library and its installed
+# header layout keep working; see README.md for building against an
+# installed libtcpreplay with pkg-config.
+
+noinst_PROGRAMS = replay_stats
+
+replay_stats_SOURCES = replay_stats.c
+replay_stats_CFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src $(LIBOPTS_CFLAGS)
+replay_stats_LDADD = $(top_builddir)/src/libtcpreplay.a @LPCAPLIB@ @LDNETLIB@ $(LIBOPTS_LDADD)
+
+EXTRA_DIST = README.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# libtcpreplay examples
+
+Since version 4.6 the Tcpreplay Suite installs **libtcpreplay**, a static
+library exposing the same replay engine the `tcpreplay` binary uses, via
+`tcpreplay_api.h` (#133). This lets applications replay pcap files and read
+live statistics programmatically instead of forking the binary and scraping
+its output.
+
+## Building against an installed libtcpreplay
+
+Headers install under `$(includedir)/tcpreplay/` and a pkg-config file is
+provided. Because the library is static, ask pkg-config for the private
+dependencies too:
+
+```sh
+cc replay_stats.c $(pkg-config --cflags --libs --static libtcpreplay) -o replay_stats
+sudo ./replay_stats eth0 test.pcap
+```
+
+## Examples
+
+* `replay_stats.c` — the minimal flow: `tcpreplay_init()`, configure with the
+  `tcpreplay_set_*()` setters and `tcpreplay_add_pcapfile()`, validate/open
+  with `tcpreplay_prepare()`, run `tcpreplay_replay()`, then read the final
+  counters from `tcpreplay_get_stats()`. The same stats call can be made from
+  another thread while the replay is running to stream live statistics.
+
+These examples are compiled as part of the normal build (they are not
+installed), so they always match the current API.
+
+## Notes
+
+* Replaying requires the same privileges as the `tcpreplay` binary (root or
+  CAP_NET_RAW on Linux).
+* The library is currently static-only and its API/ABI follows the suite's
+  version, so rebuild your application when upgrading Tcpreplay.

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,36 @@ cc replay_stats.c $(pkg-config --cflags --libs --static libtcpreplay) -o replay_
 sudo ./replay_stats eth0 test.pcap
 ```
 
+### With CMake
+
+The same pkg-config data drives a CMake consumer; use the `_STATIC_`
+variables so the static library's full dependency closure is linked:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(replay_stats C)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(TCPREPLAY REQUIRED libtcpreplay)
+
+add_executable(replay_stats replay_stats.c)
+target_include_directories(replay_stats PRIVATE ${TCPREPLAY_STATIC_INCLUDE_DIRS})
+target_link_directories(replay_stats PRIVATE ${TCPREPLAY_STATIC_LIBRARY_DIRS})
+target_link_libraries(replay_stats PRIVATE ${TCPREPLAY_STATIC_LIBRARIES})
+```
+
+```sh
+cmake -B build
+cmake --build build
+sudo ./build/replay_stats eth0 test.pcap
+```
+
+(If libtcpreplay is installed to a non-default prefix, point pkg-config at
+it: `PKG_CONFIG_PATH=/opt/tcpreplay/lib/pkgconfig cmake -B build`.)
+
+The in-tree copies of these examples are also built by the suite's own
+CMake build: `cmake --build build --target replay_stats`.
+
 ## Examples
 
 * `replay_stats.c` — the minimal flow: `tcpreplay_init()`, configure with the

--- a/examples/replay_stats.c
+++ b/examples/replay_stats.c
@@ -35,7 +35,7 @@ int
 main(int argc, char *argv[])
 {
     tcpreplay_t *ctx;
-    const tcpreplay_stats_t *stats;
+    const tcpreplay_stats_t *stats = NULL;
     struct timespec elapsed;
 
     if (argc != 3) {

--- a/examples/replay_stats.c
+++ b/examples/replay_stats.c
@@ -34,7 +34,7 @@
 int
 main(int argc, char *argv[])
 {
-    tcpreplay_t *ctx;
+    tcpreplay_t *ctx = NULL;
     const tcpreplay_stats_t *stats = NULL;
     struct timespec elapsed;
 

--- a/examples/replay_stats.c
+++ b/examples/replay_stats.c
@@ -1,0 +1,81 @@
+/*
+ *   Copyright (c) 2013-2026 Fred Klassen <tcpreplay at appneta dot com> - AppNeta
+ *
+ *   The Tcpreplay Suite of tools is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or with the authors permission any later version.
+ *
+ *   The Tcpreplay Suite is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Minimal libtcpreplay example (#133): replay a pcap file onto an interface
+ * at top speed and print the statistics tcpreplay normally writes to stdout,
+ * without forking the tcpreplay binary or scraping its output.
+ *
+ * Against an installed libtcpreplay:
+ *
+ *   cc replay_stats.c $(pkg-config --cflags --libs --static libtcpreplay) -o replay_stats
+ *   sudo ./replay_stats <interface> <file.pcap>
+ */
+
+#include "defines.h"
+#include "config.h"
+#include "tcpreplay_api.h"
+#include <stdio.h>
+
+int
+main(int argc, char *argv[])
+{
+    tcpreplay_t *ctx;
+    const tcpreplay_stats_t *stats;
+    struct timespec elapsed;
+
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <interface> <file.pcap>\n", argv[0]);
+        return 1;
+    }
+
+    ctx = tcpreplay_init();
+
+    if (tcpreplay_set_interface(ctx, intf1, argv[1]) < 0 || tcpreplay_add_pcapfile(ctx, argv[2]) < 0 ||
+        tcpreplay_set_speed_mode(ctx, speed_topspeed) < 0 || tcpreplay_set_loop(ctx, 1) < 0) {
+        fprintf(stderr, "setup failed: %s\n", tcpreplay_geterr(ctx));
+        tcpreplay_close(ctx);
+        return 1;
+    }
+
+    /* validates the configuration and opens the interface(s) */
+    if (tcpreplay_prepare(ctx) < 0) {
+        fprintf(stderr, "prepare failed: %s\n", tcpreplay_geterr(ctx));
+        tcpreplay_close(ctx);
+        return 1;
+    }
+
+    if (tcpreplay_replay(ctx) < 0) {
+        fprintf(stderr, "replay failed: %s\n", tcpreplay_geterr(ctx));
+        tcpreplay_close(ctx);
+        return 1;
+    }
+
+    /* tcpreplay_get_stats() may also be polled from another thread while
+     * tcpreplay_replay() is running, e.g. to stream live statistics
+     */
+    stats = tcpreplay_get_stats(ctx);
+    timessub(&stats->end_time, &stats->start_time, &elapsed);
+
+    printf("packets sent:  " COUNTER_SPEC "\n", stats->pkts_sent);
+    printf("bytes sent:    " COUNTER_SPEC "\n", stats->bytes_sent);
+    printf("failed:        " COUNTER_SPEC "\n", stats->failed);
+    printf("elapsed:       %lld.%09ld seconds\n", (long long)elapsed.tv_sec, elapsed.tv_nsec);
+
+    tcpreplay_close(ctx);
+    return 0;
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,10 @@
 # (mirrors lib/Makefile.am's SYSTEM_STRLCPY conditional).
 
 if(NOT HAVE_STRLCPY)
-    add_library(strl STATIC strlcat.c strlcpy.c)
-    target_include_directories(strl PRIVATE
+    # object library so the installable libtcpreplay archive can fold these
+    # objects in (#133); the 'strl' static wrapper keeps consumers unchanged
+    add_library(strl_obj OBJECT strlcat.c strlcpy.c)
+    target_include_directories(strl_obj PRIVATE
         ${TCPR_GENERATED_INCLUDE_DIRS} ${TCPR_SOURCE_INCLUDE_DIRS})
+    add_library(strl STATIC $<TARGET_OBJECTS:strl_obj>)
 endif()

--- a/libopts/CMakeLists.txt
+++ b/libopts/CMakeLists.txt
@@ -2,11 +2,18 @@
 # libopts.c #includes every other translation unit, so this is a single-TU build
 # (same as libopts/Makefile.am's libopts_la_SOURCES = libopts.c).
 
-add_library(opts STATIC libopts.c)
+# object library so the installable libtcpreplay archive can fold the tearoff
+# in (#133); the 'opts' static wrapper keeps every existing consumer unchanged
+add_library(opts_obj OBJECT libopts.c)
+target_include_directories(opts_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/autoopts
+    ${TCPR_GENERATED_INCLUDE_DIRS})
+# The tearoff triggers plenty of warnings on modern compilers; it is vendored
+# code we don't maintain, so keep the build output focused on our own sources.
+target_compile_options(opts_obj PRIVATE -w)
+
+add_library(opts STATIC $<TARGET_OBJECTS:opts_obj>)
 target_include_directories(opts PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/autoopts)
-target_include_directories(opts PRIVATE ${TCPR_GENERATED_INCLUDE_DIRS})
-# The tearoff triggers plenty of warnings on modern compilers; it is vendored
-# code we don't maintain, so keep the build output focused on our own sources.
-target_compile_options(opts PRIVATE -w)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,12 +201,25 @@ install(TARGETS ${TCPR_INSTALL_TARGETS} RUNTIME DESTINATION ${CMAKE_INSTALL_PREF
 # libtcpreplay - installable static library exposing tcpreplay_api.h (#133)
 # (mirrors the lib_LIBRARIES/tcpreplayinclude_HEADERS rules in Makefile.am)
 # ---------------------------------------------------------------------------
+# tcpreplay_opts.c is compiled by both tcpreplay_bin and this library; with
+# the Makefiles generator each consuming target would otherwise emit its own
+# copy of the autogen rule, and two concurrent autogen runs corrupt the
+# output.  Funnel generation through one custom target instead.
+if(AUTOGEN_EXECUTABLE)
+    add_custom_target(tcpreplay_opts_gen
+        DEPENDS ${TCPR_AUTOGEN_OPTS_DIR}/tcpreplay_opts.c ${TCPR_AUTOGEN_OPTS_DIR}/tcpreplay_opts.h)
+    add_dependencies(tcpreplay_bin tcpreplay_opts_gen)
+endif()
+
 add_library(tcpreplay_static STATIC
     ${tcpreplay_opts_SOURCE}
     send_packets.c signal_handler.c tcpreplay_api.c sleep.c replay.c
     libtcpreplay_globals.c
     $<TARGET_OBJECTS:common_obj>
     $<TARGET_OBJECTS:opts_obj>)
+if(TARGET tcpreplay_opts_gen)
+    add_dependencies(tcpreplay_static tcpreplay_opts_gen)
+endif()
 if(NOT HAVE_STRLCPY)
     target_sources(tcpreplay_static PRIVATE $<TARGET_OBJECTS:strl_obj>)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,62 @@ endif()
 install(TARGETS ${TCPR_INSTALL_TARGETS} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 # ---------------------------------------------------------------------------
+# libtcpreplay - installable static library exposing tcpreplay_api.h (#133)
+# (mirrors the lib_LIBRARIES/tcpreplayinclude_HEADERS rules in Makefile.am)
+# ---------------------------------------------------------------------------
+add_library(tcpreplay_static STATIC
+    ${tcpreplay_opts_SOURCE}
+    send_packets.c signal_handler.c tcpreplay_api.c sleep.c replay.c
+    libtcpreplay_globals.c
+    $<TARGET_OBJECTS:common_obj>
+    $<TARGET_OBJECTS:opts_obj>)
+if(NOT HAVE_STRLCPY)
+    target_sources(tcpreplay_static PRIVATE $<TARGET_OBJECTS:strl_obj>)
+endif()
+set_target_properties(tcpreplay_static PROPERTIES OUTPUT_NAME tcpreplay)
+target_compile_definitions(tcpreplay_static PRIVATE TCPREPLAY)
+tcpr_binary_common(tcpreplay_static)
+target_include_directories(tcpreplay_static PRIVATE
+    ${CMAKE_SOURCE_DIR}/libopts ${CMAKE_SOURCE_DIR}/libopts/autoopts)
+
+install(TARGETS tcpreplay_static ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(FILES tcpreplay_api.h tcpreplay.h tcpr.h common.h
+        ${CMAKE_BINARY_DIR}/src/defines.h ${CMAKE_BINARY_DIR}/src/config.h
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/tcpreplay)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/common/
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/tcpreplay/common
+        FILES_MATCHING PATTERN "*.h")
+
+# libtcpreplay.pc: reuse the autotools template; the tearoff is always folded
+# into the archive in CMake builds so no -lopts is needed
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "\${prefix}")
+set(libdir "\${exec_prefix}/lib")
+set(includedir "\${prefix}/include")
+set(VERSION ${PROJECT_VERSION})
+# entries may be bare library names or ready-made -l/-L/absolute-path flags
+function(tcpr_pc_libs out)
+    set(_flags "")
+    foreach(_l ${ARGN})
+        if(_l MATCHES "^-" OR _l MATCHES "^/")
+            list(APPEND _flags "${_l}")
+        else()
+            list(APPEND _flags "-l${_l}")
+        endif()
+    endforeach()
+    string(REPLACE ";" " " _s "${_flags}")
+    set(${out} "${_s}" PARENT_SCOPE)
+endfunction()
+tcpr_pc_libs(LPCAPLIB ${PCAP_LIBRARIES})
+tcpr_pc_libs(LDNETLIB ${DNET_LIBRARIES})
+tcpr_pc_libs(LIBS ${TCPR_SYSTEM_LIBS})
+set(LIBTCPREPLAY_PCLIBS "")
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libtcpreplay.pc.in
+               ${CMAKE_CURRENT_BINARY_DIR}/libtcpreplay.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libtcpreplay.pc
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+
+# ---------------------------------------------------------------------------
 # man pages (optional target, requires autogen; mirrors the manpages target)
 # ---------------------------------------------------------------------------
 if(AUTOGEN_EXECUTABLE)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,6 +87,53 @@ tcpreplay_LDFLAGS = -framework CoreServices -framework Carbon
 tcpreplay_edit_LDFLAGS = -framework CoreServices -framework Carbon
 endif
 
+######################################################################
+# libtcpreplay - installable static library exposing tcpreplay_api.h (#133)
+#
+# Additive: the tcpreplay binary keeps building from its own objects; the
+# library recompiles the same engine sources (per-target flags give the
+# objects unique names) plus everything from common/ so a single archive
+# is self-contained apart from libpcap and (system) libopts.
+######################################################################
+lib_LIBRARIES = libtcpreplay.a
+libtcpreplay_a_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. $(LNAV_CFLAGS) @LDNETINC@ -DTCPREPLAY
+libtcpreplay_a_SOURCES = send_packets.c signal_handler.c tcpreplay_api.c sleep.c replay.c \
+	libtcpreplay_globals.c \
+	common/cidr.c common/err.c common/list.c common/cache.c common/services.c common/get.c \
+	common/fakepcap.c common/fakepcapnav.c common/fakepoll.c common/xX.c common/utils.c \
+	common/timer.c common/sendpacket.c common/dlt_names.c common/mac.c common/interface.c \
+	common/flows.c common/txring.c
+nodist_libtcpreplay_a_SOURCES = tcpreplay_opts.c common/git_version.c
+if ENABLE_TCPDUMP
+libtcpreplay_a_SOURCES += common/tcpdump.c
+endif
+if COMPILE_NETMAP
+libtcpreplay_a_SOURCES += common/netmap.c
+endif
+if !SYSTEM_STRLCPY
+libtcpreplay_a_SOURCES += ../lib/strlcpy.c ../lib/strlcat.c
+endif
+if NEED_LIBOPTS
+# libopts tearoff builds aren't installed, so fold the tearoff into the
+# archive to keep the installed library self-contained
+nodist_libtcpreplay_a_SOURCES += ../libopts/libopts.c
+endif
+
+# public headers, installed under $(includedir)/tcpreplay preserving layout
+# so the internal '#include <common/...>' / '#include "config.h"' includes
+# resolve with the single -I from libtcpreplay.pc's Cflags
+tcpreplayincludedir = $(includedir)/tcpreplay
+nobase_tcpreplayinclude_HEADERS = tcpreplay_api.h tcpreplay.h tcpr.h common.h \
+	common/cache.h common/cidr.h common/dlt_names.h common/err.h common/fakepcap.h \
+	common/fakepcapnav.h common/fakepoll.h common/flows.h common/get.h common/interface.h \
+	common/list.h common/mac.h common/netmap.h common/pcap_dlt.h common/sendpacket.h \
+	common/services.h common/tcpdump.h common/timer.h common/txring.h common/utils.h \
+	common/xX.h
+nodist_tcpreplayinclude_HEADERS = defines.h config.h
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libtcpreplay.pc
+
 tcpliveplay_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. $(LNAV_CFLAGS) -DTCPREPLAY -DTCPLIVEPLAY
 tcpliveplay_SOURCES = tcpliveplay_opts.c tcpliveplay.c
 tcpliveplay_LDADD = ./common/libcommon.a $(LIBSTRL) @LPCAPLIB@ @LDNETLIB@ $(LIBOPTS_LDADD)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -25,18 +25,28 @@ if(HAVE_NETMAP)
     list(APPEND COMMON_SOURCES netmap.c)
 endif()
 
-add_library(common STATIC ${COMMON_SOURCES})
-target_include_directories(common PUBLIC
+# object library so the installable libtcpreplay archive can fold these
+# objects in (#133); the 'common' static wrapper keeps every existing
+# consumer unchanged
+add_library(common_obj OBJECT ${COMMON_SOURCES})
+target_include_directories(common_obj PRIVATE
     ${TCPR_GENERATED_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${TCPR_SOURCE_INCLUDE_DIRS}
     ${PCAP_INCLUDE_DIR})
 if(LNAV_CFLAGS)
-    target_compile_options(common PRIVATE ${LNAV_CFLAGS})
+    target_compile_options(common_obj PRIVATE ${LNAV_CFLAGS})
 endif()
 if(DNET_CFLAGS)
-    target_compile_options(common PRIVATE ${DNET_CFLAGS})
+    target_compile_options(common_obj PRIVATE ${DNET_CFLAGS})
 endif()
+
+add_library(common STATIC $<TARGET_OBJECTS:common_obj>)
+target_include_directories(common PUBLIC
+    ${TCPR_GENERATED_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${TCPR_SOURCE_INCLUDE_DIRS}
+    ${PCAP_INCLUDE_DIR})
 if(NOT HAVE_STRLCPY)
     target_link_libraries(common PUBLIC strl)
 endif()

--- a/src/libtcpreplay.pc.in
+++ b/src/libtcpreplay.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libtcpreplay
+Description: pcap file replay engine of the Tcpreplay Suite (tcpreplay_api.h)
+URL: https://tcpreplay.appneta.com
+Version: @VERSION@
+Libs: -L${libdir} -ltcpreplay
+Libs.private: @LPCAPLIB@ @LDNETLIB@ @LIBTCPREPLAY_PCLIBS@ @LIBS@
+Cflags: -I${includedir}/tcpreplay

--- a/src/libtcpreplay_globals.c
+++ b/src/libtcpreplay_globals.c
@@ -1,0 +1,35 @@
+/*
+ *   Copyright (c) 2013-2026 Fred Klassen <tcpreplay at appneta dot com> - AppNeta
+ *
+ *   The Tcpreplay Suite of tools is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or with the authors permission any later version.
+ *
+ *   The Tcpreplay Suite is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Globals normally defined by each tool's main() translation unit
+ * (tcpreplay.c), provided here so applications linking libtcpreplay don't
+ * have to define them themselves (#133):
+ * - debug: level used by the dbg()/dbgx() macros in --enable-debug builds
+ * - ctx: context the SIGUSR1/SIGCONT suspend/resume signal handlers act on;
+ *   it stays NULL unless the application installs those handlers itself
+ */
+
+#include "defines.h"
+#include "config.h"
+#include "tcpreplay_api.h"
+
+#ifdef DEBUG
+int debug = 0;
+#endif
+
+tcpreplay_t *ctx;

--- a/src/libtcpreplay_globals.c
+++ b/src/libtcpreplay_globals.c
@@ -32,4 +32,5 @@
 int debug = 0;
 #endif
 
-tcpreplay_t *ctx;
+/* mutable by design: mirrors the global the tcpreplay binary itself defines */
+tcpreplay_t *ctx; /* NOLINT */


### PR DESCRIPTION
## Summary

Implements #133 (open since 2014): applications wanting programmatic replay and live statistics had to fork the `tcpreplay` binary and scrape its output — the exact pain described in the issue thread — even though `tcpreplay_api.h` has offered `tcpreplay_init()` / `tcpreplay_set_*()` / `tcpreplay_add_pcapfile()` / `tcpreplay_prepare()` / `tcpreplay_replay()` / `tcpreplay_get_stats()` for years. Nothing was installed and there were no usage examples.

## What gets installed (both build systems)

- **`libtcpreplay.a`** — the replay engine plus everything from `common/` (and the libopts tearoff when in use), recompiled with per-target flags so the `tcpreplay` binary's own build is completely untouched. Self-contained apart from libpcap and system libopts.
- **Headers** under `include/tcpreplay/`, preserving layout so the internal `#include <common/...>` / `#include "config.h"` style resolves with the single `-I` from pkg-config.
- **`libtcpreplay.pc`** with the full static dependency closure in `Libs.private`:
  ```
  cc myapp.c $(pkg-config --cflags --libs --static libtcpreplay) -o myapp
  ```

`src/libtcpreplay_globals.c` provides the `debug`/`ctx` globals each tool's `main()` normally defines. On the CMake side, `common`/`opts`/`strl` become OBJECT libraries with static wrappers (every existing consumer unchanged) so the installed archive can fold their objects; the `.pc` is generated from the same template.

## Example

`examples/replay_stats.c` demonstrates the full API flow — the statistics use case from the issue thread — and builds as part of `make` (noinst), so it can never drift from the API. `examples/README.md` documents installed-library usage.

## Testing

- **Both build systems, external-consumer round trip**: install to a prefix, compile the example *purely* from `pkg-config --cflags --libs --static libtcpreplay` (no in-tree paths), replay `test.pcap` on loopback — 179 packets sent, statistics read through the API.
- In-tree example builds and runs identically.
- `make dist` packages the new files; full `sudo make test` suite passes.

## Scope notes

Static library only for v1 — a shared library needs PIC conversion of all convenience libraries plus symbol-visibility work, and the API/ABI currently follows the suite version (documented in examples/README.md). Both are natural follow-ups if demand appears.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)