### PR TITLE
common: fix pointer/int cast warnings in txring.c (Linux TX_RING)

### DIFF
--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -55,7 +55,7 @@ txring_send(void *arg)
 {
     int ec_send;
     static int total = 0;
-    int fd_socket = (int)arg;
+    int fd_socket = (int)(intptr_t)arg;
 
     do {
         /* send all buffers with TP_STATUS_SEND_REQUEST */
@@ -74,7 +74,7 @@ txring_send(void *arg)
     // if(blocking) printf("end of task send()\n");
     // printf("end of task send(ec=%x)\n", ec_send);
 
-    return (void *)ec_send;
+    return (void *)(intptr_t)ec_send;
 }
 
 /**
@@ -229,7 +229,7 @@ txring_init(int fd, unsigned int mtu)
     para_send.sched_priority = 20;
     pthread_attr_setschedparam(&t_attr_send, &para_send);
 
-    if (pthread_create(&txp->tx_send, &t_attr_send, txring_send, (void *)fd) != 0) {
+    if (pthread_create(&txp->tx_send, &t_attr_send, txring_send, (void *)(intptr_t)fd) != 0) {
         perror("pthread_create() failed\n");
         abort();
     }


### PR DESCRIPTION
## Summary
Fixes the build warnings reported:
\`\`\`
../../src/common/txring.c:58:21: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
../../src/common/txring.c:77:12: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
../../src/common/txring.c:232:66: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
\`\`\`

The socket fd is passed to \`pthread_create()\` as its \`void *\` arg and cast straight back to \`int\` in \`txring_send()\`. Direct \`int\`<->\`void *\` casts are only \`sizeof(int)\`-safe when pointers happen to be that size; on 64-bit Linux they aren't, hence the warnings. Routed all three sites (the two-way fd cast plus \`txring_send()\`'s unused return value) through \`intptr_t\`, which exists specifically for this and round-trips losslessly. No behavior change — same bit pattern in, same bit pattern out.

\`intptr_t\` is already available here via \`defines.h\`'s \`<stdint.h>\` include, no new include needed.

## Test plan
- [x] Reviewed all three call sites and the (unused, never `pthread_join`'d) return-value path
- [x] Linux CI (\`HAVE_TX_RING\` is Linux-only; can't compile-test this path locally on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)