### PR TITLE
docs: credit Dmitrii Sharshakov for the packet loss simulation PR

### DIFF
--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -169,3 +169,6 @@ plusky <GitHub @plusky>
 momo-trip <GitHub @momo-trip>
     - reported an out-of-bounds read in libopts' --save-opts handling triggered by strstr()
       running on a possibly-unmapped/non-terminated buffer (#931)
+
+Dmitrii Sharshakov <GitHub @dsseng>
+    - tcpreplay: random packet loss simulation (#755, #1055)


### PR DESCRIPTION
## Summary
- Adds a docs/CREDIT entry for @dsseng's packet-loss-simulation contribution (#755, tracked in #1055).

🤖 Generated with [Claude Code](https://claude.com/claude-code)