### PR TITLE
build: write generated *_opts.c/h/.adoc/.1 atomically to fix dist-tarball rebuilds

### DIFF
--- a/scripts/autoopts/generate.py
+++ b/scripts/autoopts/generate.py
@@ -15,6 +15,7 @@ GNU autogen.  See README.md in this directory.
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -83,7 +84,14 @@ def main(argv=None):
             elif out.exists() and out.read_text() == text:
                 print(f"current {out.relative_to(top)}")
             else:
-                out.write_text(text)
+                # Write to a temp file and rename over the target rather
+                # than writing it directly: a dist tarball extracted
+                # read-only (or any other reason the existing file isn't
+                # writable) only needs the containing directory to be
+                # writable for a rename to replace it (#895 follow-up).
+                tmp = out.with_suffix(out.suffix + ".tmp")
+                tmp.write_text(text)
+                os.replace(tmp, out)
                 print(f"wrote   {out.relative_to(top)}")
     return rc
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,27 +67,36 @@ function(tcpr_autogen_opts base def)
     if(_stale)
         if(PYTHON3_EXECUTABLE)
             message(STATUS "Regenerating ${base}.c/h and ${_manbase}.adoc with python3")
+            # Write to a .tmp path and rename over the real target rather than
+            # writing it directly: a dist tarball extracted read-only (or any
+            # other reason the existing file isn't writable) only needs the
+            # containing directory to be writable for rename() to replace it -
+            # OUTPUT_FILE writing straight to ${_out_h} would instead fail
+            # with a permission error on such a file (#895 follow-up).
             execute_process(
                 COMMAND ${PYTHON3_EXECUTABLE} ${AUTOOPTS_DIR}/emit_h.py ${base} ${def} "${ARG_DEFINES}"
-                OUTPUT_FILE ${_out_h}
+                OUTPUT_FILE ${_out_h}.tmp
                 RESULT_VARIABLE _rc)
             if(NOT _rc EQUAL 0)
                 message(FATAL_ERROR "emit_h.py failed regenerating ${base}.h from ${def}")
             endif()
+            file(RENAME ${_out_h}.tmp ${_out_h})
             execute_process(
                 COMMAND ${PYTHON3_EXECUTABLE} ${AUTOOPTS_DIR}/emit_c.py ${base} ${def} "${ARG_DEFINES}"
-                OUTPUT_FILE ${_out_c}
+                OUTPUT_FILE ${_out_c}.tmp
                 RESULT_VARIABLE _rc)
             if(NOT _rc EQUAL 0)
                 message(FATAL_ERROR "emit_c.py failed regenerating ${base}.c from ${def}")
             endif()
+            file(RENAME ${_out_c}.tmp ${_out_c})
             execute_process(
                 COMMAND ${PYTHON3_EXECUTABLE} ${AUTOOPTS_DIR}/emit_adoc.py ${_manbase} ${def} "${ARG_DEFINES}"
-                OUTPUT_FILE ${_out_adoc}
+                OUTPUT_FILE ${_out_adoc}.tmp
                 RESULT_VARIABLE _rc)
             if(NOT _rc EQUAL 0)
                 message(FATAL_ERROR "emit_adoc.py failed regenerating ${_manbase}.adoc from ${def}")
             endif()
+            file(RENAME ${_out_adoc}.tmp ${_out_adoc})
         else()
             message(FATAL_ERROR
                 "${base}.c/h or ${_manbase}.adoc is missing or older than ${def}, and python3 is "

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,46 +39,46 @@ opts_list=-L tcpedit
 autoopts_dir = $(abs_top_srcdir)/scripts/autoopts
 
 tcpprep.adoc: tcpprep_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpprep tcpprep_opts.def > tcpprep.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpprep tcpprep_opts.def > tcpprep.adoc.tmp && mv -f tcpprep.adoc.tmp tcpprep.adoc
 
 tcpprep.1: tcpprep.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpprep.1 tcpprep.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpprep.1.tmp tcpprep.adoc && mv -f tcpprep.1.tmp tcpprep.1
 
 tcprewrite.adoc: tcprewrite_opts.def tcpedit/tcpedit_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcprewrite tcprewrite_opts.def > tcprewrite.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcprewrite tcprewrite_opts.def > tcprewrite.adoc.tmp && mv -f tcprewrite.adoc.tmp tcprewrite.adoc
 
 tcprewrite.1: tcprewrite.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcprewrite.1 tcprewrite.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcprewrite.1.tmp tcprewrite.adoc && mv -f tcprewrite.1.tmp tcprewrite.1
 
 tcpreplay-edit.adoc: tcpreplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay-edit tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay-edit.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay-edit tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay-edit.adoc.tmp && mv -f tcpreplay-edit.adoc.tmp tcpreplay-edit.adoc
 
 tcpreplay-edit.1: tcpreplay-edit.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpreplay-edit.1 tcpreplay-edit.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpreplay-edit.1.tmp tcpreplay-edit.adoc && mv -f tcpreplay-edit.1.tmp tcpreplay-edit.1
 
 tcpreplay.adoc: tcpreplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay tcpreplay_opts.def > tcpreplay.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay tcpreplay_opts.def > tcpreplay.adoc.tmp && mv -f tcpreplay.adoc.tmp tcpreplay.adoc
 
 tcpreplay.1: tcpreplay.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpreplay.1 tcpreplay.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpreplay.1.tmp tcpreplay.adoc && mv -f tcpreplay.1.tmp tcpreplay.1
 
 tcpbridge.adoc: tcpbridge_opts.def tcpedit/tcpedit_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpbridge tcpbridge_opts.def > tcpbridge.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpbridge tcpbridge_opts.def > tcpbridge.adoc.tmp && mv -f tcpbridge.adoc.tmp tcpbridge.adoc
 
 tcpbridge.1: tcpbridge.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpbridge.1 tcpbridge.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpbridge.1.tmp tcpbridge.adoc && mv -f tcpbridge.1.tmp tcpbridge.1
 
 tcpliveplay.adoc: tcpliveplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpliveplay tcpliveplay_opts.def > tcpliveplay.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpliveplay tcpliveplay_opts.def > tcpliveplay.adoc.tmp && mv -f tcpliveplay.adoc.tmp tcpliveplay.adoc
 
 tcpliveplay.1: tcpliveplay.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpliveplay.1 tcpliveplay.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpliveplay.1.tmp tcpliveplay.adoc && mv -f tcpliveplay.1.tmp tcpliveplay.1
 
 tcpcapinfo.adoc: tcpcapinfo_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpcapinfo tcpcapinfo_opts.def > tcpcapinfo.adoc
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpcapinfo tcpcapinfo_opts.def > tcpcapinfo.adoc.tmp && mv -f tcpcapinfo.adoc.tmp tcpcapinfo.adoc
 
 tcpcapinfo.1: tcpcapinfo.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpcapinfo.1 tcpcapinfo.adoc
+	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpcapinfo.1.tmp tcpcapinfo.adoc && mv -f tcpcapinfo.1.tmp tcpcapinfo.1
 
 man_MANS = tcpreplay.1 tcpprep.1 tcprewrite.1 tcpreplay-edit.1 tcpcapinfo.1
 EXTRA_DIST = tcpreplay.1 tcpprep.1 tcprewrite.1 tcpbridge.1 tcpreplay-edit.1 \
@@ -104,10 +104,10 @@ tcpreplay_edit_OBJECTS: tcpreplay_edit_opts.h
 
 BUILT_SOURCES += tcpreplay_edit_opts.h
 tcpreplay_edit_opts.h: tcpreplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpreplay_edit_opts tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay_edit_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpreplay_edit_opts tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay_edit_opts.h.tmp && mv -f tcpreplay_edit_opts.h.tmp tcpreplay_edit_opts.h
 
 tcpreplay_edit_opts.c: tcpreplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpreplay_edit_opts tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay_edit_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpreplay_edit_opts tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay_edit_opts.c.tmp && mv -f tcpreplay_edit_opts.c.tmp tcpreplay_edit_opts.c
 
 tcpreplay_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. $(LNAV_CFLAGS) @LDNETINC@ -DTCPREPLAY
 tcpreplay_SOURCES = tcpreplay_opts.c send_packets.c signal_handler.c tcpreplay.c tcpreplay_api.c sleep.c replay.c
@@ -116,10 +116,10 @@ tcpreplay_OBJECTS: tcpreplay_opts.h
 
 BUILT_SOURCES += tcpreplay_opts.h
 tcpreplay_opts.h: tcpreplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpreplay_opts tcpreplay_opts.def > tcpreplay_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpreplay_opts tcpreplay_opts.def > tcpreplay_opts.h.tmp && mv -f tcpreplay_opts.h.tmp tcpreplay_opts.h
 
 tcpreplay_opts.c: tcpreplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpreplay_opts tcpreplay_opts.def > tcpreplay_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpreplay_opts tcpreplay_opts.def > tcpreplay_opts.c.tmp && mv -f tcpreplay_opts.c.tmp tcpreplay_opts.c
 
 if ENABLE_OSX_FRAMEWORKS
 tcpreplay_LDFLAGS = -framework CoreServices -framework Carbon
@@ -180,10 +180,10 @@ tcpliveplay_OBJECTS: tcpliveplay_opts.h
 
 BUILT_SOURCES += tcpliveplay_opts.h
 tcpliveplay_opts.h: tcpliveplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpliveplay_opts tcpliveplay_opts.def > tcpliveplay_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpliveplay_opts tcpliveplay_opts.def > tcpliveplay_opts.h.tmp && mv -f tcpliveplay_opts.h.tmp tcpliveplay_opts.h
 
 tcpliveplay_opts.c: tcpliveplay_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpliveplay_opts tcpliveplay_opts.def > tcpliveplay_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpliveplay_opts tcpliveplay_opts.def > tcpliveplay_opts.c.tmp && mv -f tcpliveplay_opts.c.tmp tcpliveplay_opts.c
 
 
 tcprewrite_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. -I$(srcdir)/tcpedit @LDNETINC@ $(LNAV_CFLAGS) -DTCPREWRITE -DHAVE_CACHEFILE_SUPPORT
@@ -195,10 +195,10 @@ tcprewrite_OBJECTS: tcprewrite_opts.h
 
 BUILT_SOURCES += tcprewrite_opts.h
 tcprewrite_opts.h: tcprewrite_opts.def tcpedit/tcpedit_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcprewrite_opts tcprewrite_opts.def > tcprewrite_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcprewrite_opts tcprewrite_opts.def > tcprewrite_opts.h.tmp && mv -f tcprewrite_opts.h.tmp tcprewrite_opts.h
 
 tcprewrite_opts.c: tcprewrite_opts.def tcpedit/tcpedit_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcprewrite_opts tcprewrite_opts.def > tcprewrite_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcprewrite_opts tcprewrite_opts.def > tcprewrite_opts.c.tmp && mv -f tcprewrite_opts.c.tmp tcprewrite_opts.c
 
 tcpcapinfo_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. $(LNAV_CFLAGS) @LDNETINC@ -DTCPCAPINFO
 tcpcapinfo_LDADD = ./common/libcommon.a \
@@ -208,10 +208,10 @@ tcpcapinfo_OBJECTS: tcpcapinfo_opts.h
 
 BUILT_SOURCES += tcpcapinfo_opts.h
 tcpcapinfo_opts.h: tcpcapinfo_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpcapinfo_opts tcpcapinfo_opts.def > tcpcapinfo_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpcapinfo_opts tcpcapinfo_opts.def > tcpcapinfo_opts.h.tmp && mv -f tcpcapinfo_opts.h.tmp tcpcapinfo_opts.h
 
 tcpcapinfo_opts.c: tcpcapinfo_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpcapinfo_opts tcpcapinfo_opts.def > tcpcapinfo_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpcapinfo_opts tcpcapinfo_opts.def > tcpcapinfo_opts.c.tmp && mv -f tcpcapinfo_opts.c.tmp tcpcapinfo_opts.c
 
 tcpprep_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. $(LNAV_CFLAGS) @LDNETINC@ -DTCPPREP
 tcpprep_LDADD = ./common/libcommon.a \
@@ -221,10 +221,10 @@ tcpprep_OBJECTS: tcpprep_opts.h
 
 BUILT_SOURCES += tcpprep_opts.h
 tcpprep_opts.h: tcpprep_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpprep_opts tcpprep_opts.def > tcpprep_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpprep_opts tcpprep_opts.def > tcpprep_opts.h.tmp && mv -f tcpprep_opts.h.tmp tcpprep_opts.h
 
 tcpprep_opts.c: tcpprep_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpprep_opts tcpprep_opts.def > tcpprep_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpprep_opts tcpprep_opts.def > tcpprep_opts.c.tmp && mv -f tcpprep_opts.c.tmp tcpprep_opts.c
 
 tcpbridge_CFLAGS = $(LIBOPTS_CFLAGS) -I$(srcdir)/.. -I$(srcdir)/tcpedit $(LNAV_CFLAGS) @LDNETINC@ -DTCPBRIDGE
 tcpbridge_LDADD = ./tcpedit/libtcpedit.a ./common/libcommon.a \
@@ -237,10 +237,10 @@ tcpbridge_OBJECTS: tcpbridge_opts.h
 
 BUILT_SOURCES += tcpbridge_opts.h
 tcpbridge_opts.h: tcpbridge_opts.def tcpedit/tcpedit_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpbridge_opts tcpbridge_opts.def > tcpbridge_opts.h
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_h.py tcpbridge_opts tcpbridge_opts.def > tcpbridge_opts.h.tmp && mv -f tcpbridge_opts.h.tmp tcpbridge_opts.h
 
 tcpbridge_opts.c: tcpbridge_opts.def tcpedit/tcpedit_opts.def
-	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpbridge_opts tcpbridge_opts.def > tcpbridge_opts.c
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_c.py tcpbridge_opts tcpbridge_opts.def > tcpbridge_opts.c.tmp && mv -f tcpbridge_opts.c.tmp tcpbridge_opts.c
 
 noinst_HEADERS = tcpreplay.h tcpprep.h bridge.h defines.h tree.h tcpliveplay.h \
 		 send_packets.h signal_handler.h common.h tcpreplay_opts.h tcpliveplay_opts.h \


### PR DESCRIPTION
## Summary

Fixes #1033, a regression introduced by #1030.

Since #1030 stopped committing `src/*_opts.c/h/.adoc/.1`, they're regenerated at build time by writing directly into the existing target path - shell `> file` redirection in `src/Makefile.am`, CMake's `execute_process(... OUTPUT_FILE ...)`, and `Path.write_text()` in `scripts/autoopts/generate.py`. All three require the target file, if it already exists, to be writable - which a file extracted from a `make dist` tarball is not guaranteed to be (e.g. packaged with a strict umask, or extracted as a different user than the one building). Reported by @grandpappydude building from a fresh tarball:

\`\`\`
cd ../../src && /usr/bin/python3 .../scripts/autoopts/emit_h.py tcpreplay_edit_opts tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay_edit_opts.h
/bin/bash: line 1: tcpreplay_edit_opts.h: Permission denied
\`\`\`

Reproduced locally: \`chmod 444\` on a freshly extracted tarball's \`src/tcpreplay_edit_opts.h\`, touch its \`.def\` to force a rebuild - identical error.

## Fix

Write to a sibling \`.tmp\` path and rename over the real target instead, in all three code paths. `rename()`/`file(RENAME)`/`os.replace()` only require the *containing directory* to be writable, not the target file itself - sidestepping the whole class of "existing file isn't writable" failures regardless of cause. This is also strictly safer than direct `> file` writes even in the common case: a generator crash mid-write can no longer leave a truncated/corrupt target behind, since the old file is never touched until the new one is fully written.

`src/tcpedit/tcpedit_stub.h` (still autogen-generated and committed) and CMake's man-page rendering (writes into the build tree, never the source tree) are unrelated to this bug and untouched.

## Test plan

- [x] Autotools: extracted a fresh `make dist` tarball, `chmod 444` on `*_opts.h`/`*.adoc`/`*.1`, touched the `.def` to force staleness, full out-of-tree rebuild succeeds (previously failed with the exact reported error); `sudo make test` passes
- [x] CMake: same `chmod 444` + forced staleness against `*_opts.c/h/.adoc`, full reconfigure + build succeeds, permissions correctly reset to normal afterward
- [x] `scripts/autoopts/generate.py`: `chmod 444` + content mismatch, direct invocation succeeds and replaces the file
- [x] Clean end-to-end sanity check from a fresh clone: `autogen.sh` → `configure` → `make` → `sudo make test`, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)