### PR TITLE
cmake: make --target test fail loudly instead of silently no-op'ing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,19 @@ set(srcdir ${CMAKE_SOURCE_DIR}/test)
 configure_file(${CMAKE_SOURCE_DIR}/test/config.in
                ${CMAKE_BINARY_DIR}/test/config @ONLY)
 
+# The line above creates a real ${CMAKE_BINARY_DIR}/test directory. Without a
+# target explicitly named "test", `cmake --build . --target test` would find
+# that directory sitting there with no build rule and nothing out of date,
+# and treat the goal as trivially satisfied - exiting 0 having silently run
+# nothing (#1047). Make that failure loud instead: this suite's tests are
+# still autotools-only (see docs/HACKING / CLAUDE.md), so point at that.
+add_custom_target(test
+    COMMAND ${CMAKE_COMMAND} -E echo "error: the test suite is autotools-only for now."
+    COMMAND ${CMAKE_COMMAND} -E echo "  from ${CMAKE_SOURCE_DIR}: run ./autogen.sh, then ./configure, then sudo make test in test/"
+    COMMAND ${CMAKE_COMMAND} -E false
+    COMMENT "cmake does not run the test suite yet"
+)
+
 add_compile_definitions(HAVE_CONFIG_H)
 
 # Common include order: generated headers first, then the source tree


### PR DESCRIPTION
## Summary
- `cmake --build build --target test` (and `sudo cmake --build build-cmake --target test`) exits 0 and runs nothing, instead of running tests or erroring.
- Root cause: `CMakeLists.txt` generates `<builddir>/test/config` so the autotools test fixtures can be reused, which creates a real directory named `test` in the build tree. With no CMake target actually named `test` defined anywhere, GNU Make finds that directory sitting there with no rule and nothing out of date, and treats the goal as trivially satisfied — a silent, false success (confirmed via `make -d test`: "No need to remake target 'test'.").
- This suite's tests are still autotools-only (`docs/HACKING`); CMake was never meant to run them. The fix doesn't try to run tests via CMake — it makes the gap loud and honest instead of silently masked.

## Fix
Add an explicit `add_custom_target(test ...)` (CMake marks custom targets `.PHONY`, which takes precedence over the directory-name collision — confirmed experimentally) that prints a clear message and exits non-zero, pointing at the autotools test path.

## Verification
- `cmake --build build --target test` now exits non-zero with an explanatory message (both plain and under `sudo`, matching the exact reported invocation).
- A plain `cmake --build build` (no target) is unaffected — confirmed the default build still succeeds.
- Clean-clone verification (fresh `git clone` of this branch): CMake build + `--target test` behavior confirmed; autotools build (`./autogen.sh && ./configure && make`) confirmed unaffected, plus `sudo make tcpprep` (20 tests) passing.

Closes #1047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)