### PR TITLE
docs: fix 'make docs' HTML rendering for out-of-tree builds

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -5,25 +5,25 @@ MAKEFLAGS=-s
 docs: clean-docs manpages
 
 web/tcpreplay.html:
-	mkdir -p web; @GROFF@ -Thtml -mman ../src/tcpreplay.1 > web/tcpreplay.html
+	mkdir -p web; @GROFF@ -Thtml -mman $(top_srcdir)/src/tcpreplay.1 > web/tcpreplay.html
 
 web/tcpprep.html:
-	@GROFF@ -Thtml -mman ../src/tcpprep.1 > web/tcpprep.html
+	@GROFF@ -Thtml -mman $(top_srcdir)/src/tcpprep.1 > web/tcpprep.html
 
 web/tcprewrite.html:
-	@GROFF@ -Thtml -mman ../src/tcprewrite.1 > web/tcprewrite.html
+	@GROFF@ -Thtml -mman $(top_srcdir)/src/tcprewrite.1 > web/tcprewrite.html
 
 web/tcpbridge.html:
-	@GROFF@ -Thtml -mman ../src/tcpbridge.1 > web/tcpbridge.html
+	@GROFF@ -Thtml -mman $(top_srcdir)/src/tcpbridge.1 > web/tcpbridge.html
 
 web/tcpreplay-edit.html:
-	@GROFF@ -Thtml -mman ../src/tcpreplay-edit.1 > web/tcpreplay-edit.html
+	@GROFF@ -Thtml -mman $(top_srcdir)/src/tcpreplay-edit.1 > web/tcpreplay-edit.html
 
 web/tcpliveplay.html:
-	@GROFF@ -Thtml -mman ../src/tcpliveplay.1 > web/tcpliveplay.html
+	@GROFF@ -Thtml -mman $(top_srcdir)/src/tcpliveplay.1 > web/tcpliveplay.html
 
 web/tcpcapinfo.html:
-	@GROFF@ -Thtml -mman ../src/tcpcapinfo.1 > web/tcpcapinfo.html
+	@GROFF@ -Thtml -mman $(top_srcdir)/src/tcpcapinfo.1 > web/tcpcapinfo.html
 
 manpages: web/tcpreplay.html web/tcpprep.html web/tcprewrite.html \
     web/tcpbridge.html web/tcpreplay-edit.html web/tcpliveplay.html \


### PR DESCRIPTION
## Summary

- `make docs` fails on an out-of-tree build (`mkdir build && cd build && ../configure && make && make docs`) with:
  ```
  soelim: error: can't open '../src/tcpreplay.1': No such file or directory
  ```
- `docs/Makefile.am`'s `web/*.html` rules reference the man pages via the hardcoded relative path `../src/X.1`, which only resolves correctly when the build directory and source directory are the same.
- Since #895 phase 1 (`e55c0583`), the `*_opts.def` -> `*.1` rules in `src/Makefile.am` always write their output into `$(srcdir)` (so the generated files can be committed to git and shipped in tarballs — see `CLAUDE.md`). For an out-of-tree build, `../src/X.1` (relative to the build tree's `docs/` directory) never existed, while `$(srcdir)`'s copy did.
- Fix: use `$(top_srcdir)/src/X.1` instead, which resolves correctly for both in-tree and out-of-tree builds.
- Not caught earlier because `make docs` isn't part of the CI-exercised path (`make`/`make dist`/`make test`); it's only invoked manually to publish the website's man pages.

## Test plan

- [x] Fresh out-of-tree build (`../autogen.sh; ../configure; make`) followed by `make docs` — all 7 `web/*.html` files generated successfully (previously failed on the first one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)