### PR TITLE
libopts: fix out-of-bounds read in --save-opts handling (#931)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,21 @@
 UNRELEASED
+    - libopts: fix out-of-bounds read in --save-opts handling (#931, reported by @momo-trip) -
+      remove_settings() (libopts/save.c), called to strip an existing program's section out of the
+      save-opts file before rewriting it, ran strstr()/strlen() directly on the buffer returned by
+      text_mmap() without checking it for failure first. text_mmap() returns MAP_FAILED outright
+      when the file doesn't exist yet (the common case: the first time --save-opts is used) or is
+      otherwise unmappable, and even on success only NUL-terminates on a best-effort basis - its own
+      doc comment notes that when the file size lands exactly on a page boundary, it tries to map an
+      extra page after the data to hold the terminator, and silently returns without one if that
+      extra mapping fails (checkable via txt_size == txt_full_size). remove_settings() checked
+      neither condition, so a missing/unmappable save file sent strstr() scanning from a pointer
+      near -1, and (in principle, though not independently reproduced outside of induced mmap
+      failure) a page-exact save file could do the same past the end of the mapping. Fixed by
+      copying exactly txt_size bytes into a heap buffer and NUL-terminating it explicitly before any
+      scanning, so the fix no longer depends on text_mmap()'s guarantees at all, plus an explicit
+      MAP_FAILED check. Verified under AddressSanitizer: the original code crashes
+      (heap-buffer-overflow / wild pointer read) when --save-opts targets a nonexistent file; the
+      fix does not
     - common: finish fixing Linux TX_RING support after #1043 (#1044) - #1043 (thanks @plusky) fixed
       a typo in src/common/txring.h's include guard ('__GLIBC_MINOR' instead of '__GLIBC_MINOR__',
       always evaluating false, so the #else branch - missing the TX_RING API entirely - was taken

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -165,3 +165,7 @@ Gabriel Ganne <GitHub @GabrielGanne>
 plusky <GitHub @plusky>
     - diagnosed and fixed the __GLIBC_MINOR typo in src/common/txring.h that had silently
       disabled Linux TX_RING support on every glibc system since the check was added (#1043)
+
+momo-trip <GitHub @momo-trip>
+    - reported an out-of-bounds read in libopts' --save-opts handling triggered by strstr()
+      running on a possibly-unmapped/non-terminated buffer (#931)

--- a/libopts/save.c
+++ b/libopts/save.c
@@ -493,11 +493,12 @@ remove_settings(tOptions * opts, char const * fname)
     size_t const name_len = strlen(opts->pzProgName);
     tmap_info_t  map_info;
     char *       mapped = text_mmap(fname, PROT_READ|PROT_WRITE, MAP_PRIVATE, &map_info);
-    char *       text;
-    char *       scan;
+    char *       text = NULL;
+    char *       scan = NULL;
 
-    if (mapped == (char *)MAP_FAILED)
+    if (mapped == (char *)MAP_FAILED) {
         return;
+    }
 
     /*
      * text_mmap() only guarantees a trailing NUL on a best-effort basis:
@@ -544,7 +545,9 @@ remove_settings(tOptions * opts, char const * fname)
             new_sz = map_info.txt_size - strlen(scan);
         else {
             int fd = open(fname, O_RDWR);
-            if (fd < 0) goto leave;
+            if (fd < 0) {
+                goto leave;
+            }
             if (lseek(fd, (scan - text), SEEK_SET) < 0)
                 scan = next;
             else if (write(fd, next, strlen(next)) < 0)

--- a/libopts/save.c
+++ b/libopts/save.c
@@ -492,8 +492,30 @@ remove_settings(tOptions * opts, char const * fname)
 {
     size_t const name_len = strlen(opts->pzProgName);
     tmap_info_t  map_info;
-    char *       text = text_mmap(fname, PROT_READ|PROT_WRITE, MAP_PRIVATE, &map_info);
-    char *       scan = text;
+    char *       mapped = text_mmap(fname, PROT_READ|PROT_WRITE, MAP_PRIVATE, &map_info);
+    char *       text;
+    char *       scan;
+
+    if (mapped == (char *)MAP_FAILED)
+        return;
+
+    /*
+     * text_mmap() only guarantees a trailing NUL on a best-effort basis:
+     * if the file size lands exactly on a page boundary, it tries to map
+     * an extra page after the data for the NUL byte, and if that extra
+     * mapping fails, it silently returns the buffer without one (see its
+     * own doc comment - callers are expected to check
+     * txt_size == txt_full_size to detect this). Every scan below assumes
+     * NUL-termination (strstr()/strlen() on "scan"), so work on a
+     * definitely-terminated heap copy instead of trusting that best-effort
+     * guarantee directly - a save file crafted to hit this case could
+     * otherwise send strstr()/strlen() reading past the mapped region
+     * (reported as #931).
+     */
+    text = (char *)AGALOC(map_info.txt_size + 1, "save file text");
+    memcpy(text, mapped, map_info.txt_size);
+    text[map_info.txt_size] = NUL;
+    scan = text;
 
     for (;;) {
         char * next = scan = strstr(scan, zCfgProg);
@@ -522,7 +544,7 @@ remove_settings(tOptions * opts, char const * fname)
             new_sz = map_info.txt_size - strlen(scan);
         else {
             int fd = open(fname, O_RDWR);
-            if (fd < 0) return;
+            if (fd < 0) goto leave;
             if (lseek(fd, (scan - text), SEEK_SET) < 0)
                 scan = next;
             else if (write(fd, next, strlen(next)) < 0)
@@ -537,6 +559,7 @@ remove_settings(tOptions * opts, char const * fname)
     }
 
  leave:
+    AGFREE(text);
     text_munmap(&map_info);
 }
 


### PR DESCRIPTION
## Summary
- `remove_settings()` in `libopts/save.c` scanned the buffer returned by `text_mmap()` with `strstr()`/`strlen()` without checking it for failure first.
- `text_mmap()` returns `MAP_FAILED` outright when the target save-opts file doesn't exist yet (the common case — the first time `--save-opts` is used) and, even on success, only NUL-terminates its buffer on a best-effort basis (its own doc comment notes a page-exact file size can leave it unterminated if the extra guard-page mapping fails).
- Neither condition was checked, so a missing/unmappable save file sent `strstr()` scanning from a pointer near `-1` — reported as an out-of-bounds read / crash in #931 by @momo-trip.

## Fix
- Copy exactly `txt_size` bytes from the mapped region into a heap buffer and explicitly NUL-terminate it before any scanning, removing the dependency on `text_mmap()`'s guarantees entirely.
- Add an explicit `MAP_FAILED` check before touching the buffer at all.

## Verification
- AddressSanitizer (gcc, **local/vendored** libopts — confirmed via `configure`'s "Using included libopts tearoff", not the system copy): original code crashes when `--save-opts` targets a nonexistent file; patched code does not, and produces a valid save file.
- Also checked the page-boundary NUL-termination theory directly (an exactly-4096-byte, page-aligned save file): does not reproduce under normal conditions since the kernel's extra guard-page mapping only fails under real address-space exhaustion — but the fix removes the dependency on that guarantee regardless, so it's covered by construction either way.
- Full clean-clone verification (fresh `git clone` of this branch, not the working tree): both autotools (`./autogen.sh && ../configure && make`) and CMake (`cmake -B build && cmake --build build`) build cleanly.
- `sudo make test`: all 20 `tcpprep` tests and all 33 `tcprewrite` tests pass (including the config/save-opts paths this touches). The `tcpreplay` live-injection tests fail in this environment because the test suite's default NIC (`eth0`, hardcoded in `configure.ac`) doesn't exist on this box (`enp0s3` instead) — a pre-existing environment mismatch unrelated to this change, confirmed by grepping `configure.ac`'s hardcoded default.

Closes #931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)