### PR TITLE
ci(docs): auto-deploy the docs site to the live website

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,37 +1,43 @@
-# Build the full user guide (with rendered man pages) and publish it to this
-# repository's GitHub Pages. This is the unified MkDocs site that replaces the
-# Jekyll wiki.
+# Build the documentation site and publish it to the live website.
 #
-# It does NOT touch the live appneta.github.io site or claim the custom domain:
-# it publishes to this repo's own Pages URL (https://appneta.github.io/tcpreplay/)
-# as a reviewable preview. Cutover to tcpreplay.appneta.com is a manual, separate
-# step — see docs/guide/README.md.
+# The Markdown source lives here in docs/guide/; the rendered static site is
+# pushed to the appneta/appneta.github.io repository, which GitHub Pages serves
+# at https://tcpreplay.appneta.com/. This is the auto-deploy that keeps the
+# published site in step with the source.
 #
-# One-time setup: repository Settings → Pages → Source: "GitHub Actions".
+# Credential (one-time): this needs write access to appneta.github.io. It uses
+# an SSH deploy key:
+#   1. A deploy key (write) is added to appneta/appneta.github.io.
+#   2. Its private key is stored here as the PAGES_DEPLOY_KEY Actions secret.
+# See docs/guide/README.md for the exact setup, and to rotate it.
+#
+# The Jekyll site this replaced is archived on the appneta.github.io
+# `jekyll-legacy` branch; this workflow only ever writes the `master` branch
+# there, so the archive is never touched.
 name: docs-deploy
 
 on:
-  # Manual trigger for previews.
   workflow_dispatch:
-  # Publish automatically once the docs land on master.
   push:
-    branches: [master]
+    # The website tracks whichever branch currently carries the docs. Today
+    # that is the active 4.6 line; master joins once the docs merge there. The
+    # path filter means only real docs changes publish.
+    branches: [master, 4.6.0-beta3]
     paths:
       - "docs/**"
       - "src/**_opts.def"
       - ".github/workflows/docs-deploy.yml"
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
+# Serialize deploys so two pushes can't race on the target repo.
 concurrency:
   group: docs-deploy
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,11 +52,11 @@ jobs:
           sudo apt-get install -y libpcap-dev asciidoctor
           pip install -r docs/guide/requirements.txt
 
-      - name: Generate man-page AsciiDoc from a configured tree
-        # The man-page hook (docs/hooks.py) renders these seven src/*.adoc files.
-        # Build them explicitly: the target names don't all map cleanly from the
-        # *_opts.def names — notably tcpreplay-edit.adoc comes from
-        # tcpreplay_opts.def with a TCPREPLAY_EDIT flag, so a glob misses it.
+      - name: Generate man-page AsciiDoc
+        # docs/hooks.py renders these seven src/*.adoc into the site. Regenerate
+        # them from the *_opts.def sources so the published man pages match this
+        # revision. (tcpreplay-edit.adoc comes from tcpreplay_opts.def with a
+        # TCPREPLAY_EDIT flag, so it's listed explicitly rather than globbed.)
         run: |
           ./autogen.sh
           ./configure
@@ -62,16 +68,15 @@ jobs:
         working-directory: docs
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@v3
+      - name: Publish to appneta.github.io (serves tcpreplay.appneta.com)
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: docs/site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}
+          external_repository: appneta/appneta.github.io
+          publish_branch: master
+          publish_dir: ./docs/site
+          cname: tcpreplay.appneta.com
+          force_orphan: true
+          user_name: "tcpreplay-docs-bot"
+          user_email: "noreply@github.com"
+          full_commit_message: "Publish docs (tcpreplay@${{ github.sha }})"

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -75,25 +75,40 @@ build.
 working after the Jekyll site is retired. The map lives in `hooks.py`
 (`REDIRECTS`).
 
-## Publishing and cutover
+## Publishing
 
 Two workflows drive this:
 
 - **`.github/workflows/docs.yml`** builds the guide with `--strict` on every docs
-  change, so a dead link or bad config fails CI.
+  change, so a dead link or bad config fails CI (no C toolchain needed; man
+  pages fall back to placeholders).
 - **`.github/workflows/docs-deploy.yml`** builds the full site (with rendered man
-  pages) and publishes it to this repository's **GitHub Pages** — a reviewable
-  preview at `https://appneta.github.io/tcpreplay/` that does **not** touch the
-  live site or claim the `tcpreplay.appneta.com` domain.
+  pages) and **publishes it to the live website**. It pushes the static build to
+  the `appneta/appneta.github.io` repo's `master` branch, which GitHub Pages
+  serves at `https://tcpreplay.appneta.com/`. Triggered by docs changes on the
+  branch that carries them, plus manual `workflow_dispatch`.
 
-**Cutover to production** (retiring the Jekyll site) is a deliberate, manual step:
+So editing a page here and merging it updates the live site automatically —
+source and site never drift.
 
-1. Review the preview build.
-2. Enable Pages on this repo (Settings → Pages → Source: *GitHub Actions*) if not
-   already, and let `docs-deploy` publish.
-3. Move the `tcpreplay.appneta.com` custom domain from the `appneta.github.io`
-   repo to this repo's Pages (add the `CNAME`, update DNS as needed).
-4. Archive the old `appneta.github.io` Jekyll content.
+### Deploy credential
 
-Keeping the domain move as the final manual step means nothing about the live
-site changes until you decide to flip it.
+`docs-deploy` needs write access to `appneta.github.io`. It uses an SSH deploy
+key, not a personal token, so the credential is scoped to exactly that one repo:
+
+- The **public** key is registered as a write **deploy key** on
+  `appneta/appneta.github.io`.
+- The **private** key is stored as the `PAGES_DEPLOY_KEY` Actions secret in this
+  (`appneta/tcpreplay`) repo.
+
+To rotate it: generate a new keypair
+(`ssh-keygen -t ed25519 -C tcpreplay-docs-deploy -f key`), replace the deploy key
+on `appneta.github.io` with the new `key.pub`, and update the `PAGES_DEPLOY_KEY`
+secret with the new private key (`gh secret set PAGES_DEPLOY_KEY < key`).
+
+### Rollback / history
+
+`docs-deploy` only ever writes `appneta.github.io`'s `master` branch, as a clean
+single-commit publish (`force_orphan`). The original Jekyll site is preserved on
+that repo's **`jekyll-legacy`** branch — restore it with
+`git reset --hard jekyll-legacy && git push --force origin master` if ever needed.


### PR DESCRIPTION
Wires up automatic publishing so editing a docs page and merging updates the live site — no manual copy.

## What it does

`docs-deploy.yml` (reworked from the preview version) builds the full MkDocs site — including the rendered man pages — and pushes the static output to **`appneta/appneta.github.io`'s `master` branch**, which GitHub Pages serves at **https://tcpreplay.appneta.com/**. It keeps the `CNAME` and adds `.nojekyll` (via `peaceiris/actions-gh-pages`).

Triggers: docs changes on the branch that carries them (`master` + the active `4.6.0-beta3` line, filtered to `docs/**` etc.) plus manual `workflow_dispatch`.

## Credential — already set up

Auth is a **repo-scoped SSH deploy key**, not a personal token:
- Public key → **write deploy key** on `appneta/appneta.github.io`.
- Private key → **`PAGES_DEPLOY_KEY`** Actions secret in this repo.

Both are already installed, so this activates on merge. Rotation instructions are in `docs/guide/README.md`.

## Safety

- The workflow **only writes `appneta.github.io`'s `master`** — as a clean single-commit publish (`force_orphan`).
- The retired Jekyll site is preserved on that repo's **`jekyll-legacy`** branch; rollback is `git reset --hard jekyll-legacy && git push --force origin master`.
- `docs.yml` stays as the light `--strict` PR check.

## Note on activation

The deploy runs on the next docs push to a trigger branch after this merges (or a manual `workflow_dispatch`). It assumes the one-time go-live has put the MkDocs site on `appneta.github.io` master; after that, this keeps it current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2Rdq79uuiVVq9G9GyuvDw