### PR TITLE
build: ship CMake build files in make dist tarballs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,15 +75,21 @@ Mirrors configure.ac feature-for-feature; every `--enable-*`/`--with-*` flag has
 (mapping table in the top-level `CMakeLists.txt` header comment, e.g. `-DENABLE_DEBUG=ON`,
 `-DWITH_NETMAP=DIR`). Feature detection lives in `cmake/*.cmake`; `cmake/config.h.cmake` is the
 CMake twin of `src/config.h.in` — **when adding a configure.ac check or a new config.h define, update
-the corresponding `cmake/` file too**. `*_opts.c/h` and man-page `.adoc` source are **not** committed
-(same convention as autotools, see above) — `cmake -B build` regenerates them at configure time via
-`scripts/autoopts` (python3), so python3 is required for any CMake build from a git checkout.
-Rendering `.adoc` to `.1` is opt-in and asciidoctor-only-if-used: a plain `cmake --build build` never
-touches man pages at all (unlike autotools, where they're part of the default build); only
-`cmake --build build --target manpages` does, and needs asciidoctor. `autogen` itself is only needed
-for `src/tcpedit/tcpedit_stub.h`, which does stay committed. CMake is the primary, recommended way to
-build the suite; `make test` remains autotools-only, so autotools is still required for that and for
-release tarballs (`make dist`/`make dist-xz`, which bundle the already-built generated files).
+the corresponding `cmake/` file too**. `*_opts.c/h` are **not** committed (same convention as
+autotools, see above) — `cmake -B build` regenerates them at configure time via `scripts/autoopts`
+(python3), so python3 is required to compile from a git checkout — but only if they're actually
+missing or stale; a tarball-shipped, already-fresh copy needs no tool. Man pages (`*.adoc`/`*.1`)
+are handled differently from autotools: neither is needed to compile, so their generation is wired
+into the build graph (`add_custom_command` OUTPUT/DEPENDS) instead of happening eagerly at configure
+time — a plain `cmake --build build` never touches man pages at all (unlike autotools, where they're
+part of the default build); only `cmake --build build --target manpages` does, regenerating `.adoc`
+(python3) and rendering `.1` (asciidoctor) as needed. `autogen` itself is only needed for
+`src/tcpedit/tcpedit_stub.h`, which does stay committed. CMake is the primary, recommended way to
+build the suite; `make test` remains autotools-only, so autotools is still required for that.
+Release tarballs (`make dist`/`make dist-xz`, autotools-only to produce) ship both build systems'
+files — pre-built `*_opts.c/h`/`*.1` (no `*.adoc`, a git-checkout-only artifact) plus every
+`CMakeLists.txt`/`CMakePresets.json`/`cmake/*.cmake` — so a tarball builds standalone with either
+autotools or CMake, needing none of autogen/python3/asciidoctor for either.
 
 ## Tests
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,4 +62,7 @@ MAINTAINERCLEANFILES = Makefile.in configure *.bak
 
 EXTRA_DIST = doxygen.cfg.in \
 	m4/libtool.m4 m4/ltoptions.m4 m4/ltsugar.m4 \
-	m4/ltversion.m4 m4/lt~obsolete.m4 acinclude.m4
+	m4/ltversion.m4 m4/lt~obsolete.m4 acinclude.m4 \
+	CMakeLists.txt CMakePresets.json \
+	cmake/config.h.cmake cmake/ConfigureChecks.cmake cmake/FindPCAP.cmake \
+	cmake/GitVersion.cmake cmake/OptionalDeps.cmake cmake/PcapChecks.cmake

--- a/README.md
+++ b/README.md
@@ -109,12 +109,15 @@ Python replacement) and `asciidoctor` produce them from the `.def` files at
 build time instead, so you need those two tools installed to build from git
 (neither is EOL, unlike autogen). GNU autogen itself is only still needed
 for one internal header (`src/tcpedit/tcpedit_stub.h`); see
-`scripts/autoopts/README.md`. Release tarballs (`make dist`, autotools
-only) ship the already-generated option parsers and pre-built man pages
-(`*_opts.c/h`/`*.1`) — matching the pre-#895 behavior of shipping pre-built
-man pages, not a separate source format — so building from a tarball needs
-none of these three tools; the AsciiDoc man-page source (`*.adoc`) is a
-git-checkout-only build artifact and isn't distributed.
+`scripts/autoopts/README.md`. Release tarballs (`make dist`, autotools-
+built but not autotools-only to consume) ship the already-generated option
+parsers and pre-built man pages (`*_opts.c/h`/`*.1`) — matching the
+pre-#895 behavior of shipping pre-built man pages, not a separate source
+format — plus every CMake build file (`CMakeLists.txt`,
+`CMakePresets.json`, `cmake/*.cmake`), so a tarball builds standalone with
+either autotools or CMake, needing none of autogen/python3/asciidoctor for
+either. The AsciiDoc man-page source (`*.adoc`) is a git-checkout-only
+build artifact and isn't distributed.
 
 ```
 cmake -B build
@@ -150,11 +153,12 @@ cmake -B build-debug -DENABLE_DEBUG=ON
 cmake -B build-release
 ```
 
-Handy targets: `cmake --build build --target manpages` renders the man pages
-with asciidoctor — a plain `cmake --build build` never needs asciidoctor,
-only that explicit target does. VS Code users with the CMake Tools extension
-can simply open the repository folder and select a configure preset when
-prompted.
+Handy targets: `cmake --build build --target manpages` regenerates the man
+pages (python3 to produce `*.adoc`, asciidoctor to render `*.1`) — a plain
+`cmake --build build` never touches man pages at all, so it needs neither
+tool unless `*_opts.c/h` themselves are missing or stale (python3 only).
+VS Code users with the CMake Tools extension can simply open the repository
+folder and select a configure preset when prompted.
 
 Build netmap feature
 --------------------

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,18 @@
 UNRELEASED
+    - build: make dist tarballs are now buildable with CMake, not just autotools (#1037) - every
+      CMakeLists.txt, CMakePresets.json, and cmake/*.cmake support module is now added to the
+      relevant EXTRA_DIST variables, so 'make dist'/'make dist-xz' tarballs ship both build
+      systems' files; also fixes two plugins (dlt_jnpr_ether, dlt_pppserial) whose *_api.c file
+      was never added to autotools' source list (present only in CMake's, so the file was missing
+      from dist tarballs entirely, breaking a from-tarball CMake build with 'cannot find source
+      file') - both now compile under both build systems. CMake's *_opts.c/h and man-page
+      generation (src/CMakeLists.txt) is restructured so man pages (*.adoc/*.1, not needed to
+      compile) no longer share a staleness check with *_opts.c/h (needed to compile): man-page
+      generation moves from eager configure-time execute_process() calls into the build graph via
+      add_custom_command() OUTPUT/DEPENDS, so it now only runs - needing python3/asciidoctor - when
+      the opt-in 'manpages' target is actually invoked, instead of every configure forcing python3
+      just because *.adoc (never distributed, see #1035/#1036) was missing; a tarball-shipped,
+      already-fresh *_opts.c/h now needs neither tool with CMake either, matching autotools
     - build: GNU autogen is no longer required to build (#895, phase 1) - autogen is EOL (Debian
       Bug#1076243), so the AutoOpts-generated option parsers (src/*_opts.c/h, tcpedit_stub.h) and
       man pages are now committed to git; both build systems use them directly and only invoke

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -271,26 +271,33 @@ CMake Tools extension) and CLion pick these up automatically, e.g.
 
 Notes:
 
-  - The AutoOpts-generated option parsers (*_opts.c/h) and man-page source
-    (*.adoc) are NOT committed to git - they're ordinary build products,
-    matching this project's original convention for generated files.
-    scripts/autoopts (python3) regenerates *_opts.c/h and *.adoc at
-    configure time from the .def files, so python3 is required to build
-    from a git checkout. Rendering *.adoc to *.1 is a separate, opt-in step
-    (the `manpages` target above) requiring asciidoctor - a plain
-    `cmake --build` never touches man pages at all. Release tarballs
-    (`make dist`, autotools-only) ship the already-built *_opts.c/h/*.1 -
-    matching the pre-#895 behavior of shipping pre-built man pages, not
-    autogen's separate mdoc source - so building from a tarball needs
-    neither tool; *.adoc is a git-checkout-only build artifact, never
-    distributed. GNU autogen (EOL) is only still needed for
+  - The AutoOpts-generated option parsers (*_opts.c/h) are NOT committed to
+    git - they're ordinary build products, matching this project's original
+    convention for generated files. scripts/autoopts (python3) regenerates
+    them at configure time from the .def files, but only if they're
+    missing or stale, so python3 is required to build from a git checkout
+    but not from a tarball that already ships them (see below). Man pages
+    (*.adoc/*.1) work differently: neither is needed to compile, so their
+    generation is wired into the build graph instead of happening eagerly
+    at configure time - a plain `cmake --build` never touches man pages at
+    all; only `cmake --build build --target manpages` above does,
+    regenerating *.adoc (python3) and rendering *.1 (asciidoctor) as
+    needed. GNU autogen (EOL) is only still needed for
     src/tcpedit/tcpedit_stub.h, which does stay committed - see
     scripts/autoopts/README.md.
+  - Release tarballs (`make dist`/`make dist-xz`) are produced by autotools
+    but buildable with either build system: they ship the already-built
+    *_opts.c/h and pre-built *.1 (matching the pre-#895 behavior of
+    shipping pre-built man pages, not autogen's separate mdoc source - see
+    docs/CHANGELOG), plus every CMakeLists.txt/CMakePresets.json/cmake/*
+    file, so building from a tarball needs none of
+    autogen/python3/asciidoctor with either build system. *.adoc is a
+    git-checkout-only build artifact and is never distributed.
   - `make test' remains autotools-driven.  The CMake build generates
     test/config so the test fixtures can be used, but running the test
     suite still requires the autotools flow described above.
   - CMake is the primary, recommended way to build the suite; autotools
-    remains supported for release tarballs and `make test`.
+    remains required to produce release tarballs and to run `make test`.
 
 Compilers and Options
 =====================

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -10,4 +10,4 @@ replay_stats_SOURCES = replay_stats.c
 replay_stats_CFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src $(LIBOPTS_CFLAGS)
 replay_stats_LDADD = $(top_builddir)/src/libtcpreplay.a @LPCAPLIB@ @LDNETLIB@ $(LIBOPTS_LDADD)
 
-EXTRA_DIST = README.md
+EXTRA_DIST = README.md CMakeLists.txt

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,3 +8,5 @@ noinst_HEADERS = strlcpy.h tree.h queue.h sll.h
 MOSTLYCLEANFILES = *~ *.o *.a
 
 MAINTAINERCLEANFILES = Makefile.in
+
+EXTRA_DIST = CMakeLists.txt

--- a/libopts/Makefile.am
+++ b/libopts/Makefile.am
@@ -8,7 +8,7 @@ endif
 libopts_la_SOURCES      = libopts.c
 libopts_la_CPPFLAGS     = -I$(srcdir)
 libopts_la_LDFLAGS      = -version-info  42:1:17
-EXTRA_DIST		=
+EXTRA_DIST		= CMakeLists.txt
 BUILT_SOURCES		=
 MOSTLYCLEANFILES	=
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,43 +15,37 @@ if(ENABLE_FRAGROUTE)
 endif()
 
 # ---------------------------------------------------------------------------
-# AutoOpts code generation (*_opts.def → *_opts.c/h, *.adoc man-page source)
+# AutoOpts code generation (*_opts.def → *_opts.c/h)
 # ---------------------------------------------------------------------------
 # Unlike src/tcpedit/tcpedit_stub.h, none of these generated files are
 # committed to git (see .gitignore) - they're ordinary build products,
 # matching this project's original convention (nothing generated was ever
 # committed; a release tarball ships the already-built output via 'make
 # dist'). scripts/autoopts (python3) replaces GNU autogen for these targets
-# - see scripts/autoopts/README.md - so python3 (and asciidoctor, for the
-# man pages) is needed for any build from a git checkout, exactly like
-# autogen used to be, except neither tool is EOL. Regeneration happens here
-# at configure time, in the source tree, so the build graph never runs it
-# (and cannot race on its outputs). autogen remains required only for
-# src/tcpedit/tcpedit_stub.h (further down in this file), a distinct
-# AutoOpts template mode not yet ported to scripts/autoopts - that one file
-# stays committed since autogen genuinely is EOL.
+# - see scripts/autoopts/README.md - so python3 is needed for any build
+# from a git checkout, exactly like autogen used to be, except it isn't
+# EOL. Regeneration happens here at configure time, in the source tree, so
+# the build graph never runs it (and cannot race on its outputs); *_opts.c/h
+# are needed to compile, unlike man pages (see the manpages target further
+# down), so they can't be deferred to build time the way man-page
+# generation is. autogen remains required only for src/tcpedit/
+# tcpedit_stub.h (further down in this file), a distinct AutoOpts template
+# mode not yet ported to scripts/autoopts - that one file stays committed
+# since autogen genuinely is EOL.
 set(TCPR_AUTOGEN_OPTS_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(AUTOOPTS_DIR ${CMAKE_SOURCE_DIR}/scripts/autoopts)
 
-# tcpr_autogen_opts(<base> <def-file> [MANBASE name] [DEFINES sym] [DEPENDS ...])
+# tcpr_autogen_opts(<base> <def-file> [DEFINES sym] [DEPENDS ...])
 # Defines <base>_SOURCE pointing at the (re)generated .c file in the source
-# tree.  MANBASE (the man page/adoc basename, e.g. "tcpreplay-edit" for base
-# "tcpreplay_edit_opts") defaults to <base> with any trailing "_opts"
-# stripped.
+# tree.
 function(tcpr_autogen_opts base def)
-    cmake_parse_arguments(ARG "" "MANBASE;DEFINES" "DEPENDS" ${ARGN})
-    if(ARG_MANBASE)
-        set(_manbase ${ARG_MANBASE})
-    else()
-        string(REGEX REPLACE "_opts$" "" _manbase ${base})
-    endif()
+    cmake_parse_arguments(ARG "" "DEFINES" "DEPENDS" ${ARGN})
     set(_out_c ${CMAKE_CURRENT_SOURCE_DIR}/${base}.c)
     set(_out_h ${CMAKE_CURRENT_SOURCE_DIR}/${base}.h)
-    set(_out_adoc ${CMAKE_CURRENT_SOURCE_DIR}/${_manbase}.adoc)
     # strictly-newer comparison (like make): IS_NEWER_THAN treats equal
     # timestamps as newer, which a fresh git checkout produces for every file
     set(_stale FALSE)
-    foreach(_f ${_out_c} ${_out_h} ${_out_adoc})
+    foreach(_f ${_out_c} ${_out_h})
         if(NOT EXISTS ${_f})
             set(_stale TRUE)
         else()
@@ -66,7 +60,7 @@ function(tcpr_autogen_opts base def)
     endforeach()
     if(_stale)
         if(PYTHON3_EXECUTABLE)
-            message(STATUS "Regenerating ${base}.c/h and ${_manbase}.adoc with python3")
+            message(STATUS "Regenerating ${base}.c/h with python3")
             # Write to a .tmp path and rename over the real target rather than
             # writing it directly: a dist tarball extracted read-only (or any
             # other reason the existing file isn't writable) only needs the
@@ -89,19 +83,11 @@ function(tcpr_autogen_opts base def)
                 message(FATAL_ERROR "emit_c.py failed regenerating ${base}.c from ${def}")
             endif()
             file(RENAME ${_out_c}.tmp ${_out_c})
-            execute_process(
-                COMMAND ${PYTHON3_EXECUTABLE} ${AUTOOPTS_DIR}/emit_adoc.py ${_manbase} ${def} "${ARG_DEFINES}"
-                OUTPUT_FILE ${_out_adoc}.tmp
-                RESULT_VARIABLE _rc)
-            if(NOT _rc EQUAL 0)
-                message(FATAL_ERROR "emit_adoc.py failed regenerating ${_manbase}.adoc from ${def}")
-            endif()
-            file(RENAME ${_out_adoc}.tmp ${_out_adoc})
         else()
             message(FATAL_ERROR
-                "${base}.c/h or ${_manbase}.adoc is missing or older than ${def}, and python3 is "
-                "not installed. Install python3 to regenerate them, or if the .def content is "
-                "unchanged refresh the timestamps:\n  touch src/*_opts.c src/*_opts.h src/*.adoc")
+                "${base}.c/h is missing or older than ${def}, and python3 is not installed. "
+                "Install python3 to regenerate them, or if the .def content is unchanged "
+                "refresh the timestamps:\n  touch src/*_opts.c src/*_opts.h")
         endif()
     endif()
     set(${base}_SOURCE ${_out_c} PARENT_SCOPE)
@@ -111,7 +97,7 @@ set(TCPEDIT_OPTS_DEF ${CMAKE_CURRENT_SOURCE_DIR}/tcpedit/tcpedit_opts.def)
 
 tcpr_autogen_opts(tcpreplay_opts ${CMAKE_CURRENT_SOURCE_DIR}/tcpreplay_opts.def)
 tcpr_autogen_opts(tcpreplay_edit_opts ${CMAKE_CURRENT_SOURCE_DIR}/tcpreplay_opts.def
-    MANBASE tcpreplay-edit DEFINES TCPREPLAY_EDIT)
+    DEFINES TCPREPLAY_EDIT)
 tcpr_autogen_opts(tcprewrite_opts ${CMAKE_CURRENT_SOURCE_DIR}/tcprewrite_opts.def
     DEPENDS ${TCPEDIT_OPTS_DEF})
 tcpr_autogen_opts(tcpprep_opts ${CMAKE_CURRENT_SOURCE_DIR}/tcpprep_opts.def)
@@ -290,21 +276,45 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libtcpreplay.pc
 
 # ---------------------------------------------------------------------------
 # man pages (optional target, requires asciidoctor; mirrors the autotools
-# manpages target).  Renders from the .adoc source in the source tree (kept
-# current by tcpr_autogen_opts() above) into the build tree, so a plain
-# `cmake --build` never needs asciidoctor - only `--target manpages` does.
-# ---------------------------------------------------------------------------
+# manpages target).  Unlike *_opts.c/h above, *.adoc/*.1 generation is
+# wired into the build graph via add_custom_command OUTPUT/DEPENDS instead
+# of happening eagerly at configure time: neither is needed to compile, and
+# *.adoc is never distributed in a dist tarball (#1035/#1036 did the same
+# for autotools) - a tarball-shipped, already-fresh *_opts.c/h must not
+# force python3 just because *.adoc is missing. Letting the underlying
+# generator (make/ninja) track *.adoc's own staleness against its .def
+# means it's only (re)built - needing python3 - when something that
+# depends on it (ultimately, the manpages target) is actually invoked, and
+# `cmake --build` on its own still never needs asciidoctor.
+# tcpr_manpage(<man> <def-file-basename> [DEFINES sym] [DEPENDS ...])
+macro(tcpr_manpage man def)
+    cmake_parse_arguments(MP "" "DEFINES" "DEPENDS" ${ARGN})
+    set(_def ${CMAKE_CURRENT_SOURCE_DIR}/${def})
+    set(_adoc ${CMAKE_CURRENT_SOURCE_DIR}/${man}.adoc)
+    add_custom_command(
+        OUTPUT ${_adoc}
+        COMMAND ${PYTHON3_EXECUTABLE} ${AUTOOPTS_DIR}/emit_adoc.py ${man} ${_def} "${MP_DEFINES}"
+                > ${_adoc}.tmp
+        COMMAND ${CMAKE_COMMAND} -E rename ${_adoc}.tmp ${_adoc}
+        DEPENDS ${_def} ${MP_DEPENDS}
+        COMMENT "Generating ${man}.adoc")
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${man}.1
+        COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage
+                -o ${CMAKE_CURRENT_BINARY_DIR}/${man}.1 ${_adoc}
+        DEPENDS ${_adoc}
+        COMMENT "Generating ${man}.1")
+    list(APPEND _manpages ${CMAKE_CURRENT_BINARY_DIR}/${man}.1)
+endmacro()
+
 if(ASCIIDOCTOR_EXECUTABLE)
     set(_manpages "")
-    foreach(_man tcpprep tcprewrite tcpreplay tcpbridge tcpliveplay tcpcapinfo tcpreplay-edit)
-        add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_man}.1
-            COMMAND ${ASCIIDOCTOR_EXECUTABLE} -b manpage
-                    -o ${CMAKE_CURRENT_BINARY_DIR}/${_man}.1
-                    ${CMAKE_CURRENT_SOURCE_DIR}/${_man}.adoc
-            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_man}.adoc
-            COMMENT "Generating ${_man}.1")
-        list(APPEND _manpages ${CMAKE_CURRENT_BINARY_DIR}/${_man}.1)
-    endforeach()
+    tcpr_manpage(tcpprep tcpprep_opts.def)
+    tcpr_manpage(tcprewrite tcprewrite_opts.def DEPENDS ${TCPEDIT_OPTS_DEF})
+    tcpr_manpage(tcpreplay tcpreplay_opts.def)
+    tcpr_manpage(tcpbridge tcpbridge_opts.def DEPENDS ${TCPEDIT_OPTS_DEF})
+    tcpr_manpage(tcpliveplay tcpliveplay_opts.def)
+    tcpr_manpage(tcpcapinfo tcpcapinfo_opts.def)
+    tcpr_manpage(tcpreplay-edit tcpreplay_opts.def DEFINES TCPREPLAY_EDIT)
     add_custom_target(manpages DEPENDS ${_manpages})
 endif()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,7 +94,7 @@ tcpcapinfo.1: tcpcapinfo_opts.def
 
 man_MANS = tcpreplay.1 tcpprep.1 tcprewrite.1 tcpreplay-edit.1 tcpcapinfo.1
 EXTRA_DIST = tcpreplay.1 tcpprep.1 tcprewrite.1 tcpbridge.1 tcpreplay-edit.1 \
-	tcpliveplay.1 tcpcapinfo.1
+	tcpliveplay.1 tcpcapinfo.1 CMakeLists.txt
 bin_PROGRAMS = tcpreplay tcpprep tcprewrite tcpreplay-edit tcpcapinfo
 
 if COMPILE_TCPBRIDGE

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -40,3 +40,5 @@ noinst_HEADERS = cidr.h err.h list.h cache.h services.h get.h \
 MOSTLYCLEANFILES = *~
 
 MAINTAINERCLEANFILES = Makefile.in git_version.c
+
+EXTRA_DIST = CMakeLists.txt

--- a/src/fragroute/Makefile.am
+++ b/src/fragroute/Makefile.am
@@ -17,3 +17,5 @@ noinst_HEADERS = bget.h mod.h pkt.h randutil.h iputil.h fragroute.h argv.h \
 MOSTLYCLEANFILES = *~
 
 MAINTAINERCLEANFILES = Makefiles.in
+
+EXTRA_DIST = CMakeLists.txt

--- a/src/tcpedit/Makefile.am
+++ b/src/tcpedit/Makefile.am
@@ -34,7 +34,7 @@ MOSTLYCLEANFILES = *~
 
 MAINTAINERCLEANFILES = Makefile.in tcpedit_stub.h tcpedit.1
 
-EXTRA_DIST = tcpedit_stub.def tcpedit_opts.def
+EXTRA_DIST = tcpedit_stub.def tcpedit_opts.def CMakeLists.txt
 
 include plugins/Makefile.am
 

--- a/src/tcpedit/plugins/dlt_jnpr_ether/Makefile.am
+++ b/src/tcpedit/plugins/dlt_jnpr_ether/Makefile.am
@@ -7,7 +7,8 @@
 # add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
-	%reldir%/jnpr_ether.c
+	%reldir%/jnpr_ether.c \
+	%reldir%/jnpr_ether_api.c
 
 noinst_HEADERS += \
 	%reldir%/jnpr_ether.h \

--- a/src/tcpedit/plugins/dlt_pppserial/Makefile.am
+++ b/src/tcpedit/plugins/dlt_pppserial/Makefile.am
@@ -7,7 +7,8 @@
 # add your dependency information (see comment below)
 
 libtcpedit_a_SOURCES += \
-	%reldir%/pppserial.c
+	%reldir%/pppserial.c \
+	%reldir%/pppserial_api.c
 
 noinst_HEADERS += \
 	%reldir%/pppserial.h \


### PR DESCRIPTION
## Summary

Fixes #1037.

\`make dist\` tarballs previously included only the autotools build files — none of the \`CMakeLists.txt\` files, \`CMakePresets.json\`, or the \`cmake/\` support modules were distributed, so a tarball could only be built with autotools even though CMake is the primary, recommended way to build from a git checkout.

## Changes

1. **Ship the CMake files**: added every \`CMakeLists.txt\`/\`CMakePresets.json\`/\`cmake/*.cmake\` file to the relevant \`EXTRA_DIST\` variables across the tree (top-level, \`lib\`, \`libopts\`, \`examples\`, \`src\`, \`src/common\`, \`src/fragroute\`, \`src/tcpedit\`).

2. **Fixed two pre-existing autotools bugs**, surfaced while actually verifying a from-tarball CMake build: \`plugins/dlt_jnpr_ether\` and \`dlt_pppserial\` each have a \`*_api.c\` file (matching the pattern every other plugin with an \`_api.c\` already follows) that CMake's source list referenced but autotools' \`libtcpedit_a_SOURCES\` never did — so the file was never compiled by autotools, and (since automake only distributes what \`_SOURCES\`/\`EXTRA_DIST\` reference) never included in \`make dist\` tarballs at all. This broke CMake's \`add_library\` with "Cannot find source file" once the tarball was actually extracted and configured. Both plugins now compile identically under both build systems.

3. **Restructured CMake's man-page generation** (\`src/CMakeLists.txt\`) so it doesn't share a staleness bundle with \`*_opts.c/h\`: previously \`tcpr_autogen_opts()\` checked \`*_opts.c/h\` *and* \`*.adoc\` staleness together, regenerating all three (needing python3) if any one was missing. Since \`*.adoc\` is never distributed (#1035/#1036), this meant every CMake configure against a tarball would unnecessarily regenerate perfectly fresh \`*_opts.c/h\` just because \`*.adoc\` wasn't there. Man pages aren't needed to compile, unlike \`*_opts.c/h\`, so their generation moves from an eager \`execute_process()\` call at configure time into the build graph via \`add_custom_command()\` \`OUTPUT\`/\`DEPENDS\` — it now only runs (needing python3/asciidoctor) when the opt-in \`manpages\` target is actually invoked, matching the same design principle #1036 established for autotools.

## Test plan

- [x] \`make dist\` tarball contains all 15 CMake files (9 \`CMakeLists.txt\`/\`CMakePresets.json\` + 6 \`cmake/*.cmake\`) and both previously-missing plugin \`_api.c\` files
- [x] Extracted the tarball and built with **CMake**: configure produces no unnecessary "Regenerating" messages (\`*_opts.c/h\` correctly recognized as already fresh), full build succeeds, binaries smoke-tested, \`tcprewrite\` portmap output byte-matches the golden test fixture
- [x] \`cmake --build --target manpages\` from the same tarball still correctly regenerates \`*.adoc\`/\`*.1\` on demand
- [x] Extracted the same tarball and built with **autotools** (regression check): configure/build/\`sudo make test\` all still pass
- [x] Full clean-clone autotools build + \`sudo make test\` passes
- [x] All \`scripts/autoopts\` check scripts (\`validate_ir.py\`, \`check_emitters.py\`, \`check_adoc.py\`, \`check-generated-opts.sh\`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)