### PR TITLE
cmake: propagate netmap include dir/define to libtcpreplay consumers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,17 @@ target_compile_definitions(tcpreplay_static PRIVATE TCPREPLAY)
 tcpr_binary_common(tcpreplay_static)
 target_include_directories(tcpreplay_static PRIVATE
     ${CMAKE_SOURCE_DIR}/libopts ${CMAKE_SOURCE_DIR}/libopts/autoopts)
+if(HAVE_NETMAP)
+    # tcpreplay_api.h (via common/sendpacket.h) conditionally includes
+    # net/netmap.h, so any consumer compiling against the installed headers
+    # needs these too - PUBLIC exports them as usage requirements. The plain
+    # include_directories()/add_compile_definitions() above only cover
+    # targets under this directory (src/ and its subdirectories); they don't
+    # reach sibling directories like examples/, added separately from the
+    # top-level CMakeLists.txt.
+    target_include_directories(tcpreplay_static PUBLIC ${NETMAP_INCLUDE_DIR})
+    target_compile_definitions(tcpreplay_static PUBLIC NETMAP_WITH_LIBS)
+endif()
 
 install(TARGETS tcpreplay_static ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(FILES tcpreplay_api.h tcpreplay.h tcpr.h common.h


### PR DESCRIPTION
## Summary

- `cmake -B build -DWITH_NETMAP=/path/to/netmap` fails building `examples/replay_stats` with `fatal error: net/netmap.h: No such file or directory`, even though the rest of the suite (`tcpreplay`, `tcprewrite`, etc.) builds fine.
- Root cause: `HAVE_NETMAP`'s `include_directories(${NETMAP_INCLUDE_DIR})` / `add_compile_definitions(NETMAP_WITH_LIBS)` in `src/CMakeLists.txt` are directory-scoped CMake commands — they only apply to targets defined in `src/` and its subdirectories. `examples/` is added as a *sibling* subdirectory from the top-level `CMakeLists.txt`, so it never inherits them. `examples/replay_stats.c` pulls in `net/netmap.h` transitively via `tcpreplay_api.h` -> `common/sendpacket.h`, and has no other way to see the netmap include path.
- Fix: export `NETMAP_INCLUDE_DIR`/`NETMAP_WITH_LIBS` as `PUBLIC` usage requirements on the `tcpreplay_static` target (the installable `libtcpreplay.a`) instead of relying on directory scope. Any consumer that links against it — in-tree (`examples/replay_stats`) or an external application built against the installed `libtcpreplay.a` + headers — now picks them up automatically via normal CMake target propagation.
- autotools is unaffected and was already correct: `NETMAP_CFLAGS` is folded into the global `CFLAGS` once, near `AC_OUTPUT` (see the comment in `configure.ac`), which every compiled object — including `examples/replay_stats.c` — already sees. Verified by building `examples/` under autotools with `--with-netmap`: the compile step succeeds (only a missing prerequisite from building the subdirectory in isolation, unrelated to netmap).

## Test plan

- [x] `cmake -B build -DWITH_NETMAP=<checkout>` + `cmake --build build` (full build) succeeds
- [x] `cmake --build build --target replay_stats` succeeds (previously failed with the `net/netmap.h` error)
- [x] Confirmed autotools (`./configure --with-netmap=<checkout>`) was never affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)