### PR TITLE
docs: add tcpreplay-edit as a first-class tool page

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -86,6 +86,7 @@ against realistic, repeatable traffic.
 | Tool | One-liner |
 | --- | --- |
 | [`tcpreplay`](tools/tcpreplay.md) | Replay pcap files onto the network at arbitrary speeds. |
+| [`tcpreplay-edit`](tools/tcpreplay-edit.md) | Replay while rewriting headers in one pass (`tcpreplay` + `tcprewrite`). |
 | [`tcprewrite`](tools/tcprewrite.md) | Rewrite Layer 2–4 headers in a pcap (front end to `libtcpedit`). |
 | [`tcpprep`](tools/tcpprep.md) | Pre-process a pcap into a cache file, classifying packets as client/server. |
 | [`tcpbridge`](tools/tcpbridge.md) | Bridge two network segments, applying `tcprewrite` logic in flight. |

--- a/docs/guide/tools/index.md
+++ b/docs/guide/tools/index.md
@@ -17,6 +17,13 @@ does one job well; you compose them into a workflow.
     Replay pcap files onto the network at arbitrary speeds — original timing,
     a fixed rate, or line rate.
 
+-   :material-play-box-edit: **[tcpreplay-edit](tcpreplay-edit.md)**
+
+    ---
+
+    `tcpreplay` with `tcprewrite`'s editing folded in — rewrite headers and
+    replay in a single pass.
+
 -   :material-file-replace: **[tcprewrite](tcprewrite.md)**
 
     ---
@@ -85,11 +92,12 @@ full story.
 
 ## `tcpreplay` and `tcpreplay-edit`
 
-When the suite is built with editing support, `tcpreplay-edit` is produced
-alongside `tcpreplay`. It is `tcpreplay` **plus** every rewriting option from
-`tcprewrite`, so you can edit and replay in a single pass without an
+When the suite is built with editing support, [`tcpreplay-edit`](tcpreplay-edit.md)
+is produced alongside `tcpreplay`. It is `tcpreplay` **plus** every rewriting
+option from `tcprewrite`, so you can edit and replay in a single pass without an
 intermediate file. Plain `tcpreplay` omits the editing engine and is the lean
-choice when you only need to send an unmodified capture.
+choice when you only need to send an unmodified capture. See its
+[own page](tcpreplay-edit.md) for details.
 
 ## Full option reference
 

--- a/docs/guide/tools/tcpreplay-edit.md
+++ b/docs/guide/tools/tcpreplay-edit.md
@@ -1,0 +1,67 @@
+---
+title: tcpreplay-edit
+description: Replay pcap files while rewriting their headers in a single pass.
+---
+
+# tcpreplay-edit
+
+**Replays pcap files onto the network *and* rewrites their headers in a single
+pass.** It is [`tcpreplay`](tcpreplay.md) with the entire
+[`tcprewrite`](tcprewrite.md) editing engine folded in — every replay option
+*plus* every rewrite option — so you can retarget a capture and send it without
+an intermediate file.
+
+```
+tcpreplay-edit [OPTION]... <pcap_file(s)> | <pcap_dir(s)>
+```
+
+!!! danger "Sends live traffic — needs root"
+    Like `tcpreplay`, this injects real packets and requires root. Never point it
+    at a production network or the interface you're connected through.
+
+## When to use it
+
+| Use… | …when |
+| --- | --- |
+| **tcpreplay-edit** | you want to edit packets *on the way out* — rewrite MACs/IPs/ports, change VLANs or DLT, fix checksums — as part of the replay. |
+| **[tcpreplay](tcpreplay.md)** | the capture is already correct for your target; it's the leaner, edit-free engine. |
+| **[tcprewrite](tcprewrite.md)** | you only want to produce an edited pcap file and not send anything. |
+
+!!! note "Present when built with editing support"
+    `tcpreplay-edit` is produced alongside `tcpreplay` whenever the suite is
+    built with the tcpedit engine — the case in a normal build.
+
+## Basic use
+
+Rewrite and replay in one command — no separate `tcprewrite` step:
+
+```console
+$ sudo tcpreplay-edit -i eth0 \
+    --enet-dmac=00:11:22:33:44:55 \
+    --pnat=10.0.0.0/8:192.168.0.0/16 \
+    --fixcsum sample.pcap
+```
+
+That sets the destination MAC, remaps the `10.0.0.0/8` network onto
+`192.168.0.0/16`, fixes the checksums, and sends.
+
+## Options
+
+`tcpreplay-edit` accepts the union of two option sets:
+
+- **every [`tcpreplay`](tcpreplay.md) option** — interface, speed control,
+  looping, the fast-path backends, two-NIC in-line testing; and
+- **every [`tcprewrite`](tcprewrite.md) editing option** — address, port, VLAN
+  and DLT rewriting, checksum fixing, and the rest.
+
+Rather than duplicate them here, see those two pages for what each does — and the
+[`tcpreplay-edit` man page](../reference/man/tcpreplay-edit.md) for the complete,
+combined list.
+
+## See also
+
+- [tcpreplay](tcpreplay.md) — replay without editing.
+- [tcprewrite](tcprewrite.md) — edit a capture into a file.
+- [Rewriting packet headers](../guides/rewriting-headers.md) — the edits you can
+  apply on the way out.
+- [`tcpreplay-edit` man page](../reference/man/tcpreplay-edit.md) — every option.

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -79,7 +79,7 @@ def on_pre_build(config, **kwargs) -> None:
         if html is not None:
             page += intro.format(tool=tool) + html + "\n"
         else:
-            tool_page = "index.md" if tool == "tcpreplay-edit" else f"{tool}.md"
+            tool_page = f"{tool}.md"
             page += placeholder.format(tool=tool, tool_page=tool_page)
         (out_dir / f"{tool}.md").write_text(page)
 
@@ -113,7 +113,7 @@ REDIRECTS = {
     "wiki/tcpbridge.html": "tools/tcpbridge.md",
     "wiki/tcpliveplay.html": "tools/tcpliveplay.md",
     "wiki/tcpcapinfo.html": "tools/tcpcapinfo.md",
-    "wiki/tcpreplay-edit.html": "tools/index.md",
+    "wiki/tcpreplay-edit.html": "tools/tcpreplay-edit.md",
     "wiki/using-libtcpreplay.html": "developers/libtcpreplay.md",
     "wiki/using-libtcpedit.html": "developers/libtcpedit.md",
     "wiki/dlt-plugin-developer-guide.html": "developers/writing-dlt-plugins.md",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
   - Tools:
       - tools/index.md
       - tcpreplay: tools/tcpreplay.md
+      - tcpreplay-edit: tools/tcpreplay-edit.md
       - tcprewrite: tools/tcprewrite.md
       - tcpprep: tools/tcpprep.md
       - tcpbridge: tools/tcpbridge.md


### PR DESCRIPTION
`tcpreplay-edit` is a distinct installed binary (tcpreplay + tcprewrite's editing engine), and its man page was already hosted, but it wasn't represented in the **Tools** section — only mentioned in a note on the tcpreplay page. This adds it as a first-class tool.

- New `tools/tcpreplay-edit.md` — what it is, when to use it vs. `tcpreplay`/`tcprewrite`, basic use, and a pointer to the combined option set rather than duplicating it.
- Card in the Tools index, row in the home-page suite table, and a Tools nav entry (right after `tcpreplay`).
- Its legacy `/wiki/tcpreplay-edit.html` redirect now points at the new page instead of the Tools index.

Builds clean under `mkdocs build --strict`. Merging republishes the live site via the auto-deploy.