### PR TITLE
xdp: hand back TX descriptors reserved but never submitted (#1084)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,8 @@
 07/24/2026 Version 4.6.0-beta3
+    - xdp: fix --xdp-batch-size collapsing throughput (#1084) - a full batch of TX descriptors was
+      reserved but only the filled ones submitted, so libxdp cached producer index crept ahead on
+      every short batch until the ring looked full; --xdp-batch-size=64 against a 179-packet pcap
+      ran at 120 pps, now ~685k. Unused reservations are handed back
     - xdp: fix --xdp delivering only the first --loop iteration and then wedging (#1082) - the TX
       ring's cached producer/consumer indices were zeroed between loops, desynchronising them from
       the kernel's and stranding every later descriptor; libxdp maintains them itself

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -292,6 +292,22 @@ struct xsk_socket_info *create_xsk_socket(struct xsk_umem_info *umem,
                                           u_int32_t queue_id,
                                           __u32 xdp_flags,
                                           char *errbuf);
+/**
+ * Give back TX descriptors reserved but not used.
+ *
+ * libxdp exposes xsk_ring_cons__cancel() but no producer equivalent, so this
+ * is the mirror image of it: xsk_ring_prod__reserve() advanced cached_prod by
+ * the whole batch, while xsk_ring_prod__submit() advances the *real* producer
+ * by however many were actually filled. Undo exactly the difference, or
+ * cached_prod creeps ahead of the producer on every short batch until the ring
+ * looks permanently full (#1084).
+ */
+static inline void
+tcpr_xsk_prod_cancel(struct xsk_ring_prod *prod, __u32 nb)
+{
+    prod->cached_prod -= nb;
+}
+
 static inline void
 gen_eth_frame(struct xsk_umem_info *umem, u_int64_t addr, u_char *pkt_data, COUNTER pkt_size)
 {

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -1467,6 +1467,18 @@ prepare_remaining_elements_of_batch(tcpreplay_t *ctx,
     if (pckt_count < sp->batch_size) {
         // No more packets to read, it is essential for cached packet processing
         *read_next_packet = false;
+
+        /*
+         * The caller reserved a full batch of TX descriptors but the pcap ran
+         * out first, and only pckt_count of them get submitted. Hand the rest
+         * back: reserve() has already advanced libxdp's cached producer past
+         * them, so without this the cached index creeps ahead of the real one
+         * by the shortfall on every short batch until the ring looks
+         * permanently full. With --xdp-batch-size=64 and a 179-packet pcap
+         * that leaked 13 descriptors a loop and collapsed throughput to
+         * ~120 pps (#1084).
+         */
+        tcpr_xsk_prod_cancel(&(sp->xsk_info->tx), sp->batch_size - pckt_count);
     }
     sp->pckt_count = pckt_count;
     dbgx(2,


### PR DESCRIPTION
Addresses the first half of #1084.

`xsk_ring_prod__reserve()` advances libxdp's `cached_prod` by the whole batch; `xsk_ring_prod__submit()` advances the *real* producer by however many descriptors were actually filled. The batch path reserves a full batch and submits only `pckt_count`, so the difference is never given back and `cached_prod` creeps ahead on every short batch until the ring looks permanently full.

A 179-packet pcap with `--xdp-batch-size=64` leaks 13 descriptors per pass (179 mod 64 = 51). The stall detection from #1080 names it exactly — *"stalled for 2 seconds with **13** packets outstanding"*.

libxdp exposes `xsk_ring_cons__cancel()` but no producer equivalent, so `tcpr_xsk_prod_cancel()` is its mirror image: undo precisely what `reserve()` added.

Measured on veth over 35800 packets — every batch size now delivers in full with no stalls:

| `--xdp-batch-size` | before | after |
|---|---|---|
| 1 | 915k pps | 571k pps |
| 8 | 654k pps | 1167k pps |
| **64** | **120 pps** | **685k pps** |
| 256 | 758k pps | 1132k pps |

(The box is noisy at ±25%, so read the orders of magnitude, not the individual figures. The 64 row is the one that matters.)

## Not addressed here

The other half of #1084: the send path still blocks until each batch has fully completed before preparing the next packet.

```c
xsk_ring_prod__submit(&(sp->xsk_info->tx), sp->pckt_count);
sp->xsk_info->outstanding_tx += sp->pckt_count;
while (sp->xsk_info->outstanding_tx != 0)   /* no pipelining */
```

That cannot simply be deleted, because the umem is indexed `umem_index % sp->batch_size` — only `batch_size` frames are ever used, so a second batch in flight would overwrite the first's buffers. Fixing it properly means indexing across the whole umem and reaping opportunistically, which is a real rework of the AF_XDP TX path and wants its own change.

That blocking wait is what makes `--xdp` slow on real hardware: with the default `--xdp-batch-size=1` it is one full completion round-trip per packet, invisible on veth (µs, software) but tens of µs on a NIC. Until it is fixed, `--xdp-batch-size=64` or higher is the practical lever — and this PR is what makes those values usable.

`make tcpprep tcprewrite tcpreplay` passes bar the pre-existing `replay_config`; clang-format clean; GCC warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
