### PR TITLE
cmake: fix configuration summary and LIBXDP false negative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,34 +433,60 @@ add_subdirectory(examples)
 # ---------------------------------------------------------------------------
 # Configuration summary (mirrors the configure.ac results banner)
 # ---------------------------------------------------------------------------
+# configure.ac's shell have_xxx/enable_xxx variables are always explicitly
+# "yes" or "no" (initialized to "no", flipped on success). CMake's
+# check_c_source_compiles()/check_library_exists() results, and plain
+# ON/OFF-style variables, don't share that convention - a failed check
+# leaves its result variable empty (not "no"), and a successful one holds
+# "1"/TRUE (not "yes"), so interpolating them directly into message()
+# printed either blank lines (read as "not reported") or "1" instead of
+# "yes" for nearly every feature in this summary. tcpr_yn() normalizes any
+# CMake truthy/falsy value to the same "yes"/"no" text autotools prints,
+# for display only - it doesn't touch the underlying HAVE_xxx/ENABLE_xxx
+# variables, which every #cmakedefine/if() elsewhere keeps using as-is.
+function(tcpr_yn var out)
+    if(${var})
+        set(${out} "yes" PARENT_SCOPE)
+    else()
+        set(${out} "no" PARENT_SCOPE)
+    endif()
+endfunction()
+
+foreach(_v PF_RING_FOUND ENABLE_64BITS ENABLE_FRAGROUTE ENABLE_TCPBRIDGE ENABLE_TCPLIVEPLAY
+            HAVE_TX_RING HAVE_PF_PACKET HAVE_BPF HAVE_LIBDNET HAVE_PCAP_INJECT
+            HAVE_PCAP_SENDPACKET HAVE_LIBPCAP_NETMAP HAVE_NETMAP HAVE_TUNTAP HAVE_LIBXDP
+            HAVE_LIBURING)
+    tcpr_yn(${_v} _yn_${_v})
+endforeach()
+
 message(STATUS "")
 message(STATUS "##########################################################################")
 message(STATUS "             TCPREPLAY Suite Configuration Results (${TCPREPLAY_VERSION})")
 message(STATUS "##########################################################################")
 message(STATUS "libpcap:                    ${PCAP_INCLUDE_FILE} (${LIBPCAP_VERSION})")
-message(STATUS "PF_RING libpcap:            ${PF_RING_FOUND} ${WITH_PFRING_LIB}")
-message(STATUS "libdnet:                    ${HAVE_LIBDNET} ${LIBDNET_VERSION_STR}")
+message(STATUS "PF_RING libpcap:            ${_yn_PF_RING_FOUND} ${WITH_PFRING_LIB}")
+message(STATUS "libdnet:                    ${_yn_HAVE_LIBDNET} ${LIBDNET_VERSION_STR}")
 message(STATUS "autogen:                    ${AUTOGEN_EXECUTABLE} (${AUTOGEN_VERSION})")
 message(STATUS "python3 (scripts/autoopts): ${PYTHON3_EXECUTABLE}")
 message(STATUS "asciidoctor (man pages):    ${ASCIIDOCTOR_EXECUTABLE}")
-message(STATUS "64bit counter support:      ${ENABLE_64BITS}")
+message(STATUS "64bit counter support:      ${_yn_ENABLE_64BITS}")
 message(STATUS "tcpdump binary path:        ${TCPDUMP_PATH}")
-message(STATUS "fragroute support:          ${ENABLE_FRAGROUTE}")
-message(STATUS "tcpbridge support:          ${ENABLE_TCPBRIDGE}")
-message(STATUS "tcpliveplay support:        ${ENABLE_TCPLIVEPLAY}")
+message(STATUS "fragroute support:          ${_yn_ENABLE_FRAGROUTE}")
+message(STATUS "tcpbridge support:          ${_yn_ENABLE_TCPBRIDGE}")
+message(STATUS "tcpliveplay support:        ${_yn_ENABLE_TCPLIVEPLAY}")
 message(STATUS "")
 message(STATUS "Supported Packet Injection Methods (*):")
-message(STATUS "Linux TX_RING:              ${HAVE_TX_RING}")
-message(STATUS "Linux PF_PACKET:            ${HAVE_PF_PACKET}")
-message(STATUS "BSD BPF:                    ${HAVE_BPF}")
-message(STATUS "libdnet:                    ${HAVE_LIBDNET}")
-message(STATUS "pcap_inject:                ${HAVE_PCAP_INJECT}")
-message(STATUS "pcap_sendpacket:            ${HAVE_PCAP_SENDPACKET} **")
-message(STATUS "pcap_netmap:                ${HAVE_LIBPCAP_NETMAP}")
-message(STATUS "Linux/BSD netmap:           ${HAVE_NETMAP} ${NETMAP_INCLUDE_DIR}")
-message(STATUS "Tuntap device support:      ${HAVE_TUNTAP}")
-message(STATUS "LIBXDP for AF_XDP socket:   ${HAVE_LIBXDP}")
-message(STATUS "liburing for io_uring:      ${HAVE_LIBURING}")
+message(STATUS "Linux TX_RING:              ${_yn_HAVE_TX_RING}")
+message(STATUS "Linux PF_PACKET:            ${_yn_HAVE_PF_PACKET}")
+message(STATUS "BSD BPF:                    ${_yn_HAVE_BPF}")
+message(STATUS "libdnet:                    ${_yn_HAVE_LIBDNET}")
+message(STATUS "pcap_inject:                ${_yn_HAVE_PCAP_INJECT}")
+message(STATUS "pcap_sendpacket:            ${_yn_HAVE_PCAP_SENDPACKET} **")
+message(STATUS "pcap_netmap:                ${_yn_HAVE_LIBPCAP_NETMAP}")
+message(STATUS "Linux/BSD netmap:           ${_yn_HAVE_NETMAP} ${NETMAP_INCLUDE_DIR}")
+message(STATUS "Tuntap device support:      ${_yn_HAVE_TUNTAP}")
+message(STATUS "LIBXDP for AF_XDP socket:   ${_yn_HAVE_LIBXDP}")
+message(STATUS "liburing for io_uring:      ${_yn_HAVE_LIBURING}")
 message(STATUS "")
 message(STATUS "* In order of preference; see options in CMakeLists.txt to override")
 message(STATUS "** Required for tcpbridge")

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -395,7 +395,16 @@ int main(void) { int test = TP_STATUS_WRONG_FORMAT; return test; }
 
 check_library_exists(bpf bpf_object__open_file "" HAVE_LIBBPF_LIB)
 check_library_exists(xdp xsk_umem__delete "" HAVE_LIBXDP_LIB)
-check_c_source_compiles("
+if(HAVE_LIBXDP_LIB)
+    # check_c_source_compiles() links a full test executable despite its
+    # name, so xsk_socket__create() below needs -lxdp on the link line via
+    # CMAKE_REQUIRED_LIBRARIES, or the check fails with "undefined
+    # reference" even though the header and call are both fine - it was
+    # never being set here, so this check always failed even with libxdp
+    # genuinely installed (matches the pattern already used correctly for
+    # liburing just below).
+    set(CMAKE_REQUIRED_LIBRARIES xdp)
+    check_c_source_compiles("
 #include <stdlib.h>
 #include <xdp/xsk.h>
 #include <sys/socket.h>
@@ -406,6 +415,8 @@ int main(void) {
     xsk_socket__create(&xsk, \"lo\", 0, NULL, rxr, txr, NULL);
     return socket(AF_XDP, SOCK_RAW, 0) < 0;
 }" HAVE_LIBXDP_COMPILES)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
 if(HAVE_LIBXDP_COMPILES AND HAVE_LIBXDP_LIB)
     set(HAVE_LIBXDP 1)
 endif()

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,19 @@
 UNRELEASED
+    - cmake: fix the configuration summary and a LIBXDP false negative (#1039) - CMake's
+      "TCPREPLAY Suite Configuration Results" banner interpolated raw CMake variables (empty on a
+      failed check, "1" on success) directly into the summary instead of normalizing them, so most
+      boolean feature lines (Linux TX_RING, BSD BPF, pcap_netmap, LIBXDP, ...) printed blank instead
+      of "no" like autotools' equivalent summary, and successes printed "1" instead of "yes"; a new
+      tcpr_yn() helper normalizes every such field for display only, without touching the
+      HAVE_xxx/ENABLE_xxx variables everything else in the build still uses. Separately, LIBXDP
+      detection itself was a genuine false negative, not just a display issue: the
+      HAVE_LIBXDP_COMPILES check_c_source_compiles() test calls xsk_socket__create() but never set
+      CMAKE_REQUIRED_LIBRARIES to link against -lxdp first (unlike the equivalent, correct liburing
+      check right below it) - check_c_source_compiles() actually builds and links a full test
+      executable despite its name, so the check failed with "undefined reference to
+      `xsk_socket__create'" even with libxdp-dev/libbpf-dev genuinely installed and autotools
+      correctly detecting it, silently disabling --xdp support in CMake builds that should have had
+      it; verified with libxdp-dev/libbpf-dev actually installed, matching autotools exactly
     - build: make dist tarballs are now buildable with CMake, not just autotools (#1037) - every
       CMakeLists.txt, CMakePresets.json, and cmake/*.cmake support module is now added to the
       relevant EXTRA_DIST variables, so 'make dist'/'make dist-xz' tarballs ship both build


### PR DESCRIPTION
## Summary

Fixes #1039.

Two related bugs in CMake's "TCPREPLAY Suite Configuration Results" banner, both making it differ from autotools' equivalent summary — reported after noticing LIBXDP showed up in autotools but not CMake, and that some items in the CMake summary "aren't reported" at all.

### 1. Display bug (affects nearly every boolean field, not just LIBXDP)

The summary interpolated raw CMake variables directly into `message()` calls. `check_c_source_compiles()`/`check_library_exists()` results are empty (not `"no"`) on failure and `"1"` (not `"yes"`) on success, and several AND-combined flags (`HAVE_LIBXDP`, `HAVE_NETMAP`, ...) are simply never `set()` at all when their condition is false. This made most boolean feature lines — `Linux TX_RING`, `BSD BPF`, `pcap_netmap`, `LIBXDP`, and others — print **blank** instead of `no` (looking like they "aren't reported"), while successes printed a bare `1` instead of `yes`.

Fixed with a new `tcpr_yn(var out)` helper that normalizes any CMake truthy/falsy value to `"yes"`/`"no"` text **for display only** — the underlying `HAVE_xxx`/`ENABLE_xxx` variables everything else in the build uses are untouched.

### 2. Genuine LIBXDP detection bug

Beyond the display issue, LIBXDP really was a false negative. `cmake/ConfigureChecks.cmake`'s `HAVE_LIBXDP_COMPILES` check calls `xsk_socket__create()`, but never set `CMAKE_REQUIRED_LIBRARIES` to link against `-lxdp` first — unlike the equivalent, correct `liburing` check right below it, which does. `check_c_source_compiles()` actually builds and links a full test executable despite its name, so the check failed with `undefined reference to 'xsk_socket__create'` even with `libxdp-dev`/`libbpf-dev` genuinely installed and linkable — silently disabling `--xdp` support in CMake builds that should have had it. Confirmed autotools' equivalent `AC_COMPILE_IFELSE` test never links at all, so it correctly reported `yes` in the exact same environment where CMake's stricter (but under-configured) check failed.

Fixed by setting `CMAKE_REQUIRED_LIBRARIES xdp` around the check (save/restore), matching the `liburing` pattern already used correctly nearby.

## Test plan

- [x] Installed `libxdp-dev`/`libbpf-dev` and confirmed autotools reports `LIBXDP for AF_XDP socket: yes` while CMake (pre-fix) reported `no` — reproduced the false negative directly, then confirmed post-fix CMake also reports `yes`
- [x] Full CMake summary now matches autotools field-for-field (`yes`/`no` everywhere, no blank lines)
- [x] Full CMake build with the fix links and runs correctly; `--xdp` shows up in `tcpreplay --help` and `Optional injection method: AF_XDP` in `--version` output
- [x] `tcprewrite` portmap output byte-matches the golden test fixture
- [x] Confirmed `HAVE_LIBBPF` doesn't share the same bug (no compile+link test combining both requirements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)