### PR TITLE
docs: fix broken vulnerability-reporting email in SECURITY.md

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -24,6 +24,6 @@ receiving such patches depend on the CVSS v3.0 Rating:
 ## Reporting a Vulnerability
 
 Please report (suspected) security vulnerabilities to
-**[tcpreplay@appneta.com](mailto:appneta.com)**. You will receive a response from
+**[tcpreplay.dev@gmail.com](mailto:tcpreplay.dev@gmail.com)**. You will receive a response from
 us within 72 hours. If the issue is confirmed, we will release a patch as soon
 as possible depending on complexity but historically within a few days.


### PR DESCRIPTION
## Summary
- \`docs/SECURITY.md\`'s mailto link was truncated to \`mailto:appneta.com\` (missing the local part), and the displayed address \`tcpreplay@appneta.com\` isn't the right contact anymore. Both now point at \`tcpreplay.dev@gmail.com\`.

Found while reviewing README.md (#1049).

🤖 Generated with [Claude Code](https://claude.com/claude-code)