### PR TITLE
def: fix unclosed @table blocks and bare @item lists in man page doc text

### DIFF
--- a/src/tcpedit/plugins/dlt_en10mb/en10mb_opts.def
+++ b/src/tcpedit/plugins/dlt_en10mb/en10mb_opts.def
@@ -104,6 +104,7 @@ VLAN tag.
 @item
 @var{del}
 Rewrites the existing 802.1q VLAN header as an 802.3 ethernet header
+@end table
 EOText;
 };
 
@@ -164,5 +165,6 @@ Specifies that 802.1q VLAN headers are to be added. This is the default.
 @var{802.1ad}
 Specifies that 802.1ad Q-in-Q VLAN headers are to be added. To make valid packets,
 input packets must already have 802.1q VLAN headers.
+@end table
 EOText;
 };

--- a/src/tcpedit/tcpedit_opts.def
+++ b/src/tcpedit/tcpedit_opts.def
@@ -292,6 +292,7 @@ the actual packet length
 @item
 @var{del}
 Delete the packet
+@end table
 EOText;
 };
 

--- a/src/tcprewrite_opts.def
+++ b/src/tcprewrite_opts.def
@@ -60,28 +60,41 @@ pcapng input produce a nanosecond resolution pcap output file, everything
 else produces the classic microsecond format (requires libpcap >= 1.5.1).
 
 tcprewrite currently supports reading the following DLT types:
+@table @bullet
 @item
-@var{DLT_C_HDLC} aka Cisco HDLC
+@var{DLT_C_HDLC}
+aka Cisco HDLC
 @item
-@var{DLT_EN10MB} aka Ethernet
+@var{DLT_EN10MB}
+aka Ethernet
 @item
-@var{DLT_LINUX_SLL} aka Linux Cooked Socket
+@var{DLT_LINUX_SLL}
+aka Linux Cooked Socket
 @item
-@var{DLT_LINUX_SLL2} aka Linux Cooked Socket v2
+@var{DLT_LINUX_SLL2}
+aka Linux Cooked Socket v2
 @item
-@var{DLT_RAW} aka RAW IP
+@var{DLT_RAW}
+aka RAW IP
 @item
-@var{DLT_NULL} aka BSD Loopback
+@var{DLT_NULL}
+aka BSD Loopback
 @item
-@var{DLT_LOOP} aka OpenBSD Loopback
+@var{DLT_LOOP}
+aka OpenBSD Loopback
 @item
-@var{DLT_IEEE802_11} aka 802.11a/b/g
+@var{DLT_IEEE802_11}
+aka 802.11a/b/g
 @item
-@var{DLT_IEEE802_11_RADIO} aka 802.11a/b/g with Radiotap headers
+@var{DLT_IEEE802_11_RADIO}
+aka 802.11a/b/g with Radiotap headers
 @item
-@var{DLT_JUNIPER_ETHER} aka Juniper Encapsulated Ethernet
+@var{DLT_JUNIPER_ETHER}
+aka Juniper Encapsulated Ethernet
 @item
-@var{DLT_PPP_SERIAL} aka PPP over Serial
+@var{DLT_PPP_SERIAL}
+aka PPP over Serial
+@end table
 
 Please see the --dlt option for supported DLT types for writing.
 


### PR DESCRIPTION
## Summary
Found while regenerating man pages to update appneta.github.io. Three option/description lists across two files rendered as garbled, unstructured text (or, before #1062, literal texinfo markup) instead of proper bulleted lists in the generated `.adoc`/`.1`/HTML output:

- `tcprewrite_opts.def`'s DESCRIPTION section DLT-type list used bare `@item` lines with no enclosing `@table` at all, so `scripts/autoopts/emit_adoc.py`'s `_ITEM_BLOCK_RE` (which requires an explicit `@table`/`@end table` or `@enumerate`/`@end enumerate` wrapper) never matched it — the whole block, texinfo markup included, fell through as plain prose.
- `tcpedit_opts.def`'s `--fixlen` (pad/trunc/del) option and `dlt_en10mb/en10mb_opts.def`'s `--enet-vlan` and `--enet-vlan-proto` options each opened a `@table @bullet` block that was never closed with `@end table`, so the same regex never matched these either.

Also reformats tcprewrite's DLT-type list entries from a single `"@var{NAME} description"` line per item to `@var{NAME}` alone followed by the description on the next line, matching the format `_render_items()` actually expects to split a term from its body (the single-line form silently became one long bolded label with an empty body instead).

## Test plan
- [x] `scripts/autoopts/check_adoc.py` — zero groff warnings, full option coverage for all 7 tools
- [x] Verified in both `groff`/`man` output and asciidoctor HTML5 output: the DLT-type list and the three affected options now render as proper bulleted/description lists instead of a single run-on paragraph
- [x] Review by @fklassen

🤖 Generated with [Claude Code](https://claude.com/claude-code)