### PR TITLE
tcpreplay: add --raw, a PF_INET/SOCK_RAW packet-injection backend (#465)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ endfunction()
 foreach(_v PF_RING_FOUND ENABLE_64BITS ENABLE_FRAGROUTE ENABLE_TCPBRIDGE ENABLE_TCPLIVEPLAY
             HAVE_TX_RING HAVE_PF_PACKET HAVE_BPF HAVE_LIBDNET HAVE_PCAP_INJECT
             HAVE_PCAP_SENDPACKET HAVE_LIBPCAP_NETMAP HAVE_NETMAP HAVE_TUNTAP HAVE_LIBXDP
-            HAVE_LIBURING)
+            HAVE_LIBURING HAVE_SOCK_RAW)
     tcpr_yn(${_v} _yn_${_v})
 endforeach()
 
@@ -500,6 +500,7 @@ message(STATUS "Linux/BSD netmap:           ${_yn_HAVE_NETMAP} ${NETMAP_INCLUDE_
 message(STATUS "Tuntap device support:      ${_yn_HAVE_TUNTAP}")
 message(STATUS "LIBXDP for AF_XDP socket:   ${_yn_HAVE_LIBXDP}")
 message(STATUS "liburing for io_uring:      ${_yn_HAVE_LIBURING}")
+message(STATUS "PF_INET SOCK_RAW (--raw):   ${_yn_HAVE_SOCK_RAW}")
 message(STATUS "")
 message(STATUS "* In order of preference; see options in CMakeLists.txt to override")
 message(STATUS "** Required for tcpbridge")

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -398,6 +398,20 @@ check_c_source_compiles("
 int main(void) { int test = TP_STATUS_WRONG_FORMAT; return test; }
 " HAVE_TX_RING)
 
+# PF_INET/SOCK_RAW raw IP socket support (#465): unlike PF_PACKET, packets
+# sent this way go through the normal Linux IP stack (routing,
+# netfilter/iptables) rather than straight onto the wire. SO_BINDTODEVICE
+# is Linux-specific, so this probe effectively gates the feature to Linux.
+check_c_source_compiles("
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <net/if.h>
+int main(void) {
+    int raw_socket = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
+    struct ifreq ifr;
+    return setsockopt(raw_socket, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr));
+}" HAVE_SOCK_RAW)
+
 check_library_exists(bpf bpf_object__open_file "" HAVE_LIBBPF_LIB)
 check_library_exists(xdp xsk_umem__delete "" HAVE_LIBXDP_LIB)
 if(HAVE_LIBXDP_LIB)

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -406,6 +406,9 @@
 /* Define to 1 if you have the 'snprintf' function. */
 #cmakedefine HAVE_SNPRINTF @HAVE_SNPRINTF@
 
+/* Do we have PF_INET SOCK_RAW raw IP socket support? */
+#cmakedefine HAVE_SOCK_RAW @HAVE_SOCK_RAW@
+
 /* Define to 1 if you have the 'socket' function. */
 #cmakedefine HAVE_SOCKET @HAVE_SOCKET@
 

--- a/configure.ac
+++ b/configure.ac
@@ -1558,6 +1558,29 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     AC_MSG_RESULT(no)
 ])
 
+have_sock_raw=no
+dnl Check for PF_INET/SOCK_RAW raw IP socket support (#465): unlike
+dnl PF_PACKET, packets sent this way go through the normal Linux IP stack
+dnl (routing, netfilter/iptables) rather than straight onto the wire.
+AC_MSG_CHECKING(for PF_INET SOCK_RAW raw IP socket sending support)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <net/if.h>
+]], [[
+    int raw_socket;
+    struct ifreq ifr;
+    raw_socket = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
+    setsockopt(raw_socket, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr));
+]])],[
+    AC_DEFINE([HAVE_SOCK_RAW], [1],
+            [Do we have PF_INET SOCK_RAW raw IP socket support?])
+    AC_MSG_RESULT(yes)
+    have_sock_raw=yes
+],[
+    AC_MSG_RESULT(no)
+])
+
 have_libxdp=no
 dnl Check for LIBXDP AF_XDP socket support
 AC_MSG_CHECKING(for LIBXDP XDP packet sending support)
@@ -2170,6 +2193,7 @@ Linux/BSD netmap:           ${have_netmap}
 Tuntap device support:      ${have_tuntap}
 LIBXDP for AF_XDP socket:   ${have_libxdp}
 liburing for io_uring:      ${have_liburing}
+PF_INET SOCK_RAW (--raw):   ${have_sock_raw}
 
 * In order of preference; see configure --help to override
 ** Required for tcpbridge

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,8 @@
 07/21/2026 Version 4.6.0-beta1
+    - tcpreplay: add --raw, a PF_INET/SOCK_RAW packet-injection backend (#465, originally attempted
+      in #511) - lets replayed traffic pass through the local IP stack (routing,
+      netfilter/iptables) instead of going straight onto the wire via PF_PACKET; trades off L2
+      fidelity (kernel builds its own Ethernet framing) and is IPv4-only for now
     - build: add CMake build support alongside autotools (#688)
     - tcpreplay: add Linux io_uring packet injection support via --io-uring (#954)
     - cmake: fail configure on stale pre-generated AutoOpts files in the source tree (#1020)

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -196,7 +196,30 @@ example:
 If you want to compile a version that only uses io_uring, use the
 `--enable-force-liburing` configure option.
 
-4) libtcpreplay C library
+4) PF_INET raw IP sockets
+   -----------------------
+
+By default tcpreplay injects packets with PF_PACKET, which writes directly
+to the network driver below the IP stack - so locally-configured
+netfilter/iptables rules never see the traffic, even when replaying on the
+same host those rules are configured on (#465). This feature is detected
+on Linux systems that support PF_INET/SOCK_RAW sockets with SO_BINDTODEVICE
+(essentially all of them), enabling the `--raw` option, which instead sends
+each packet's IP header and payload through a raw IP socket bound to the
+outbound interface, so the kernel's normal IP stack - including
+netfilter/iptables - processes it like any other locally-generated packet.
+The trade-off is L2 fidelity: the kernel builds its own Ethernet framing,
+so the captured source/destination MAC addresses are not reproduced, and
+only IPv4 is currently supported. For example:
+
+    $ ./configure | tail
+    liburing for io_uring:      yes
+    PF_INET SOCK_RAW (--raw):   yes
+    $ make
+    $ sudo make install
+    $ tcpreplay -i eth0 --raw test/test.pcap
+
+5) libtcpreplay C library
    ----------------------
 
 Both build systems install libtcpreplay.a, the tcpreplay_api.h headers

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -194,6 +194,13 @@ static int sendpacket_send_raw_ip(sendpacket_t *, const u_char *, size_t);
 
 #endif /* HAVE_PF_PACKET */
 
+#ifdef HAVE_SOCK_RAW
+#include <net/if.h>
+#include <netinet/in.h>
+static sendpacket_t *sendpacket_open_sock_raw(const char *, char *);
+static int sendpacket_send_sock_raw(sendpacket_t *, const u_char *, size_t);
+#endif /* HAVE_SOCK_RAW */
+
 #ifdef HAVE_TUNTAP
 #ifdef HAVE_LINUX
 #include <linux/if_tun.h>
@@ -381,6 +388,40 @@ TRY_SEND_AGAIN:
     case SP_TYPE_TUNTAP:
         retcode = (int)write(sp->handle.fd, (void *)data, len);
         break;
+
+#ifdef HAVE_SOCK_RAW
+    case SP_TYPE_SOCK_RAW:
+        retcode = sendpacket_send_sock_raw(sp, data, len);
+
+        if (retcode == -2) {
+            retcode = -1; /* packet this backend can't send: hard failure, error already set */
+        } else if (retcode < 0 && !sp->abort) {
+            switch (errno) {
+            case EAGAIN:
+                sp->retry_eagain++;
+                goto TRY_SEND_AGAIN;
+            case ENOBUFS:
+                sp->retry_enobufs++;
+                goto TRY_SEND_AGAIN;
+            default:
+                sendpacket_seterr(sp,
+                                  "Error with PF_INET SOCK_RAW send() [" COUNTER_SPEC "]: %s (errno = %d)",
+                                  sp->sent + sp->failed + 1,
+                                  strerror(errno),
+                                  errno);
+            }
+        } else if (retcode >= 0) {
+            /*
+             * sendto() only reports the L3-only bytes actually written
+             * (the Ethernet header was stripped before sending), but
+             * callers compare our return value against the full captured
+             * packet length. Normalize to that on success, same as
+             * pcap_sendpacket() below.
+             */
+            retcode = (int)len;
+        }
+        break;
+#endif /* HAVE_SOCK_RAW */
 
         /* Linux PF_PACKET and TX_RING */
     case SP_TYPE_PF_PACKET:
@@ -710,6 +751,11 @@ sendpacket_open(const char *device,
                 sp = sendpacket_open_io_uring(device, errbuf);
             else
 #endif
+#ifdef HAVE_SOCK_RAW
+                    if (sendpacket_type == SP_TYPE_SOCK_RAW)
+                sp = sendpacket_open_sock_raw(device, errbuf);
+            else
+#endif
 #if defined HAVE_PF_PACKET
                 sp = sendpacket_open_pf(device, errbuf);
 #elif defined HAVE_LIBURING
@@ -747,6 +793,7 @@ sendpacket_open(const char *device,
         case SP_TYPE_LIBPCAP:
         case SP_TYPE_LIBXDP:
         case SP_TYPE_IO_URING:
+        case SP_TYPE_SOCK_RAW:
             if (sendpacket_is_running(sp->device) == 0) {
                 warnx("WARNING: %s has no carrier (cable unplugged or link down). Packets will "
                       "appear to send successfully but will not reach the wire.",
@@ -819,6 +866,9 @@ sendpacket_close(sendpacket_t *sp)
     assert(sp);
     switch (sp->handle_type) {
     case SP_TYPE_KHIAL:
+#ifdef HAVE_SOCK_RAW
+    case SP_TYPE_SOCK_RAW:
+#endif
         close(sp->handle.fd);
         break;
 
@@ -1381,6 +1431,110 @@ sendpacket_get_hwaddr_pf(sendpacket_t *sp)
 }
 #endif /* HAVE_PF_PACKET */
 
+#ifdef HAVE_SOCK_RAW
+/**
+ * Inner sendpacket_open() method for a PF_INET/SOCK_RAW raw IP socket
+ * (#465). Unlike PF_PACKET, packets sent this way go through the normal
+ * Linux IP stack -- routing, netfilter/iptables -- rather than straight
+ * onto the wire, at the cost of L2 fidelity: the kernel builds its own
+ * Ethernet framing, so the captured source/dest MAC are not reproduced.
+ */
+static sendpacket_t *
+sendpacket_open_sock_raw(const char *device, char *errbuf)
+{
+    int mysocket;
+    struct ifreq ifr;
+    sendpacket_t *sp;
+    int err;
+    socklen_t errlen = sizeof(err);
+
+    assert(device);
+    assert(errbuf);
+
+    dbg(1, "sendpacket: using PF_INET SOCK_RAW");
+
+    /* IPPROTO_RAW implies IP_HDRINCL: we supply our own IP header */
+    if ((mysocket = socket(PF_INET, SOCK_RAW, IPPROTO_RAW)) < 0) {
+        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "raw socket: %s", strerror(errno));
+        return NULL;
+    }
+
+    /* bind socket to our interface so packets go out the requested NIC */
+    memset(&ifr, 0, sizeof(ifr));
+    strlcpy(ifr.ifr_name, device, sizeof(ifr.ifr_name));
+    if (setsockopt(mysocket, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) < 0) {
+        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "raw bind error: %s", strerror(errno));
+        close(mysocket);
+        return NULL;
+    }
+
+    /* check for errors, network down, etc... */
+    if (getsockopt(mysocket, SOL_SOCKET, SO_ERROR, &err, &errlen) < 0) {
+        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "error opening raw %s: %s", device, strerror(errno));
+        close(mysocket);
+        return NULL;
+    }
+
+    if (err > 0) {
+        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "error opening raw %s: %s", device, strerror(err));
+        close(mysocket);
+        return NULL;
+    }
+
+    /* prep & return our sp handle */
+    sp = (sendpacket_t *)safe_malloc(sizeof(sendpacket_t));
+    memset(sp, 0, sizeof(*sp));
+    strlcpy(sp->device, device, sizeof(sp->device));
+    sp->handle.fd = mysocket;
+    sp->handle_type = SP_TYPE_SOCK_RAW;
+
+    return sp;
+}
+
+/**
+ * Send a captured Ethernet-framed IPv4 packet on a PF_INET/SOCK_RAW socket
+ * (#465). Raw IP sockets take L3-only payloads, so the Ethernet header is
+ * stripped; the destination address is pulled from the IP header for
+ * sendto(), since the socket is connectionless. Only IPv4 is supported --
+ * IPv6 needs a separate PF_INET6 socket, which this backend doesn't open.
+ * Returns bytes sent, -1 on send error (errno valid), or -2 for a packet
+ * this backend can't handle (non-IPv4, truncated) -- error already set.
+ */
+static int
+sendpacket_send_sock_raw(sendpacket_t *sp, const u_char *data, size_t len)
+{
+    const u_char *ip_data;
+    size_t ip_len;
+    const ipv4_hdr_t *ip_hdr;
+    struct sockaddr_in sin;
+
+    if (len <= sizeof(eth_hdr_t)) {
+        sendpacket_seterr(sp, "packet too short to hold an Ethernet + IP header on %s", sp->device);
+        return -2;
+    }
+
+    ip_data = data + sizeof(eth_hdr_t);
+    ip_len = len - sizeof(eth_hdr_t);
+
+    if (ip_len < sizeof(ipv4_hdr_t)) {
+        sendpacket_seterr(sp, "packet too short to hold an IPv4 header on %s", sp->device);
+        return -2;
+    }
+
+    ip_hdr = (const ipv4_hdr_t *)ip_data;
+    if (ip_hdr->ip_v != 4) {
+        sendpacket_seterr(sp, "%s (--raw) only supports IPv4; got IP version %u", sp->device, ip_hdr->ip_v);
+        return -2;
+    }
+
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_addr = ip_hdr->ip_dst;
+
+    return (int)sendto(sp->handle.fd, ip_data, ip_len, 0, (struct sockaddr *)&sin, sizeof(sin));
+}
+#endif /* HAVE_SOCK_RAW */
+
 #if defined HAVE_BPF
 /**
  * Inner sendpacket_open() method for using BSD's BPF interface
@@ -1539,6 +1693,7 @@ sendpacket_get_dlt(sendpacket_t *sp)
     case SP_TYPE_LIBXDP:
     case SP_TYPE_IO_URING:
     case SP_TYPE_LIBPCAP_DUMP:
+    case SP_TYPE_SOCK_RAW:
         /* always EN10MB */
         return dlt;
     default:;

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -78,7 +78,8 @@ typedef enum sendpacket_type_e {
     SP_TYPE_TUNTAP,
     SP_TYPE_LIBPCAP_DUMP,
     SP_TYPE_LIBXDP,
-    SP_TYPE_IO_URING
+    SP_TYPE_IO_URING,
+    SP_TYPE_SOCK_RAW
 } sendpacket_type_t;
 
 /* these are the file_operations ioctls */

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -292,6 +292,20 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
 #endif
     }
 
+    if (HAVE_OPT(RAW)) {
+#ifdef HAVE_SOCK_RAW
+        if (ctx->sp_type != SP_TYPE_NONE) {
+            tcpreplay_seterr(ctx, "%s", "--raw cannot be combined with --netmap, --xdp or --io-uring");
+            ret = -1;
+            goto out;
+        }
+        options->raw = 1;
+        ctx->sp_type = SP_TYPE_SOCK_RAW;
+#else
+        err(-1, "--raw feature was not compiled in. See INSTALL.");
+#endif
+    }
+
     if (HAVE_OPT(UNIQUE_IP))
         options->unique_ip = 1;
 

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -162,6 +162,10 @@ typedef struct tcpreplay_opt_s {
     int io_uring;
 #endif
 
+#ifdef HAVE_SOCK_RAW
+    int raw;
+#endif
+
     /* print flow statistic */
     bool flow_stats;
     int flow_expiry;

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -756,6 +756,30 @@ EOText;
 };
 
 flag = {
+    ifdef       = HAVE_SOCK_RAW;
+    name        = raw;
+    descrip     = "Send packets via a PF_INET raw IP socket instead of PF_PACKET";
+    doc         = <<- EOText
+By default, tcpreplay injects packets with PF_PACKET, which writes directly
+to the network driver below the IP stack. This means locally-generated
+netfilter/iptables rules (and anything else hooked into the normal Linux IP
+stack) never see the traffic, even when replaying it on the same host that
+has those rules configured.
+
+This option instead sends each packet's IP header and payload through a
+PF_INET raw IP (@code{SOCK_RAW}) socket bound to the interface given by
+@var{--intf1}/@var{--intf2}, so the kernel's normal IP stack -- including
+netfilter/iptables -- processes it like any other locally-generated packet.
+
+The trade-off is L2 fidelity: the kernel builds its own Ethernet framing for
+the outgoing packet, so the source/destination MAC addresses from the
+capture are not reproduced, and only IPv4 packets are currently supported.
+This option is Linux-only and requires appropriate privileges to open a raw
+socket (typically root or @code{CAP_NET_RAW}).
+EOText;
+};
+
+flag = {
     name        = version;
     value       = V;
     descrip     = "Print version information";


### PR DESCRIPTION
## Summary
- Fixes #465. The default PF_PACKET injection path writes directly to the network driver below the IP stack, so locally-configured netfilter/iptables rules never see the traffic — even when replaying on the same host those rules are configured on.
- This was traced to exactly the failure hit in the reporter's own #511 proof-of-concept ("Destination address required (errno = 89)"): a PF_INET/SOCK_RAW socket is connectionless, so `send()` needs a per-packet destination address via `sendto()`, not the plain `send()` PF_PACKET uses.
- `--raw` opens a PF_INET/SOCK_RAW/IPPROTO_RAW socket bound to the outbound interface (`SO_BINDTODEVICE`), strips the captured Ethernet header, pulls the destination address out of the IP header, and sends via `sendto()` — so the kernel's normal IP stack, including netfilter/iptables, processes each packet like any other locally-generated one.
- Trade-offs, documented in the flag's own `--help`/man-page text and docs/INSTALL: the kernel builds its own Ethernet framing (captured source/dest MAC are not reproduced), and only IPv4 is supported for now (IPv6 packets fail cleanly with a clear error rather than silently misbehaving). Linux-only, gated on `SO_BINDTODEVICE` availability in both `configure.ac` and `cmake/ConfigureChecks.cmake`, following the same runtime-selectable pattern as `--netmap`/`--xdp`/`--io-uring` (mutually exclusive with all three).

## Test plan
- [x] `cmake -B build && cmake --build build` and `./autogen.sh && ./configure && make` — both build clean, `HAVE_SOCK_RAW`/`PF_INET SOCK_RAW (--raw)` detected and shown in the configuration summary on both
- [x] `--raw` appears in `tcpreplay --help` and the generated man page
- [x] End-to-end functional test (not just compile): crafted a synthetic ICMP packet, added an nftables OUTPUT counter rule for its destination — default PF_PACKET sends "successfully" while the counter stays at 0 (reproducing the report), `--raw` increments it, confirming netfilter actually sees the traffic
- [x] Verified the IPv4-only guard rejects a synthetic IPv6 packet with a clear error instead of crashing or silently dropping it
- [x] Verified `--raw` combined with `--io-uring` fails with a clear mutual-exclusion error
- [x] Review by @fklassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)