### PR TITLE
build: stop distributing src/*.adoc in make dist tarballs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,12 @@ are **not** committed to git — matching this project's original convention for
 (#895 — GNU autogen is EOL, but its python3/asciidoctor replacements aren't, so there's no need to
 deviate from that convention the way phase 1 briefly did). `scripts/autoopts` (python3) regenerates
 `*_opts.c/h`/`*.adoc` and `asciidoctor` renders `*.adoc` to `*.1`, both at build time from the
-source tree; `make dist`/`make dist-xz` ship the already-built output, so release tarballs need
-neither tool. GNU autogen itself is only still needed for one file, `src/tcpedit/tcpedit_stub.h`
+source tree. `make dist`/`make dist-xz` ship only the rendered `*_opts.c/h`/`*.1` (matching the
+pre-#895 behavior of shipping pre-built man pages, not autogen's separate mdoc source) — `*.adoc`
+is a git-checkout-only build artifact, never distributed — so release tarballs need neither python3
+nor asciidoctor, only a git checkout does. Each `*.1` rule depends on its `.def` directly, like
+`*_opts.c/h`, not on `*.adoc` — so a shipped, already-fresh `.1` doesn't force `.adoc` to exist.
+GNU autogen itself is only still needed for one file, `src/tcpedit/tcpedit_stub.h`
 (a distinct AutoOpts template mode — see `scripts/autoopts/README.md`) — that one file (and its
 `.1`) does stay committed, since autogen genuinely is EOL. On Debian/Ubuntu:
 `apt install libpcap-dev automake autoconf libtool python3 asciidoctor` (add `autogen` if editing

--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ Python replacement) and `asciidoctor` produce them from the `.def` files at
 build time instead, so you need those two tools installed to build from git
 (neither is EOL, unlike autogen). GNU autogen itself is only still needed
 for one internal header (`src/tcpedit/tcpedit_stub.h`); see
-`scripts/autoopts/README.md`. Release tarballs (`make dist`) ship the
-already-generated files, so building from a tarball needs none of these
-three tools.
+`scripts/autoopts/README.md`. Release tarballs (`make dist`, autotools
+only) ship the already-generated option parsers and pre-built man pages
+(`*_opts.c/h`/`*.1`) — matching the pre-#895 behavior of shipping pre-built
+man pages, not a separate source format — so building from a tarball needs
+none of these three tools; the AsciiDoc man-page source (`*.adoc`) is a
+git-checkout-only build artifact and isn't distributed.
 
 ```
 cmake -B build

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -25,7 +25,10 @@ UNRELEASED
       specifically because GNU autogen was becoming unobtainable; python3/asciidoctor don't have
       that problem, so there's no need to keep deviating from the original convention for what they
       produce - it was only causing unrelated diff noise on every .def edit, e.g. via the shared
-      tcpedit_opts.def); 'make dist'/'make dist-xz' ship the already-built output, so release
+      tcpedit_opts.def); 'make dist'/'make dist-xz' ship only the rendered *_opts.c/h/.1, matching
+      the pre-#895 behavior of shipping pre-built man pages - not .adoc, which stays a git-checkout-
+      only build artifact; each .1 rule depends on its .def directly, like *_opts.c/h, not on .adoc,
+      so a shipped, already-fresh .1 doesn't force the (absent) .adoc to be built first; release
       tarballs still need none of these tools, only a git-checkout build does; GNU autogen itself is
       now needed only for src/tcpedit/tcpedit_stub.h, a distinct AutoOpts library template mode out
       of scope for this phase (see scripts/autoopts/README.md) - that one file (and its .1) is the

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -279,10 +279,13 @@ Notes:
     from a git checkout. Rendering *.adoc to *.1 is a separate, opt-in step
     (the `manpages` target above) requiring asciidoctor - a plain
     `cmake --build` never touches man pages at all. Release tarballs
-    (`make dist`, autotools-only) ship the already-built *_opts.c/h/*.adoc/
-    *.1, so building from a tarball needs neither tool. GNU autogen (EOL)
-    is only still needed for src/tcpedit/tcpedit_stub.h, which does stay
-    committed - see scripts/autoopts/README.md.
+    (`make dist`, autotools-only) ship the already-built *_opts.c/h/*.1 -
+    matching the pre-#895 behavior of shipping pre-built man pages, not
+    autogen's separate mdoc source - so building from a tarball needs
+    neither tool; *.adoc is a git-checkout-only build artifact, never
+    distributed. GNU autogen (EOL) is only still needed for
+    src/tcpedit/tcpedit_stub.h, which does stay committed - see
+    scripts/autoopts/README.md.
   - `make test' remains autotools-driven.  The CMake build generates
     test/config so the test fixtures can be used, but running the test
     suite still requires the autotools flow described above.

--- a/scripts/autoopts/README.md
+++ b/scripts/autoopts/README.md
@@ -8,8 +8,13 @@ runtime is untouched — this replaces only the generator.
 products (see `.gitignore`) — regenerated from the `.def` at build time by
 `emit_h.py`/`emit_c.py`/`emit_adoc.py`/`asciidoctor`, never checked into
 git, matching this project's original convention for generated files.
-`make dist`/`make dist-xz` ship the already-built output, so release
-tarballs need neither python3 nor asciidoctor. The "committed"/"golden
+`make dist`/`make dist-xz` ship only the rendered `*_opts.c/h`/`*.1`
+(matching the pre-#895 behavior of shipping pre-built man pages, not
+autogen's separate mdoc source) — `*.adoc` is a git-checkout-only build
+artifact, never distributed — so release tarballs need neither python3 nor
+asciidoctor. Each `*.1` rule in `src/Makefile.am` depends on its `.def`
+directly, not on `*.adoc`, so a shipped `.1` that's already newer than its
+`.def` doesn't force the (absent) `.adoc` to be created first. The "committed"/"golden
 file" language in the Status section below describes phase 2's
 *development-time* verification (the emitters were proven byte-identical
 to real GNU autogen's output while autogen was still installed and the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,63 +28,73 @@ opts_list=-L tcpedit
 
 # man-page source (AsciiDoc, generated from the .def like *_opts.c/h - see
 # scripts/autoopts/README.md) and the rendered pages.  #895 phase 2: GNU
-# autogen's man pipeline is replaced entirely.  Like *_opts.c/h, neither the
-# .adoc nor the .1 is committed to git (see .gitignore) - both are ordinary
-# build products, generated fresh from the .def by python3/asciidoctor and
-# bundled into the dist tarball, matching this project's original convention
-# (nothing generated was ever committed; only GNU autogen - now EOL - forced
-# phase 1 to briefly deviate from it for *_opts.c/h, see git history around
-# #895 phase 1/2). man_MANS below means these still get built by plain
-# 'make', not deferred to 'install'/'dist' only.
+# autogen's man pipeline is replaced entirely.  Like *_opts.c/h, neither is
+# committed to git (see .gitignore) - both are ordinary build products,
+# generated fresh from the .def by python3/asciidoctor, matching this
+# project's original convention (nothing generated was ever committed; only
+# GNU autogen - now EOL - forced phase 1 to briefly deviate from it for
+# *_opts.c/h, see git history around #895 phase 1/2). man_MANS below means
+# these still get built by plain 'make', not deferred to 'install'/'dist'
+# only.
+#
+# Only the rendered .1 is bundled into the dist tarball (EXTRA_DIST below),
+# matching the pre-#895 behavior where autogen rendered man pages directly
+# with no separate source format to ship - the .adoc intermediate is a
+# git-checkout-only build artifact.  Each .1 rule therefore depends on the
+# .def directly (like *_opts.c/h), not on its .adoc, and regenerates .adoc
+# as an internal step of its own recipe: if a shipped .1 is already newer
+# than the .def it was built from - always true for a fresh dist tarball,
+# since .adoc isn't there to depend on - neither python3 nor asciidoctor is
+# needed to build it.  A prerequisite that's simply missing (as .adoc
+# always would be in a tarball) forces make to build it regardless of the
+# dependent target's own freshness, which is what this sidesteps.
 autoopts_dir = $(abs_top_srcdir)/scripts/autoopts
 
 tcpprep.adoc: tcpprep_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpprep tcpprep_opts.def > tcpprep.adoc.tmp && mv -f tcpprep.adoc.tmp tcpprep.adoc
 
-tcpprep.1: tcpprep.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpprep.1.tmp tcpprep.adoc && mv -f tcpprep.1.tmp tcpprep.1
+tcpprep.1: tcpprep_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpprep tcpprep_opts.def > tcpprep.adoc.tmp && mv -f tcpprep.adoc.tmp tcpprep.adoc && @ASCIIDOCTOR@ -b manpage -o tcpprep.1.tmp tcpprep.adoc && mv -f tcpprep.1.tmp tcpprep.1
 
 tcprewrite.adoc: tcprewrite_opts.def tcpedit/tcpedit_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcprewrite tcprewrite_opts.def > tcprewrite.adoc.tmp && mv -f tcprewrite.adoc.tmp tcprewrite.adoc
 
-tcprewrite.1: tcprewrite.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcprewrite.1.tmp tcprewrite.adoc && mv -f tcprewrite.1.tmp tcprewrite.1
+tcprewrite.1: tcprewrite_opts.def tcpedit/tcpedit_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcprewrite tcprewrite_opts.def > tcprewrite.adoc.tmp && mv -f tcprewrite.adoc.tmp tcprewrite.adoc && @ASCIIDOCTOR@ -b manpage -o tcprewrite.1.tmp tcprewrite.adoc && mv -f tcprewrite.1.tmp tcprewrite.1
 
 tcpreplay-edit.adoc: tcpreplay_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay-edit tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay-edit.adoc.tmp && mv -f tcpreplay-edit.adoc.tmp tcpreplay-edit.adoc
 
-tcpreplay-edit.1: tcpreplay-edit.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpreplay-edit.1.tmp tcpreplay-edit.adoc && mv -f tcpreplay-edit.1.tmp tcpreplay-edit.1
+tcpreplay-edit.1: tcpreplay_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay-edit tcpreplay_opts.def TCPREPLAY_EDIT > tcpreplay-edit.adoc.tmp && mv -f tcpreplay-edit.adoc.tmp tcpreplay-edit.adoc && @ASCIIDOCTOR@ -b manpage -o tcpreplay-edit.1.tmp tcpreplay-edit.adoc && mv -f tcpreplay-edit.1.tmp tcpreplay-edit.1
 
 tcpreplay.adoc: tcpreplay_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay tcpreplay_opts.def > tcpreplay.adoc.tmp && mv -f tcpreplay.adoc.tmp tcpreplay.adoc
 
-tcpreplay.1: tcpreplay.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpreplay.1.tmp tcpreplay.adoc && mv -f tcpreplay.1.tmp tcpreplay.1
+tcpreplay.1: tcpreplay_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpreplay tcpreplay_opts.def > tcpreplay.adoc.tmp && mv -f tcpreplay.adoc.tmp tcpreplay.adoc && @ASCIIDOCTOR@ -b manpage -o tcpreplay.1.tmp tcpreplay.adoc && mv -f tcpreplay.1.tmp tcpreplay.1
 
 tcpbridge.adoc: tcpbridge_opts.def tcpedit/tcpedit_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpbridge tcpbridge_opts.def > tcpbridge.adoc.tmp && mv -f tcpbridge.adoc.tmp tcpbridge.adoc
 
-tcpbridge.1: tcpbridge.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpbridge.1.tmp tcpbridge.adoc && mv -f tcpbridge.1.tmp tcpbridge.1
+tcpbridge.1: tcpbridge_opts.def tcpedit/tcpedit_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpbridge tcpbridge_opts.def > tcpbridge.adoc.tmp && mv -f tcpbridge.adoc.tmp tcpbridge.adoc && @ASCIIDOCTOR@ -b manpage -o tcpbridge.1.tmp tcpbridge.adoc && mv -f tcpbridge.1.tmp tcpbridge.1
 
 tcpliveplay.adoc: tcpliveplay_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpliveplay tcpliveplay_opts.def > tcpliveplay.adoc.tmp && mv -f tcpliveplay.adoc.tmp tcpliveplay.adoc
 
-tcpliveplay.1: tcpliveplay.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpliveplay.1.tmp tcpliveplay.adoc && mv -f tcpliveplay.1.tmp tcpliveplay.1
+tcpliveplay.1: tcpliveplay_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpliveplay tcpliveplay_opts.def > tcpliveplay.adoc.tmp && mv -f tcpliveplay.adoc.tmp tcpliveplay.adoc && @ASCIIDOCTOR@ -b manpage -o tcpliveplay.1.tmp tcpliveplay.adoc && mv -f tcpliveplay.1.tmp tcpliveplay.1
 
 tcpcapinfo.adoc: tcpcapinfo_opts.def
 	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpcapinfo tcpcapinfo_opts.def > tcpcapinfo.adoc.tmp && mv -f tcpcapinfo.adoc.tmp tcpcapinfo.adoc
 
-tcpcapinfo.1: tcpcapinfo.adoc
-	cd $(srcdir) && @ASCIIDOCTOR@ -b manpage -o tcpcapinfo.1.tmp tcpcapinfo.adoc && mv -f tcpcapinfo.1.tmp tcpcapinfo.1
+tcpcapinfo.1: tcpcapinfo_opts.def
+	cd $(srcdir) && @PYTHON3@ $(autoopts_dir)/emit_adoc.py tcpcapinfo tcpcapinfo_opts.def > tcpcapinfo.adoc.tmp && mv -f tcpcapinfo.adoc.tmp tcpcapinfo.adoc && @ASCIIDOCTOR@ -b manpage -o tcpcapinfo.1.tmp tcpcapinfo.adoc && mv -f tcpcapinfo.1.tmp tcpcapinfo.1
 
 man_MANS = tcpreplay.1 tcpprep.1 tcprewrite.1 tcpreplay-edit.1 tcpcapinfo.1
 EXTRA_DIST = tcpreplay.1 tcpprep.1 tcprewrite.1 tcpbridge.1 tcpreplay-edit.1 \
-	tcpliveplay.1 tcpcapinfo.1 \
-	tcpreplay.adoc tcpprep.adoc tcprewrite.adoc tcpbridge.adoc \
-	tcpreplay-edit.adoc tcpliveplay.adoc tcpcapinfo.adoc
+	tcpliveplay.1 tcpcapinfo.1
 bin_PROGRAMS = tcpreplay tcpprep tcprewrite tcpreplay-edit tcpcapinfo
 
 if COMPILE_TCPBRIDGE


### PR DESCRIPTION
## Summary

Fixes #1035.

Before #895, \`make dist\` tarballs shipped pre-built man pages (\`src/*.1\`) generated directly from \`.def\` via autogen — no intermediate source format was shipped or needed to rebuild from the tarball. After #1030 switched man pages to a two-stage \`.def -> .adoc -> .1\` pipeline, both \`.adoc\` and \`.1\` ended up in \`EXTRA_DIST\`, with \`.1: .adoc\` as the dependency. This only avoided needing asciidoctor to build from a tarball by luck of tar preserving relative timestamps (\`.1\` ends up newer than \`.adoc\`) — not because of anything structural. Had \`.adoc\` ever been dropped from the tarball without also fixing the dependency, or had timestamp ordering not survived some tar/filesystem combination, \`make\` would have needed to (re)create the missing \`.adoc\` — and then asciidoctor to re-render \`.1\` — for a plain tarball build that shouldn't need either.

## Fix

- Drop \`*.adoc\` from \`EXTRA_DIST\` — it remains an ordinary, git-checkout-only build artifact, same as today (\`MAINTAINERCLEANFILES\` already covers it).
- Make each \`*.1\` target depend on its \`.def\` directly, exactly like \`*_opts.c/h\` already do, instead of depending on \`*.adoc\`; the \`.adoc\` regeneration step moves into \`*.1\`'s own recipe (still also available standalone via the existing \`*.adoc\` target, e.g. for manual inspection).

A tarball-shipped \`.1\` that's already newer than its \`.def\` is therefore up to date structurally, with no missing prerequisite to force a rebuild — restoring the pre-#895 behavior for real rather than incidentally.

CMake is unaffected/out of scope: it isn't part of \`make dist\` at all (autotools-only, pre-existing), and its man-page rendering already writes into the build tree, not the source tree.

## Test plan

- [x] \`make dist\` tarball now contains \`*_opts.c/h/*.1\` but no \`*.adoc\` (previously had both)
- [x] Extracted the tarball and built **completely offline** (autogen/python3/asciidoctor all removed from \`PATH\`) — succeeds, including \`make install\` (all 7 man pages install correctly) — previously this "worked" only by timestamp luck; now it's structural even with zero \`.adoc\` files present at all
- [x] Editing a \`.def\` and rebuilding from a git checkout with tools present still regenerates both \`.adoc\` and \`.1\` correctly, matching content
- [x] \`sudo make test\` passes (both from a fresh out-of-tree build and after the offline-tarball scenario)
- [x] \`scripts/autoopts/validate_ir.py\`, \`check_emitters.py\`, \`check_adoc.py\`, \`scripts/check-generated-opts.sh\` all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)