### PR TITLE
xdp: detect the driver's XDP mode, and stop hanging when TX stalls (#1080)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,14 @@
 07/24/2026 Version 4.6.0-beta3
+    - xdp: pick the AF_XDP attach mode from what the driver supports instead of assuming native
+      (#1080) - create_xsk_socket() never set xdp_flags, so --xdp only ever worked on adapters
+      with native XDP and simply failed on e1000, e1000e and friends; it now falls back to
+      generic/SKB mode, rebuilding the umem because a failed bind leaves the old one attached
+    - xdp: bound the two TX loops that retried forever with no timeout and no abort check, so a
+      driver that binds an AF_XDP socket but never transmits is reported rather than wedging
+      tcpreplay in an unkillable 100% CPU spin; kick_tx() also called exit(0) - success - on a
+      fatal send error, hiding it from scripts and CI
+    - xdp: route libbpf/libxdp logging through dbg() instead of letting it print over the replay,
+      keeping the last warning so a non-debug build still says why AF_XDP could not be set up
     - configure: require both halves before enabling libxdp/libbpf - AC_CHECK_LIB's default
       action defined HAVE_LIBXDP/HAVE_LIBBPF off a bare link test, but both gate #includes in
       defines.h, so a system with the shared library and no headers compiled --xdp in and then

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -1905,10 +1905,10 @@ sendpacket_is_raw_ip(sendpacket_t *sp)
  * users who need it - which is how "XDP mode not supported" ended up being
  * printed straight at people in the first place.
  */
-/* NOLINTNEXTLINE - must be file scope and mutable: neither libbpf_set_print()
- * nor libxdp_set_print() hands the callback a user-data pointer, so there is
- * nowhere else to keep this */
-static char sendpacket_xdp_last_error[SENDPACKET_ERRBUF_SIZE];
+/* Must be file scope and mutable: neither libbpf_set_print() nor
+ * libxdp_set_print() hands the callback a user-data pointer, so there is
+ * nowhere else to keep this. */
+static char sendpacket_xdp_last_error[SENDPACKET_ERRBUF_SIZE]; /* NOLINT */
 
 typedef enum { XDP_LOG_LIBBPF, XDP_LOG_LIBXDP } xdp_log_source_t;
 

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -1905,11 +1905,17 @@ sendpacket_is_raw_ip(sendpacket_t *sp)
  * users who need it - which is how "XDP mode not supported" ended up being
  * printed straight at people in the first place.
  */
+/* NOLINTNEXTLINE - must be file scope and mutable: neither libbpf_set_print()
+ * nor libxdp_set_print() hands the callback a user-data pointer, so there is
+ * nowhere else to keep this */
 static char sendpacket_xdp_last_error[SENDPACKET_ERRBUF_SIZE];
 
+typedef enum { XDP_LOG_LIBBPF, XDP_LOG_LIBXDP } xdp_log_source_t;
+
 static void
-sendpacket_xdp_record(const char *lib, const char *format, va_list args)
+sendpacket_xdp_record(xdp_log_source_t source, const char *format, va_list args)
 {
+    const char *lib = (source == XDP_LOG_LIBXDP) ? "libxdp" : "libbpf";
     char msg[SENDPACKET_ERRBUF_SIZE];
 
     vsnprintf(msg, sizeof(msg), format, args);
@@ -1924,7 +1930,11 @@ sendpacket_xdp_record(const char *lib, const char *format, va_list args)
     if (strncmp(msg, lib, strlen(lib)) == 0) {
         strlcpy(sendpacket_xdp_last_error, msg, sizeof(sendpacket_xdp_last_error));
     } else {
-        snprintf(sendpacket_xdp_last_error, sizeof(sendpacket_xdp_last_error), "%s: %s", lib, msg);
+        /* strl* rather than one snprintf("%s: %s"): both buffers are
+         * SENDPACKET_ERRBUF_SIZE, which -Wformat-truncation rightly objects to */
+        strlcpy(sendpacket_xdp_last_error, lib, sizeof(sendpacket_xdp_last_error));
+        strlcat(sendpacket_xdp_last_error, ": ", sizeof(sendpacket_xdp_last_error));
+        strlcat(sendpacket_xdp_last_error, msg, sizeof(sendpacket_xdp_last_error));
     }
 
     dbgx(1, "%s", sendpacket_xdp_last_error);
@@ -1934,7 +1944,7 @@ static int
 sendpacket_libbpf_print(enum libbpf_print_level level, const char *format, va_list args)
 {
     if (level == LIBBPF_WARN) {
-        sendpacket_xdp_record("libbpf", format, args);
+        sendpacket_xdp_record(XDP_LOG_LIBBPF, format, args);
     }
 
     return 0;
@@ -1948,7 +1958,7 @@ static int
 sendpacket_libxdp_print(enum libxdp_print_level level, const char *format, va_list args)
 {
     if (level == LIBXDP_WARN) {
-        sendpacket_xdp_record("libxdp", format, args);
+        sendpacket_xdp_record(XDP_LOG_LIBXDP, format, args);
     }
 
     return 0;
@@ -1996,7 +2006,7 @@ sendpacket_open_xsk(const char *device, char *errbuf)
     u_int32_t queue_id = 0;
     struct xsk_umem_info *umem_info = NULL;
     struct xsk_socket_info *xsk_info = NULL;
-    unsigned int i;
+    unsigned int mode_idx = 0;
 
     /*
      * AF_XDP runs either in the driver (native) or in the generic/SKB path.
@@ -2016,7 +2026,7 @@ sendpacket_open_xsk(const char *device, char *errbuf)
         const char *name;
     } xdp_modes[] = {{XDP_FLAGS_DRV_MODE, "native"}, {XDP_FLAGS_SKB_MODE, "generic (SKB)"}};
 
-    for (i = 0; i < sizeof(xdp_modes) / sizeof(xdp_modes[0]); i++) {
+    for (mode_idx = 0; mode_idx < sizeof(xdp_modes) / sizeof(xdp_modes[0]); mode_idx++) {
         umem_info = create_umem_area(nb_of_frames, frame_size, nb_of_completion_queue_desc, nb_of_fill_queue_desc);
         if (umem_info == NULL) {
             snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "unable to create the AF_XDP UMEM area for %s", device);
@@ -2028,11 +2038,11 @@ sendpacket_open_xsk(const char *device, char *errbuf)
                                      nb_of_rx_queue_desc,
                                      device,
                                      queue_id,
-                                     xdp_modes[i].flags,
+                                     xdp_modes[mode_idx].flags,
                                      errbuf);
         if (xsk_info != NULL) {
-            dbgx(1, "sendpacket: AF_XDP socket on %s bound in %s mode", device, xdp_modes[i].name);
-            if (xdp_modes[i].flags == XDP_FLAGS_SKB_MODE) {
+            dbgx(1, "sendpacket: AF_XDP socket on %s bound in %s mode", device, xdp_modes[mode_idx].name);
+            if (xdp_modes[mode_idx].flags == XDP_FLAGS_SKB_MODE) {
                 notice("%s has no native XDP support - using generic (SKB) mode, which is slower "
                        "than a driver that implements XDP (ixgbe, i40e, ice, mlx5, virtio_net, veth, ...).",
                        device);
@@ -2040,7 +2050,7 @@ sendpacket_open_xsk(const char *device, char *errbuf)
             break;
         }
 
-        dbgx(1, "sendpacket: AF_XDP %s mode unavailable on %s: %s", xdp_modes[i].name, device, errbuf);
+        dbgx(1, "sendpacket: AF_XDP %s mode unavailable on %s: %s", xdp_modes[mode_idx].name, device, errbuf);
         xsk_umem__delete(umem_info->umem);
         safe_free(umem_info->buffer);
         safe_free(umem_info);
@@ -2048,14 +2058,21 @@ sendpacket_open_xsk(const char *device, char *errbuf)
     }
 
     if (xsk_info == NULL) {
+        /* built with strl* rather than one snprintf: the recorded libxdp
+         * message is itself SENDPACKET_ERRBUF_SIZE, which -Wformat-truncation
+         * rightly objects to being formatted into a buffer of the same size */
         snprintf(errbuf,
                  SENDPACKET_ERRBUF_SIZE,
-                 "unable to set up an AF_XDP socket on %s in either native or generic mode%s%s. "
-                 "This adapter cannot be driven with --xdp; replay without it to use the default "
-                 "injection method.",
-                 device,
-                 sendpacket_xdp_last_error[0] != '\0' ? " - " : "",
-                 sendpacket_xdp_last_error);
+                 "unable to set up an AF_XDP socket on %s in either native or generic mode",
+                 device);
+        if (sendpacket_xdp_last_error[0] != '\0') {
+            strlcat(errbuf, " - ", SENDPACKET_ERRBUF_SIZE);
+            strlcat(errbuf, sendpacket_xdp_last_error, SENDPACKET_ERRBUF_SIZE);
+        }
+        strlcat(errbuf,
+                ". This adapter cannot be driven with --xdp; replay without it to use the "
+                "default injection method.",
+                SENDPACKET_ERRBUF_SIZE);
         return NULL;
     }
 

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -288,7 +288,6 @@ static int sendpacket_send_io_uring(sendpacket_t *, const u_char *, size_t);
 #define INJECT_METHOD "io_uring send()"
 #endif
 static sendpacket_t *sendpacket_open_pcap_dump(const char *, char *) _U_;
-static void sendpacket_seterr(sendpacket_t *sp, const char *fmt, ...);
 static sendpacket_t *sendpacket_open_khial(const char *, char *) _U_;
 static struct tcpr_ether_addr *sendpacket_get_hwaddr_khial(sendpacket_t *) _U_;
 
@@ -599,16 +598,26 @@ TRY_SEND_AGAIN:
         break;
     case SP_TYPE_LIBXDP:
 #ifdef HAVE_LIBXDP
+    {
+        struct timeval last_progress;
+
         retcode = len;
         xsk_ring_prod__submit(&(sp->xsk_info->tx), sp->pckt_count); // submit all packets at once
         sp->xsk_info->ring_stats.tx_npkts += sp->pckt_count;
         sp->xsk_info->outstanding_tx += sp->pckt_count;
+
+        /* drain the batch, but don't spin here forever if it never completes */
+        gettimeofday(&last_progress, NULL);
         while (sp->xsk_info->outstanding_tx != 0) {
-            complete_tx_only(sp);
+            if (xsk_wait_for_tx_progress(sp, &last_progress) < 0) {
+                sp->failed += sp->pckt_count;
+                return -1;
+            }
         }
         sp->sent += sp->pckt_count;
+    }
 #endif
-        break;
+    break;
     case SP_TYPE_IO_URING:
 #ifdef HAVE_LIBURING
         retcode = sendpacket_send_io_uring(sp, data, len);
@@ -1074,7 +1083,7 @@ sendpacket_geterr(sendpacket_t *sp)
 /**
  * Set's the error string
  */
-static void
+void
 sendpacket_seterr(sendpacket_t *sp, const char *fmt, ...)
 {
     va_list ap;
@@ -1882,6 +1891,69 @@ sendpacket_is_raw_ip(sendpacket_t *sp)
     return sp->raw_ip;
 }
 #ifdef HAVE_LIBXDP
+/**
+ * Send libbpf's and libxdp's own logging through our debug output instead of
+ * letting it go straight to stderr.  Without this, opening an AF_XDP socket on
+ * a driver without native XDP prints a wall of ELF-section and verifier
+ * chatter over the top of the replay (#1080).  The detail is genuinely useful
+ * when diagnosing an XDP problem, so it is kept at -v rather than discarded.
+ */
+/*
+ * The most recent warning either library emitted.  dbg() output is compiled
+ * out unless the build is --enable-debug, so without keeping this the real
+ * reason an AF_XDP socket could not be set up would be unavailable to the very
+ * users who need it - which is how "XDP mode not supported" ended up being
+ * printed straight at people in the first place.
+ */
+static char sendpacket_xdp_last_error[SENDPACKET_ERRBUF_SIZE];
+
+static void
+sendpacket_xdp_record(const char *lib, const char *format, va_list args)
+{
+    char msg[SENDPACKET_ERRBUF_SIZE];
+
+    vsnprintf(msg, sizeof(msg), format, args);
+
+    /* both libraries newline-terminate; dbgx()/warnx() add their own */
+    msg[strcspn(msg, "\n")] = '\0';
+    if (msg[0] == '\0') {
+        return;
+    }
+
+    /* libbpf already prefixes its own messages; don't say it twice */
+    if (strncmp(msg, lib, strlen(lib)) == 0) {
+        strlcpy(sendpacket_xdp_last_error, msg, sizeof(sendpacket_xdp_last_error));
+    } else {
+        snprintf(sendpacket_xdp_last_error, sizeof(sendpacket_xdp_last_error), "%s: %s", lib, msg);
+    }
+
+    dbgx(1, "%s", sendpacket_xdp_last_error);
+}
+
+static int
+sendpacket_libbpf_print(enum libbpf_print_level level, const char *format, va_list args)
+{
+    if (level == LIBBPF_WARN) {
+        sendpacket_xdp_record("libbpf", format, args);
+    }
+
+    return 0;
+}
+
+/**
+ * libxdp keeps its own logger, separate from libbpf's, so both have to be
+ * redirected or half the noise still lands on stderr.
+ */
+static int
+sendpacket_libxdp_print(enum libxdp_print_level level, const char *format, va_list args)
+{
+    if (level == LIBXDP_WARN) {
+        sendpacket_xdp_record("libxdp", format, args);
+    }
+
+    return 0;
+}
+
 static struct xsk_socket_info *
 xsk_configure_socket(struct xsk_umem_info *umem, struct xsk_socket_config *cfg, int queue_id, const char *device)
 {
@@ -1893,6 +1965,8 @@ xsk_configure_socket(struct xsk_umem_info *umem, struct xsk_socket_config *cfg, 
     xsk->umem = umem;
     ret = xsk_socket__create(&xsk->xsk, device, queue_id, umem->umem, rxr, &xsk->tx, cfg);
     if (ret) {
+        safe_free(xsk);
+        errno = -ret;
         return NULL;
     }
 
@@ -1909,24 +1983,79 @@ sendpacket_open_xsk(const char *device, char *errbuf)
     assert(device);
     assert(errbuf);
 
+    /* before anything can log: keep libbpf/libxdp chatter out of the replay output */
+    libbpf_set_print(sendpacket_libbpf_print);
+    libxdp_set_print(sendpacket_libxdp_print);
+
     int nb_of_frames = 4096;
     int frame_size = 4096;
     int nb_of_completion_queue_desc = 4096;
     int nb_of_fill_queue_desc = 4096;
-    struct xsk_umem_info *umem_info =
-            create_umem_area(nb_of_frames, frame_size, nb_of_completion_queue_desc, nb_of_fill_queue_desc);
-    if (umem_info == NULL) {
-        return NULL;
-    }
-
     int nb_of_tx_queue_desc = 4096;
     int nb_of_rx_queue_desc = 4096;
     u_int32_t queue_id = 0;
-    struct xsk_socket_info *xsk_info =
-            create_xsk_socket(umem_info, nb_of_tx_queue_desc, nb_of_rx_queue_desc, device, queue_id, errbuf);
-    if (xsk_info == NULL) {
+    struct xsk_umem_info *umem_info = NULL;
+    struct xsk_socket_info *xsk_info = NULL;
+    unsigned int i;
+
+    /*
+     * AF_XDP runs either in the driver (native) or in the generic/SKB path.
+     * xsk_socket__create() doesn't choose for us, and with xdp_flags left at 0
+     * the attach is native-only: on a driver without native XDP - e1000,
+     * e1000e, dummy and plenty of others - it just fails, which is why --xdp
+     * worked on some adapters and not others (#1080).
+     *
+     * There is no reliable userspace probe for "does this driver do native
+     * XDP" (bpf_xdp_query_id() answers what is *attached*, not what is
+     * supported), so try native and fall back. The retry has to rebuild the
+     * umem as well: a failed bind leaves the old one attached and reusing it
+     * comes back EBUSY.
+     */
+    static const struct {
+        __u32 flags;
+        const char *name;
+    } xdp_modes[] = {{XDP_FLAGS_DRV_MODE, "native"}, {XDP_FLAGS_SKB_MODE, "generic (SKB)"}};
+
+    for (i = 0; i < sizeof(xdp_modes) / sizeof(xdp_modes[0]); i++) {
+        umem_info = create_umem_area(nb_of_frames, frame_size, nb_of_completion_queue_desc, nb_of_fill_queue_desc);
+        if (umem_info == NULL) {
+            snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "unable to create the AF_XDP UMEM area for %s", device);
+            return NULL;
+        }
+
+        xsk_info = create_xsk_socket(umem_info,
+                                     nb_of_tx_queue_desc,
+                                     nb_of_rx_queue_desc,
+                                     device,
+                                     queue_id,
+                                     xdp_modes[i].flags,
+                                     errbuf);
+        if (xsk_info != NULL) {
+            dbgx(1, "sendpacket: AF_XDP socket on %s bound in %s mode", device, xdp_modes[i].name);
+            if (xdp_modes[i].flags == XDP_FLAGS_SKB_MODE) {
+                notice("%s has no native XDP support - using generic (SKB) mode, which is slower "
+                       "than a driver that implements XDP (ixgbe, i40e, ice, mlx5, virtio_net, veth, ...).",
+                       device);
+            }
+            break;
+        }
+
+        dbgx(1, "sendpacket: AF_XDP %s mode unavailable on %s: %s", xdp_modes[i].name, device, errbuf);
+        xsk_umem__delete(umem_info->umem);
         safe_free(umem_info->buffer);
         safe_free(umem_info);
+        umem_info = NULL;
+    }
+
+    if (xsk_info == NULL) {
+        snprintf(errbuf,
+                 SENDPACKET_ERRBUF_SIZE,
+                 "unable to set up an AF_XDP socket on %s in either native or generic mode%s%s. "
+                 "This adapter cannot be driven with --xdp; replay without it to use the default "
+                 "injection method.",
+                 device,
+                 sendpacket_xdp_last_error[0] != '\0' ? " - " : "",
+                 sendpacket_xdp_last_error);
         return NULL;
     }
 
@@ -1982,6 +2111,7 @@ create_xsk_socket(struct xsk_umem_info *umem_info,
                   int nb_of_rx_queue_desc,
                   const char *device,
                   u_int32_t queue_id,
+                  __u32 xdp_flags,
                   char *errbuf)
 {
     struct xsk_socket_info *xsk_info;
@@ -2000,11 +2130,13 @@ create_xsk_socket(struct xsk_umem_info *umem_info,
      * one (#956).
      */
     socket_config->libbpf_flags = 0;
-    socket_config->bind_flags = 0; // XDP_FLAGS_SKB_MODE (1U << 1) or XDP_FLAGS_DRV_MODE (1U << 2)
+    socket_config->bind_flags = 0;
+    socket_config->xdp_flags = xdp_flags;
+
     xsk_info = xsk_configure_socket(umem_info, socket_config, queue_id, device);
     safe_free(socket_config);
     if (xsk_info == NULL) {
-        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "AF_XDP socket configuration is not successful: %s", strerror(errno));
+        snprintf(errbuf, SENDPACKET_ERRBUF_SIZE, "%s", strerror(errno));
         return NULL;
     }
     return xsk_info;

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -111,8 +111,10 @@ union sendpacket_handle {
 
 #ifdef HAVE_LIBXDP
 #include <errno.h>
-#include <stdlib.h>
+#include <linux/if_link.h> /* XDP_FLAGS_DRV_MODE / XDP_FLAGS_SKB_MODE */
 #include <linux/if_xdp.h>
+#include <stdlib.h>
+#include <xdp/libxdp.h>
 #include <xdp/xsk.h>
 
 struct xsk_ring_stats {
@@ -276,6 +278,10 @@ struct sendpacket_s {
 };
 typedef struct sendpacket_s sendpacket_t;
 
+/* declared here rather than kept static in sendpacket.c so the AF_XDP inline
+ * helpers below can report a failure instead of exiting outright (#1080) */
+void sendpacket_seterr(sendpacket_t *sp, const char *fmt, ...);
+
 #ifdef HAVE_LIBXDP
 struct xsk_umem_info *
 create_umem_area(int nb_of_frames, int frame_size, int nb_of_completion_queue_descs, int nb_of_fill_queue_descs);
@@ -284,6 +290,7 @@ struct xsk_socket_info *create_xsk_socket(struct xsk_umem_info *umem,
                                           int nb_of_rx_queue_desc,
                                           const char *device,
                                           u_int32_t queue_id,
+                                          __u32 xdp_flags,
                                           char *errbuf);
 static inline void
 gen_eth_frame(struct xsk_umem_info *umem, u_int64_t addr, u_char *pkt_data, COUNTER pkt_size)
@@ -291,39 +298,118 @@ gen_eth_frame(struct xsk_umem_info *umem, u_int64_t addr, u_char *pkt_data, COUN
     memcpy(xsk_umem__get_data(umem->buffer, addr), pkt_data, pkt_size);
 }
 
-static inline void
-kick_tx(struct xsk_socket_info *xsk)
+/**
+ * Nudge the kernel into draining the TX ring.  Returns 0 when the send is
+ * simply not ready yet (the caller should keep waiting), or -1 on a real
+ * error, with the reason recorded on the handle.
+ *
+ * This used to exit() from here, deep inside the send path - and on EINVAL it
+ * exited with status 0, so a fatal error looked to any script or CI job like a
+ * successful run, with no statistics and no cleanup (#1080).
+ */
+static inline int
+kick_tx(sendpacket_t *sp)
 {
-    int ret = sendto(xsk_socket__fd(xsk->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
+    int ret = sendto(xsk_socket__fd(sp->xsk_info->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
+
     if (ret >= 0 || errno == ENOBUFS || errno == EAGAIN || errno == EBUSY || errno == ENETDOWN) {
-        return;
+        return 0;
     }
+
     if (errno == EINVAL) {
-        printf("%s\n", "Send error: XDP is either not supported by this underlying network driver, or it has a bug.\n"
-                          "Try upgrading to a newer kernel version and/or network driver and try again.");
-        exit(0);
+        sendpacket_seterr(sp,
+                          "AF_XDP send on %s failed: the driver does not support XDP transmit the way "
+                          "tcpreplay uses it, or has a bug. Try a newer kernel/driver, or replay "
+                          "without --xdp.",
+                          sp->device);
     } else {
-        printf("%s %s\n", "XDP packet sending exited with error!", strerror(errno));
-        exit(1);
+        sendpacket_seterr(sp, "AF_XDP send on %s failed: %s", sp->device, strerror(errno));
     }
+
+    return -1;
 }
 
-static inline void
+/**
+ * Reap whatever the kernel has finished sending.  Returns the number of
+ * completions collected, or -1 if the socket has failed.
+ */
+static inline int
 complete_tx_only(sendpacket_t *sp)
 {
     u_int32_t completion_idx = 0;
+    unsigned int rcvd;
+
     if (sp->xsk_info->outstanding_tx == 0) {
-        return;
+        return 0;
     }
+
     if (xsk_ring_prod__needs_wakeup(&(sp->xsk_info->tx))) {
         sp->xsk_info->app_stats.tx_wakeup_sendtos++;
-        kick_tx(sp->xsk_info);
+        if (kick_tx(sp) < 0) {
+            return -1;
+        }
     }
-    unsigned int rcvd = xsk_ring_cons__peek(&sp->xsk_info->umem->cq, sp->pckt_count, &completion_idx);
+
+    rcvd = xsk_ring_cons__peek(&sp->xsk_info->umem->cq, sp->pckt_count, &completion_idx);
     if (rcvd > 0) {
         xsk_ring_cons__release(&sp->xsk_info->umem->cq, rcvd);
         sp->xsk_info->outstanding_tx -= rcvd;
     }
+
+    return (int)rcvd;
+}
+
+/*
+ * How long to keep waiting on an AF_XDP TX ring that isn't completing anything
+ * before calling it dead.  A driver that binds an AF_XDP socket but never
+ * actually transmits used to wedge tcpreplay in an unkillable 100% CPU spin -
+ * both the reserve loop and the drain loop retried forever, without so much as
+ * an abort check (#1080).
+ */
+#define XSK_TX_STALL_TIMEOUT_SEC 2
+
+/**
+ * Wait for the TX ring to make progress, giving up rather than spinning
+ * forever.  "progress" is any completion at all; the deadline only starts
+ * biting once nothing has come back for XSK_TX_STALL_TIMEOUT_SEC.  Returns 0
+ * on progress, or -1 if the ring is stalled, aborted or failed.
+ */
+static inline int
+xsk_wait_for_tx_progress(sendpacket_t *sp, struct timeval *since)
+{
+    struct timeval now;
+    int rcvd = complete_tx_only(sp);
+
+    if (rcvd < 0) {
+        return -1;
+    }
+
+    if (rcvd > 0) {
+        gettimeofday(since, NULL); /* progress: reset the deadline */
+        return 0;
+    }
+
+    if (sp->abort) {
+        sendpacket_seterr(sp, "User abort");
+        return -1;
+    }
+
+    gettimeofday(&now, NULL);
+    if ((now.tv_sec - since->tv_sec) * 1000000L + (now.tv_usec - since->tv_usec) >=
+        XSK_TX_STALL_TIMEOUT_SEC * 1000000L) {
+        sendpacket_seterr(sp,
+                          "AF_XDP TX ring on %s stalled for %d seconds with %u packets outstanding - the "
+                          "driver accepted the socket but is not transmitting. Replay without --xdp.",
+                          sp->device,
+                          XSK_TX_STALL_TIMEOUT_SEC,
+                          sp->xsk_info->outstanding_tx);
+        /* a ring that has stopped completing does not start again - stop the
+         * replay rather than repeating this per packet for the whole file */
+        sp->abort = true;
+        return -1;
+    }
+
+    return 0;
 }
 #endif /* HAVE_LIBXDP */
 

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -310,7 +310,7 @@ gen_eth_frame(struct xsk_umem_info *umem, u_int64_t addr, u_char *pkt_data, COUN
 static inline int
 kick_tx(sendpacket_t *sp)
 {
-    int ret = sendto(xsk_socket__fd(sp->xsk_info->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
+    ssize_t ret = sendto(xsk_socket__fd(sp->xsk_info->xsk), NULL, 0, MSG_DONTWAIT, NULL, 0);
 
     if (ret >= 0 || errno == ENOBUFS || errno == EAGAIN || errno == EBUSY || errno == ENETDOWN) {
         return 0;
@@ -337,7 +337,7 @@ static inline int
 complete_tx_only(sendpacket_t *sp)
 {
     u_int32_t completion_idx = 0;
-    unsigned int rcvd;
+    unsigned int rcvd = 0;
 
     if (sp->xsk_info->outstanding_tx == 0) {
         return 0;
@@ -367,6 +367,7 @@ complete_tx_only(sendpacket_t *sp)
  * an abort check (#1080).
  */
 #define XSK_TX_STALL_TIMEOUT_SEC 2
+#define XSK_USEC_PER_SEC 1000000L
 
 /**
  * Wait for the TX ring to make progress, giving up rather than spinning
@@ -395,8 +396,8 @@ xsk_wait_for_tx_progress(sendpacket_t *sp, struct timeval *since)
     }
 
     gettimeofday(&now, NULL);
-    if ((now.tv_sec - since->tv_sec) * 1000000L + (now.tv_usec - since->tv_usec) >=
-        XSK_TX_STALL_TIMEOUT_SEC * 1000000L) {
+    if ((now.tv_sec - since->tv_sec) * XSK_USEC_PER_SEC + (now.tv_usec - since->tv_usec) >=
+        XSK_TX_STALL_TIMEOUT_SEC * XSK_USEC_PER_SEC) {
         sendpacket_seterr(sp,
                           "AF_XDP TX ring on %s stalled for %d seconds with %u packets outstanding - the "
                           "driver accepted the socket but is not transmitting. Replay without --xdp.",

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -579,9 +579,21 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
 
 #ifdef HAVE_LIBXDP
         if (sp->handle_type == SP_TYPE_LIBXDP) {
-            /* Reserve frames for the batc h*/
+            struct timeval last_progress;
+
+            /* Reserve frames for the batch - bounded, so a driver that binds an
+             * AF_XDP socket but never transmits fails with a diagnosis instead
+             * of wedging the replay in an unkillable spin (#1080) */
+            gettimeofday(&last_progress, NULL);
             while (xsk_ring_prod__reserve(&(sp->xsk_info->tx), sp->batch_size, &sp->tx_idx) < sp->batch_size) {
-                complete_tx_only(sp);
+                if (xsk_wait_for_tx_progress(sp, &last_progress) < 0) {
+                    warnx("Unable to send packet: %s", sendpacket_geterr(sp));
+                    ctx->abort = true;
+                    break;
+                }
+            }
+            if (ctx->abort) {
+                break;
             }
             /* The first packet is already in memory */
             prepare_first_element_of_batch(ctx, &packetnum, pktdata, pkthdr.len);
@@ -609,6 +621,11 @@ send_packets(tcpreplay_t *ctx, pcap_t *pcap, int idx)
         if ((options->loss <= 0.0f || rand() > (options->loss / 100.0f) * RAND_MAX) &&
             sendpacket(sp, send_data, send_len, &pkthdr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
+            /* the backend has declared itself unusable (e.g. a stalled AF_XDP
+             * TX ring): stop rather than repeat this for every packet left */
+            if (sp->abort) {
+                ctx->abort = true;
+            }
             continue;
         }
 
@@ -900,6 +917,11 @@ send_dual_packets(tcpreplay_t *ctx, pcap_t *pcap1, int cache_file_idx1, pcap_t *
         if ((options->loss <= 0.0f || rand() > (options->loss / 100.0f) * RAND_MAX) &&
             sendpacket(sp, send_data, send_len, pkthdr_ptr) < (int)send_len) {
             warnx("Unable to send packet: %s", sendpacket_geterr(sp));
+            /* the backend has declared itself unusable (e.g. a stalled AF_XDP
+             * TX ring): stop rather than repeat this for every packet left */
+            if (sp->abort) {
+                ctx->abort = true;
+            }
             continue;
         }
 


### PR DESCRIPTION
Fixes #1080.

`--xdp` only ever worked on adapters whose driver implements **native** XDP. On anything else it failed outright, printed raw libbpf/libxdp logs at the user, or spun forever.

## Attach mode

`create_xsk_socket()` never set `xdp_flags` at all — the comment beside it named both mode flags and then set neither, on the wrong field:

```c
socket_config->libbpf_flags = 0;
socket_config->bind_flags = 0; // XDP_FLAGS_SKB_MODE (1U << 1) or XDP_FLAGS_DRV_MODE (1U << 2)
```

With `xdp_flags` at 0 the attach is native-only and there is no automatic fallback — libxdp says so itself (`XDP mode not supported; try using SKB mode`) and we ignored it. `e1000`, `e1000e`, `dummy` and plenty of others simply failed, which is why this worked on some 10GigE adapters and not others.

There is no reliable userspace probe for "does this driver do native XDP" — `bpf_xdp_query_id()` reports what is *attached*, not what is *supported*, and succeeds on any device (I tried that first; it reported dummy0 as native-capable). So: try native, fall back to generic/SKB. The retry rebuilds the umem, because a failed bind leaves the old one attached and reusing it comes back `EBUSY` rather than working.

## Hangs

Two loops retried forever with no timeout and no abort check — the reserve loop in `send_packets.c` and the drain loop in `sendpacket()`. Neither `complete_tx_only()` nor `kick_tx()` reports lack of progress, so a driver that binds an AF_XDP socket but never transmits wedged tcpreplay in an unkillable 100% CPU spin. Both now go through `xsk_wait_for_tx_progress()`, which resets its deadline on every completion and gives up after `XSK_TX_STALL_TIMEOUT_SEC`. A stalled ring ends the replay rather than repeating the warning for every remaining packet.

## `exit()` in the send path

`kick_tx()` called `exit(0)` on `EINVAL` — **success** — so a fatal send error looked to any script or CI job like a clean run, with no statistics and no cleanup. It now returns an error through `sendpacket_seterr()` (which meant giving that function external linkage). It also used `printf()` rather than `warnx()`/`errx()`, contrary to `docs/HACKING` rule 3.

## Log noise

Nothing called `libbpf_set_print()` or `libxdp_set_print()`, so both libraries' chatter went straight to stderr over the top of the replay. Both are now routed through `dbg()`. Because `dbg()` is compiled out unless `--enable-debug`, the last warning is also retained and appended to the open failure, so a release build still says *why*.

## Verification

**Before**, on a driver without native XDP:
```
libbpf: elf: skipping unrecognized data section(8) .xdp_run_config
libbpf: elf: skipping unrecognized data section(9) xdp_metadata
... x4 more ...
libbpf: Kernel error message: Underlying driver does not support XDP in native mode
libxdp: Error attaching XDP program to ifindex 8: Operation not supported
libxdp: XDP mode not supported; try using SKB mode

Fatal Error: failed to open device dummy0: AF_XDP socket configuration is not successful: Operation not supported
```

**After**:
```
Fatal Error: failed to open device dummy0: unable to set up an AF_XDP socket on dummy0 in either
native or generic mode - libbpf: Kernel error message: Underlying driver does not support XDP in
native mode. This adapter cannot be driven with --xdp; replay without it to use the default
injection method.
```

- `veth0` (native XDP): packets go out as before.
- `dummy0` (no XDP at all): fails immediately with the message above.
- A veth TX ring that stops completing is now reported and ends the replay in 2s instead of hanging:
  ```
  Warning: Unable to send packet: AF_XDP TX ring on veth0 stalled for 2 seconds with 1 packets
  outstanding - the driver accepted the socket but is not transmitting. Replay without --xdp.
  Actual: 179 packets (69093 bytes) sent in 2.00 seconds
        Successful packets:        179
        Failed packets:            1
  ```
- TX_RING and `--io-uring` unaffected; `make tcpprep tcprewrite` passes; changed lines are clang-format clean.

## Not addressed here

- **Auto-fallback to another injection backend** when the adapter can't do AF_XDP at all. Still an open question on #1080 — silently switching backends would change what a benchmark is measuring, so this PR gives a clear error naming the alternative instead. Easy to add on top if the preference is otherwise.
- **The veth TX stall itself.** This PR makes it *detected* rather than fatal-by-hang, but the underlying reason completions stop after the first pass through the pcap is a separate question, likely the veth peer needing its own XDP program. Worth its own issue.
- **Hardcoded `queue_id = 0`.** Unchanged; noted in #1080 as worth exposing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
