### PR TITLE
txring: fix __GLIBC_MINOR typo and include the header that defines the TX_RING API

### DIFF
--- a/src/common/txring.h
+++ b/src/common/txring.h
@@ -38,9 +38,9 @@
 
 #ifdef HAVE_TX_RING
 
-#if __GLIBC__ >= 2 && __GLIBC_MINOR >= 1
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1
 #include <net/ethernet.h> /* the L2 protocols */
-#include <netpacket/packet.h>
+#include <linux/if_packet.h>
 #else
 #include <asm/types.h>
 #include <linux/if_ether.h> /* The L2 protocols */


### PR DESCRIPTION
The include guard in `src/common/txring.h` reads

```c
#if __GLIBC__ >= 2 && __GLIBC_MINOR >= 1
```

but the macro is spelled `__GLIBC_MINOR__`. `__GLIBC_MINOR` is not defined by any header, so the preprocessor substitutes `0` and the condition is **always false** — the `#else` branch has been taken unconditionally on every glibc system since this check was added.

That accident is the only reason the file has ever compiled.

### Why fixing the typo alone is not enough

`<netpacket/packet.h>`, the glibc header the "true" branch selects, defines only `struct sockaddr_ll` and `struct packet_mreq`. It has never provided the `PACKET_TX_RING` API. `struct tpacket_hdr`, `struct tpacket_req` and `TPACKET_HDRLEN` — all used by `txring.h` and `txring.c` — come only from `<linux/if_packet.h>`, which is in the `#else` branch. Correcting just the macro name gives:

```
error: storage size of 'h' isn't known        (struct tpacket_hdr)
error: 'TPACKET_HDRLEN' undeclared
```

So this PR fixes the include as well: use `<linux/if_packet.h>` in both branches and drop `<netpacket/packet.h>`, which supplies nothing this header needs.

### A second bug this fixes

Before C23, `<netpacket/packet.h>` and `<linux/if_packet.h>` **cannot be included together** — both define `struct sockaddr_ll` and `struct packet_mreq`, and the `__UAPI_DEF_*` de-duplication does not apply:

```
linux/if_packet.h:14:8: error: redefinition of 'struct sockaddr_ll'
linux/if_packet.h:297:8: error: redefinition of 'struct packet_mreq'
```

`configure`'s TX_RING probe includes both headers, so this collision makes the probe fail whenever tcpreplay is built with `-std=gnu11` or `-std=gnu17`, silently disabling `HAVE_TX_RING` and falling back to the slower `PF_PACKET send()` path. Distributions that pin an older language level for the bundled (non-C23-clean) libopts hit exactly this — openSUSE has been shipping tcpreplay without TX_RING for this reason, and Fedora carries a partial patch for the typo that does not address the header problem.

After this change `txring.h` compiles under `-std=gnu11`, `-std=gnu17` and `-std=gnu23` alike.

### Verification

Built on Linux/aarch64 with `HAVE_TX_RING` enabled (`configure` reports `Linux TX_RING: yes`), and run-tested: replayed frames were captured on a veth peer, 3/3 successful, 0 failed.
