### PR TITLE
build: finish fixing Linux TX_RING support after #1043

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -384,9 +384,14 @@ int main(void) {
     return pf_socket < 0;
 }" HAVE_PF_PACKET)
 
+# <netpacket/packet.h> and <linux/if_packet.h> cannot be included together
+# before C23 - both define struct sockaddr_ll/packet_mreq, and the
+# __UAPI_DEF_* de-duplication guards don't apply pre-C23 - so this probe
+# used to fail to even compile (never defining HAVE_TX_RING) under
+# -std=gnu11/-std=gnu17, exactly the collision src/common/txring.h had
+# (#1043/#1044). <netpacket/packet.h> supplies nothing this probe uses.
 check_c_source_compiles("
 #include <sys/socket.h>
-#include <netpacket/packet.h>
 #include <net/ethernet.h>
 #include <netinet/in.h>
 #include <linux/if_packet.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1583,10 +1583,15 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 
 have_tx_ring=no
 dnl Check for older Linux TX_RING support
+dnl <netpacket/packet.h> and <linux/if_packet.h> cannot be included
+dnl together before C23 - both define struct sockaddr_ll/packet_mreq, and
+dnl the __UAPI_DEF_* de-duplication guards don't apply pre-C23 - so this
+dnl probe used to fail to even compile (never defining HAVE_TX_RING) under
+dnl -std=gnu11/-std=gnu17, exactly the collision src/common/txring.h had
+dnl (#1043/#1044). <netpacket/packet.h> supplies nothing this probe uses.
 AC_MSG_CHECKING(for TX_RING socket sending support)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/socket.h>
-#include <netpacket/packet.h>
 #include <net/ethernet.h>     /* the L2 protocols */
 #include <netinet/in.h>       /* htons */
 #include <linux/if_packet.h>

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,27 @@
 UNRELEASED
+    - common: finish fixing Linux TX_RING support after #1043 (#1044) - #1043 (thanks @plusky) fixed
+      a typo in src/common/txring.h's include guard ('__GLIBC_MINOR' instead of '__GLIBC_MINOR__',
+      always evaluating false, so the #else branch - missing the TX_RING API entirely - was taken
+      unconditionally on every glibc system) and switched to <linux/if_packet.h>, the header that
+      actually defines struct tpacket_hdr/tpacket_req/TPACKET_HDRLEN. That fix alone wasn't enough:
+      both build systems' own TX_RING feature probes (configure.ac, cmake/ConfigureChecks.cmake)
+      independently included <netpacket/packet.h> alongside <linux/if_packet.h> - the two cannot be
+      included together before C23 (both define struct sockaddr_ll/packet_mreq, and the
+      __UAPI_DEF_* de-duplication guards don't apply pre-C23) - so the probe itself failed to
+      compile under -std=gnu11/-std=gnu17, meaning HAVE_TX_RING was never defined in the first
+      place on affected systems (the openSUSE/Fedora-style "older language level" case #1043 called
+      out) and txring.h's now-correct code was never reached. Dropped the redundant
+      <netpacket/packet.h> from both probes (it supplies nothing they use). That in turn surfaced a
+      third instance of the same collision, now hit for the first time ever since TX_RING had never
+      actually compiled before: src/common/sendpacket.h and sendpacket.c each unconditionally
+      include <netpacket/packet.h> for struct sockaddr_ll whenever HAVE_PF_PACKET is set (in
+      sendpacket.c, also whenever HAVE_LIBURING is set) - both commonly true alongside HAVE_TX_RING
+      on a modern Linux system - which then collided with txring.h's <linux/if_packet.h>. Made those
+      includes conditional on !HAVE_TX_RING, since txring.h already provides struct sockaddr_ll via
+      <linux/if_packet.h> in that case. Verified end-to-end (not just that it compiles): with all
+      four fixes applied, 'Linux TX_RING: yes' is correctly detected by both build systems on a
+      real glibc/gnu17 system, tcpreplay reports 'Injection method: PF_PACKET / TX_RING', and
+      packets are actually sent successfully through it
     - common: fix check_list() return type mismatch warning - declared 'int' in list.h but defined
       as 'tcpr_dir_t' (an unrelated enum) in list.c, triggering '-Wenum-int-mismatch' on newer GCC;
       the function only ever returns 0 or 1 and every caller treats the result as a plain boolean,

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -161,3 +161,7 @@ Gabriel Ganne <GitHub @GabrielGanne>
     - fragroute: fix heap-buffer-overflow on packets with too many MPLS labels (#993)
     - tcprewrite: fix vlan tag add silently truncating output when --enet-vlan-pri/-cfi omitted (#994)
     - tcpprep: fix buffer overflow in check_dst_port() on truncated L4 headers (#995)
+
+plusky <GitHub @plusky>
+    - diagnosed and fixed the __GLIBC_MINOR typo in src/common/txring.h that had silently
+      disabled Linux TX_RING support on every glibc system since the check was added (#1043)

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -171,7 +171,16 @@
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <netinet/in.h>
+/* <netpacket/packet.h> and <linux/if_packet.h> (pulled in below by
+ * txring.h when HAVE_TX_RING) cannot be included together before C23 -
+ * both define struct sockaddr_ll/packet_mreq, and the __UAPI_DEF_*
+ * de-duplication guards don't apply pre-C23 (#1043/#1044). When both
+ * PF_PACKET and TX_RING support are available - the common case on a
+ * modern Linux system - let txring.h's <linux/if_packet.h> be the sole
+ * source of struct sockaddr_ll for this translation unit instead. */
+#ifndef HAVE_TX_RING
 #include <netpacket/packet.h>
+#endif
 #include <sys/utsname.h>
 
 #ifdef HAVE_TX_RING
@@ -255,7 +264,11 @@ static struct tcpr_ether_addr *sendpacket_get_hwaddr_libxdp(sendpacket_t *);
 #ifdef HAVE_LIBURING
 #include <net/if_arp.h>
 #include <netinet/in.h>
+/* see the HAVE_PF_PACKET block above - same pre-C23 header collision
+ * with txring.h's <linux/if_packet.h> when HAVE_TX_RING is also set. */
+#ifndef HAVE_TX_RING
 #include <netpacket/packet.h>
+#endif
 static sendpacket_t *sendpacket_open_io_uring(const char *, char *) _U_;
 static struct tcpr_ether_addr *sendpacket_get_hwaddr_io_uring(sendpacket_t *) _U_;
 static void sendpacket_uring_process_cqe(sendpacket_t *, struct io_uring_cqe *);

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -36,7 +36,14 @@
 #include <net/netmap.h>
 #endif
 
-#ifdef HAVE_PF_PACKET
+/* <netpacket/packet.h> and <linux/if_packet.h> (pulled in below by
+ * txring.h when HAVE_TX_RING) cannot be included together before C23 -
+ * both define struct sockaddr_ll/packet_mreq, and the __UAPI_DEF_*
+ * de-duplication guards don't apply pre-C23 (#1043/#1044). When both
+ * PF_PACKET and TX_RING support are available - the common case on a
+ * modern Linux system - let txring.h's <linux/if_packet.h> be the sole
+ * source of struct sockaddr_ll for this translation unit instead. */
+#if defined HAVE_PF_PACKET && !defined HAVE_TX_RING
 #include <netpacket/packet.h>
 #endif
 


### PR DESCRIPTION
## Summary

Fixes #1044.

#1043 (thanks @plusky) fixed a typo in `src/common/txring.h`'s include guard - `__GLIBC_MINOR` instead of `__GLIBC_MINOR__` always evaluates false, so the `#else` branch (missing the TX_RING API entirely) was taken unconditionally on every glibc system - and switched to `<linux/if_packet.h>`, the header that actually defines `struct tpacket_hdr`/`tpacket_req`/`TPACKET_HDRLEN`.

That fix alone wasn't enough to actually enable TX_RING. This PR finishes the job with three more fixes surfaced by actually verifying it end-to-end (build + `sudo make test`, not just "does it compile in isolation"):

### 1. Both build systems' TX_RING probes had the same header collision

`configure.ac` and `cmake/ConfigureChecks.cmake`'s `HAVE_TX_RING` probe test programs independently included `<netpacket/packet.h>` alongside `<linux/if_packet.h>`. The two cannot be included together before C23 - both define `struct sockaddr_ll`/`packet_mreq`, and the `__UAPI_DEF_*` de-duplication guards don't apply pre-C23 (verified directly - reproduces the identical redefinition errors on a real `-std=gnu17` system). So the probe itself failed to compile, meaning `HAVE_TX_RING` was **never defined in the first place** on affected systems (the openSUSE/Fedora-style "older language level" case #1043 called out) - `txring.h`'s now-correct code was never even reached. Dropped the redundant `<netpacket/packet.h>` from both probes; it supplies nothing they use.

### 2. Fixing the probes surfaced a third instance of the same collision

Since `HAVE_TX_RING` had *literally never been true* in any build before this chain of fixes, this code path had never been exercised: `src/common/sendpacket.h` and `sendpacket.c` each unconditionally include `<netpacket/packet.h>` for `struct sockaddr_ll` whenever `HAVE_PF_PACKET` is set (in `sendpacket.c`, also whenever `HAVE_LIBURING` is set) - both commonly true alongside `HAVE_TX_RING` on a modern Linux system - which then collided with `txring.h`'s `<linux/if_packet.h>`. Made those three includes conditional on `!HAVE_TX_RING`, since `txring.h` already provides `struct sockaddr_ll` via `<linux/if_packet.h>` in that case.

## Test plan

- [x] Fresh clone, autotools: `Linux TX_RING: yes` correctly detected (was `no` before this PR, `yes` in the probe but build failures if only #1043's fix were applied), full build succeeds with zero errors, `sudo make test` passes
- [x] Fresh clone, CMake: same - `HAVE_TX_RING` succeeds, full build succeeds with zero errors
- [x] Runtime: `tcpreplay --version` reports `Injection method: PF_PACKET / TX_RING`; actually replayed packets through it (179/179 successful, 0 failed), throughput ~13x over plain `PF_PACKET send()`
- [x] Confirmed via `grep` that no other file in the tree includes both `<netpacket/packet.h>` and `<linux/if_packet.h>` (or has an unguarded include of one that could still collide) after this fix

Also updates `docs/CHANGELOG` and `docs/CREDIT` to credit @plusky for #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)