### PR TITLE
common: pthread_attr leak and explicit ring teardown in txring (#1061)

### DIFF
--- a/docs/CREDIT
+++ b/docs/CREDIT
@@ -172,3 +172,7 @@ momo-trip <GitHub @momo-trip>
 
 Dmitrii Sharshakov <GitHub @dsseng>
     - tcpreplay: random packet loss simulation (#755, #1055, #1058)
+
+Solaris-star <GitHub @Solaris-star>
+    - common: found a pthread_attr leak and suggested explicit PACKET_TX_RING
+      teardown in txring (#1061, #1063)

--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -208,16 +208,16 @@ txring_init(int fd, unsigned int mtu)
     /* Set PACKET_LOSS sockoption */
     if (setsockopt(fd, SOL_PACKET, PACKET_LOSS, (char *)&mode_loss, sizeof(mode_loss)) < 0) {
         perror("setsockopt: PACKET_LOSS");
-        free(txp->treq);
-        free(txp);
+        safe_free(txp->treq);
+        safe_free(txp);
         return NULL;
     }
 
     /* Enable TX Ring */
     if (setsockopt(fd, SOL_PACKET, PACKET_TX_RING, (char *)txp->treq, sizeof(struct tpacket_req)) < 0) {
         perror("Can't setsockopt PACKET_TX_RING");
-        free(txp->treq);
-        free(txp);
+        safe_free(txp->treq);
+        safe_free(txp);
         return NULL;
     }
 
@@ -225,8 +225,8 @@ txring_init(int fd, unsigned int mtu)
     txp->tx_head = mmap(0, txp->tx_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (txp->tx_head == MAP_FAILED) {
         perror("mmap() failed ");
-        free(txp->treq);
-        free(txp);
+        safe_free(txp->treq);
+        safe_free(txp);
         return NULL;
     }
 
@@ -241,27 +241,38 @@ txring_init(int fd, unsigned int mtu)
         abort();
     }
 
+    /* the attr object is only needed to seed the new thread; safe to
+     * release immediately once pthread_create() has returned (#1061) */
+    pthread_attr_destroy(&t_attr_send);
+
     return txp;
 }
 
 /**
- * \brief Tear down a TX ring: stop the poll thread, unmap the ring buffer,
- * and free the txring_t itself (#leak found under AddressSanitizer)
+ * \brief Tear down a TX ring: stop the poll thread, disable and unmap the
+ * ring buffer, and free the txring_t itself (#leak found under
+ * AddressSanitizer)
  */
 void
 txring_close(txring_t *txp)
 {
+    struct tpacket_req disable_req;
+
     if (!txp)
         return;
 
     txp->shutdown_flag = 1;
     pthread_join(txp->tx_send, NULL);
 
+    /* explicitly disable the ring before unmapping it (#1061) */
+    memset(&disable_req, 0, sizeof(disable_req));
+    setsockopt(txp->fd, SOL_PACKET, PACKET_TX_RING, (char *)&disable_req, sizeof(disable_req));
+
     if (txp->tx_head != NULL && txp->tx_head != MAP_FAILED)
         munmap((void *)txp->tx_head, txp->tx_size);
 
-    free(txp->treq);
-    free(txp);
+    safe_free(txp->treq);
+    safe_free(txp);
 }
 
 #endif /* HAVE_TX_RING */


### PR DESCRIPTION
## Summary
Follow-up to #1059/#1060, picking up two genuine improvements an independent parallel fix (#1061, by @Solaris-star) found on top of the already-merged resource-leak fix:

- `pthread_attr_init(&t_attr_send)` was never paired with `pthread_attr_destroy()` on the success path, leaking the attr object every time a TX_RING interface was opened. Safe to destroy immediately after `pthread_create()` returns — POSIX only requires the attr object be valid for the duration of that call, not the thread's lifetime.
- `txring_close()` now explicitly disables `PACKET_TX_RING` via `setsockopt` before unmapping the ring buffer, rather than relying solely on the fd's `close()` to tear it down implicitly.

Also switches the remaining raw `free()` calls in this file to `safe_free()`, matching this project's convention and #1061's own version.

#1061 itself isn't being merged as-is — it re-implements the same per-instance shutdown-flag fix #1060 already shipped, so merging it directly would just be conflicting, redundant churn over already-merged code. Cherry-picked the two genuinely new ideas here instead, credited to the original PR/author.

## Test plan
- [x] `./autogen.sh && ./configure --enable-asan && make` (out-of-tree) — clean, no errors
- [x] `sudo tcpreplay -Kt -i lo test.pcap` under ASan — still no leak reported
- [x] Dual-NIC run (`-i lo -I lo -c test.auto_bridge`) still closes both TX rings cleanly, no hang
- [x] Review by @fklassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)