### PR TITLE
xdp: batch 64 deep by default at top speed (#1084)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,8 @@
 07/24/2026 Version 4.6.0-beta3
+    - xdp: batch AF_XDP sends 64 deep by default when replaying at top speed (#1084) - the send
+      path waits for each batch to complete before preparing the next packet, so a batch of one
+      costs a full TX completion round-trip per packet: ~13k pps on an e1000 against ~254k at 64.
+      Paced replays keep a batch of 1, since --pps/--mbps/--multiplier are only honoured there
     - xdp: fix --xdp-batch-size collapsing throughput (#1084) - a full batch of TX descriptors was
       reserved but only the filled ones submitted, so libxdp cached producer index crept ahead on
       every short batch until the ring looked full; --xdp-batch-size=64 against a 179-packet pcap

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -117,6 +117,10 @@ union sendpacket_handle {
 #include <xdp/libxdp.h>
 #include <xdp/xsk.h>
 
+/* Default AF_XDP batch when replaying at top speed - see the note in
+ * tcpreplay_api.c for why this can't be the default for paced replays. */
+#define XDP_TOPSPEED_BATCH_SIZE 64
+
 struct xsk_ring_stats {
     unsigned long rx_npkts;
     unsigned long tx_npkts;

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -429,7 +429,24 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
             goto out;
         }
 #ifdef HAVE_LIBXDP
-        ctx->intf1->batch_size = OPT_VALUE_XDP_BATCH_SIZE;
+        /*
+         * Batching is what makes AF_XDP fast: the send path waits for each
+         * batch to complete before preparing the next packet, so a batch of
+         * one costs a full TX completion round-trip per packet. On an e1000
+         * that is ~13k pps against ~254k at a batch of 64 (#1084).
+         *
+         * It cannot simply default to 64, though. Pacing is only applied to
+         * the AF_XDP path when batch_size is 1 (see send_packets.c), so a
+         * blanket default would silently stop --pps/--mbps/--multiplier from
+         * pacing anything. Batch only when there is no rate to hold to.
+         */
+        if (HAVE_OPT(XDP_BATCH_SIZE)) {
+            ctx->intf1->batch_size = OPT_VALUE_XDP_BATCH_SIZE;
+        } else if (options->speed.mode == speed_topspeed) {
+            ctx->intf1->batch_size = XDP_TOPSPEED_BATCH_SIZE;
+        } else {
+            ctx->intf1->batch_size = 1;
+        }
 #endif
 #if defined HAVE_NETMAP
         ctx->intf1->netmap_delay = ctx->options->netmap_delay;


### PR DESCRIPTION
Second half of #1084's practical impact, on top of #1085.

The AF_XDP send path waits for each batch to complete before preparing the next packet, so a batch of one costs a **full TX completion round-trip per packet**. Invisible on veth (software completions, ~µs); crippling on real hardware, where a completion means DMA plus descriptor writeback plus NAPI.

Measured by @fklassen on an e1000, `--loop 1000 -Kt`:

| | pps | time |
|---|---|---|
| `--xdp` (batch 1) | 13,344 | 13.41 s |
| `--xdp --xdp-batch-size=64` | **253,616** | 0.71 s |
| default injector (TX_RING) | 226,982 | 0.79 s |

19×, and enough to take AF_XDP from far behind the default injector to slightly ahead of it.

## Why it isn't simply the default everywhere

Pacing is only applied to the AF_XDP path when `batch_size == 1`:

```c
if (!top_speed) {
    if (sp->handle_type != SP_TYPE_LIBXDP) {
        tcpr_sleep(ctx, sp, &ctx->nap, &now);
    } else if (sp->batch_size == 1) {
        // In case of LIBXDP packet processing waiting only makes sense when batch size is one
        tcpr_sleep(ctx, sp, &ctx->nap, &now);
    }
}
```

A blanket default of 64 would silently stop `--pps`, `--mbps` and `--multiplier` from pacing anything. So the default is conditional: batch only when there is no rate to hold to, and never override an explicit `--xdp-batch-size`.

## Verification

| case | result |
|---|---|
| `--xdp --pps=100` | 101.67 pps — unchanged |
| `--xdp --pps=500` | 514.39 pps — unchanged |
| `--xdp --topspeed` (default) | 542k → 662k pps on veth |

The veth gain is much smaller than the e1000 gain, as expected — veth completions are near-instant, so there is little round-trip to amortize. That is precisely why this never showed up in testing here.

`make tcpprep tcprewrite tcpreplay` passes bar the pre-existing `replay_config`; clang-format clean; GCC warning-free.

## Still open on #1084

The blocking wait itself. Removing it needs the umem to stop being indexed `umem_index % batch_size`, so that more than one batch can be in flight. Batching amortizes the stall; it does not eliminate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
