### PR TITLE
common: fix check_list() return type mismatch

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,10 @@
 UNRELEASED
+    - common: fix check_list() return type mismatch warning - declared 'int' in list.h but defined
+      as 'tcpr_dir_t' (an unrelated enum) in list.c, triggering '-Wenum-int-mismatch' on newer GCC;
+      the function only ever returns 0 or 1 and every caller treats the result as a plain boolean,
+      so tcpr_dir_t (TCPR_DIR_ERROR/NOSEND/C2S/S2C) was never actually meaningful here - likely a
+      copy-paste mistake, since it's the only function in list.c using that type. Now returns 'int',
+      matching the header and how it's actually used
     - cmake: fix the configuration summary and a LIBXDP false negative (#1039) - CMake's
       "TCPREPLAY Suite Configuration Results" banner interpolated raw CMake variables (empty on a
       failed check, "1" on success) directly into the summary instead of normalizing them, so most

--- a/src/common/list.c
+++ b/src/common/list.c
@@ -145,7 +145,7 @@ parse_list(tcpr_list_t **listdata, char *ourstr)
  * Checks to see if the given integer exists in the LIST.
  * Return 1 if in the list, otherwise 0
  */
-tcpr_dir_t
+int
 check_list(tcpr_list_t *list, COUNTER value)
 {
     tcpr_list_t *current;


### PR DESCRIPTION
## Summary

Fixes #1041.

\`check_list()\` was declared \`int\` in \`list.h\` but defined as \`tcpr_dir_t\` (an unrelated enum: \`TCPR_DIR_ERROR/NOSEND/C2S/S2C\`, from \`cache.h\`) in \`list.c\`, triggering \`-Wenum-int-mismatch\` on newer GCC. Not CMake- or autotools-specific — plain header/definition mismatch, reproduces identically under either build system.

The function's own docstring says "Return 1 if in the list, otherwise 0", the body only ever returns literal \`1\` or \`0\`, and every caller (\`tcpprep.c\`, \`send_packets.c\`) treats the result as a plain boolean. \`tcpr_dir_t\` is never actually meaningful here — \`check_list\` is the only function in \`list.c\` referencing that type, suggesting a copy-paste mistake.

## Fix

Return \`int\` instead, matching the header and how the result is actually used everywhere.

## Test plan

- [x] Clean CMake build (\`-DENABLE_DEBUG=ON\`): zero warnings (previously the only warning in a full build)
- [x] Clean autotools build (\`--enable-debug\`): zero warnings, \`sudo make test\` passes