### PR TITLE
tcpreplay: rework --drop into --loss per review (#755, #1055)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,8 @@
 07/21/2026 Version 4.6.0-beta1
+    - tcpreplay: add --loss, random percent packet loss simulation (#755, #1055; contributed by
+      @dsseng) - each packet is independently dropped with the given 0-100 probability, useful for
+      testing/debugging UDP-based software (e.g. realtime audio streaming) against non-ideal
+      network conditions; final scale/naming and --help wording per maintainer review
     - tcpreplay: add --raw, a PF_INET/SOCK_RAW packet-injection backend (#465, originally attempted
       in #511) - lets replayed traffic pass through the local IP stack (routing,
       netfilter/iptables) instead of going straight onto the wire via PF_PACKET; trades off L2

--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -171,4 +171,4 @@ momo-trip <GitHub @momo-trip>
       running on a possibly-unmapped/non-terminated buffer (#931)
 
 Dmitrii Sharshakov <GitHub @dsseng>
-    - tcpreplay: random packet loss simulation (#755, #1055)
+    - tcpreplay: random packet loss simulation (#755, #1055, #1058)

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -592,8 +592,8 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
             send_len -= l2len;
         }
 
-        /* write packet out on network, skipping it in random cases when asked for drop */
-        if ((options->drop == 1.0f || rand() > options->drop * RAND_MAX) &&
+        /* write packet out on network, randomly skipping it to simulate --loss */
+        if ((options->loss <= 0.0f || rand() > (options->loss / 100.0f) * RAND_MAX) &&
             sendpacket(sp, send_data, send_len, &pkthdr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
             continue;
@@ -875,8 +875,8 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
             send_len -= l2len;
         }
 
-        /* write packet out on network, skipping it in random cases when asked for drop */
-        if ((options->drop == 1.0f || rand() > options->drop * RAND_MAX) &&
+        /* write packet out on network, randomly skipping it to simulate --loss */
+        if ((options->loss <= 0.0f || rand() > (options->loss / 100.0f) * RAND_MAX) &&
             sendpacket(sp, send_data, send_len, pkthdr_ptr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
             continue;

--- a/src/tcpreplay.c
+++ b/src/tcpreplay.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #ifdef HAVE_FTS_H
 #include <fts.h>
 #endif
@@ -62,8 +61,6 @@ main(int argc, char *argv[])
     int rcode;
 
     fflush(NULL);
-
-    srand(time(NULL));
 
     ctx = tcpreplay_init();
     optct = optionProcess(&tcpreplayOptions, argc, argv);

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -204,10 +204,15 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
         options->speed.multiplier = atof(OPT_ARG(MULTIPLIER));
     }
 
-    if (HAVE_OPT(DROP)) {
-        options->drop = atof(OPT_ARG(DROP));
+    if (HAVE_OPT(LOSS)) {
+        options->loss = atof(OPT_ARG(LOSS));
+        if (options->loss < 0.0f || options->loss > 100.0f) {
+            tcpreplay_seterr(ctx, "invalid --loss value '%s': must be between 0 and 100", OPT_ARG(LOSS));
+            ret = -1;
+            goto out;
+        }
     } else {
-        options->drop = 1.0f;
+        options->loss = 0.0f;
     }
 
     if (HAVE_OPT(MAXSLEEP)) {

--- a/src/tcpreplay_api.h
+++ b/src/tcpreplay_api.h
@@ -105,7 +105,7 @@ typedef struct tcpreplay_opt_s {
     COUNTER loop;
     u_int32_t loopdelay_ms;
     u_int32_t loopdelay_ns;
-    float drop;
+    float loss; /* percent packet loss to simulate, 0-100; 0 (default) means disabled */
 
     int stats;
     bool use_pkthdr_len;

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -570,16 +570,23 @@ thus allowing for longer sleep times which can be more accurately implemented.
 EOText;
 };
 
+/* note that this is really a float, but autoopts does not support float */
 flag = {
-    name        = drop;
+    name        = loss;
     arg-type    = string;
     max         = 1;
-    descrip     = "Simluate random packet loss";
+    descrip     = "Simulate random percent packet loss (0-100)";
     doc         = <<- EOText
-Set to a value between 0 and 1 to simulate packet loss at send.
+Set to a percentage between 0 and 100 to simulate packet loss at send.
+Loss is random: each packet is independently dropped with the given
+probability, not on a fixed pattern (e.g. not every Nth packet), so the
+actual number dropped will vary slightly run to run. Dropped packets
+are not sent and are not counted as failed.
+
 Examples:
 @example
-    0.25 will drop around one quarter of packets (they will not be sent)
+    25 will drop approximately one quarter of packets, chosen at random
+    100 will drop every packet (nothing will be sent)
 @end example
 EOText;
 };


### PR DESCRIPTION
## Summary
Follow-up to #755 (merged), addressing the review feedback that wasn't applied to keep the original contribution's history intact:

- Drop the `srand(time(NULL))` seeding in `main()` — not needed.
- Switch from a 0.0-1.0 fraction (`--drop`) to a 0-100 percentage (`--loss`), matching how packet loss is normally expressed. Out-of-range values (`--loss=150`) now error out with a clear message instead of silently misbehaving.
- Update `--help`/man page text to state explicitly that the loss is random (independent per-packet probability, not a fixed pattern like every Nth packet).

Also fixes the sentinel bug flagged in the original review: `options->drop == 1.0f` was used as the "flag not passed" sentinel (skip the random check, always send), which collided with `1.0` as a genuine "drop everything" value. The new scale has no such collision — unset defaults to `0.0` (0% loss = always send, which is correct anyway), and `100` naturally always drops since `rand()`'s range `[0, RAND_MAX]` never exceeds `RAND_MAX`.

Tracked in #1055.

## Test plan
- [x] `cmake -B build && cmake --build build` and autotools `./autogen.sh && ./configure && make` — both build clean
- [x] `--loss` appears in `tcpreplay --help` and the generated man page (both `tcpreplay` and `tcpreplay-edit`), explicitly stating the loss is random
- [x] Functional: `--loss=25` drops ~25% (2670/3580 sent over 20 loops), `--loss=100` drops everything (0/895 sent, confirming no sentinel collision), `--loss=0` sends everything (895/895, same as no `--loss` at all), `--loss=150` rejected with a clear error
- [x] Review by @fklassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)