### PR TITLE
xdp: pipeline sends across the whole umem (#1084)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,10 @@
 07/24/2026 Version 4.6.0-beta3
+    - xdp: pipeline AF_XDP sends by spreading packets over the whole umem instead of recycling the
+      first batch_size frames (#1084) - the send path no longer waits for each batch to complete
+      before preparing the next packet, only when the next batch would reuse a frame still in
+      flight. The umem is 4096 frames whether used or not, so this costs no extra memory; at a
+      batch of 64 only 1.5%% of it was being used. End-of-replay draining now covers AF_XDP too,
+      so the reported counts describe what actually reached the wire
     - xdp: batch AF_XDP sends 64 deep by default when replaying at top speed (#1084) - the send
       path waits for each batch to complete before preparing the next packet, so a batch of one
       costs a full TX completion round-trip per packet: ~13k pps on an e1000 against ~254k at 64.

--- a/src/common/sendpacket.c
+++ b/src/common/sendpacket.c
@@ -608,16 +608,29 @@ TRY_SEND_AGAIN:
         xsk_ring_prod__submit(&(sp->xsk_info->tx), sp->pckt_count); // submit all packets at once
         sp->xsk_info->ring_stats.tx_npkts += sp->pckt_count;
         sp->xsk_info->outstanding_tx += sp->pckt_count;
+        sp->sent += sp->pckt_count;
 
-        /* drain the batch, but don't spin here forever if it never completes */
+        /* Reap whatever the kernel has finished, without blocking. */
+        if (complete_tx_only(sp) < 0) {
+            sp->sent -= sp->pckt_count;
+            sp->failed += sp->pckt_count;
+            return -1;
+        }
+
+        /*
+         * Only wait when the next batch would land on a umem frame that is
+         * still in flight. Everything up to that point pipelines: the kernel
+         * transmits one batch while we prepare the next, instead of the send
+         * path stalling on a full completion round-trip every time (#1084).
+         */
         gettimeofday(&last_progress, NULL);
-        while (sp->xsk_info->outstanding_tx != 0) {
+        while (sp->xsk_info->outstanding_tx + sp->batch_size > sp->umem_frame_count) {
             if (xsk_wait_for_tx_progress(sp, &last_progress) < 0) {
+                sp->sent -= sp->pckt_count;
                 sp->failed += sp->pckt_count;
                 return -1;
             }
         }
-        sp->sent += sp->pckt_count;
     }
 #endif
     break;
@@ -1048,6 +1061,29 @@ sendpacket_flush(sendpacket_t *sp)
 void
 sendpacket_drain(sendpacket_t *sp)
 {
+#ifdef HAVE_LIBXDP
+    if (sp != NULL && sp->handle_type == SP_TYPE_LIBXDP) {
+        struct timeval last_progress;
+
+        /* Sends are pipelined now, so at the end of the replay there is
+         * normally still a tail in flight. Wait for it before the statistics
+         * are read, or "Successful packets" would count packets the kernel had
+         * not finished with (#1084). */
+        gettimeofday(&last_progress, NULL);
+        while (sp->xsk_info->outstanding_tx != 0) {
+            if (xsk_wait_for_tx_progress(sp, &last_progress) < 0) {
+                warnx("%s: %u packets were still queued in the AF_XDP TX ring and never sent",
+                      sp->device,
+                      sp->xsk_info->outstanding_tx);
+                sp->sent -= sp->xsk_info->outstanding_tx;
+                sp->failed += sp->xsk_info->outstanding_tx;
+                break;
+            }
+        }
+        return;
+    }
+#endif
+
 #if defined HAVE_PF_PACKET && defined HAVE_TX_RING
     unsigned int pending;
     COUNTER bytes = 0;
@@ -2119,6 +2155,7 @@ sendpacket_open_xsk(const char *device, char *errbuf, void *arg)
     sp->xsk_info = xsk_info;
     sp->umem_info = umem_info;
     sp->frame_size = frame_size;
+    sp->umem_frame_count = (unsigned int)nb_of_frames;
     sp->tx_size = nb_of_tx_queue_desc;
     return sp;
 }

--- a/src/common/sendpacket.h
+++ b/src/common/sendpacket.h
@@ -261,6 +261,7 @@ struct sendpacket_s {
     struct xsk_umem_info *umem_info;
     unsigned int batch_size;
     unsigned int pckt_count;
+    unsigned int umem_frame_count; /* frames in the umem - the in-flight ceiling */
     int frame_size;
     unsigned int tx_idx;
     int tx_size;
@@ -370,7 +371,9 @@ complete_tx_only(sendpacket_t *sp)
         }
     }
 
-    rcvd = xsk_ring_cons__peek(&sp->xsk_info->umem->cq, sp->pckt_count, &completion_idx);
+    /* reap everything available, not just one batch's worth: with several
+     * batches in flight the completion queue holds far more than pckt_count */
+    rcvd = xsk_ring_cons__peek(&sp->xsk_info->umem->cq, sp->umem_frame_count, &completion_idx);
     if (rcvd > 0) {
         xsk_ring_cons__release(&sp->xsk_info->umem->cq, rcvd);
         sp->xsk_info->outstanding_tx -= rcvd;

--- a/src/send_packets.c
+++ b/src/send_packets.c
@@ -1419,8 +1419,16 @@ void
 fill_umem_with_data_and_set_xdp_desc(sendpacket_t *sp, int tx_idx, COUNTER umem_index, u_char *pktdata, int len)
 {
     check_packet_fits_in_umem_frame(sp, len);
-    COUNTER umem_index_mod = (umem_index % sp->batch_size) * sp->frame_size; // packets are sent in batch, after each
-                                                                             // batch umem memory is reusable
+    /*
+     * Spread packets over the whole umem rather than recycling the first
+     * batch_size frames. Indexing modulo the batch meant a second batch would
+     * overwrite the buffers of the first while it was still in flight, which
+     * is why the send path had to block for every batch to complete before
+     * preparing the next packet - a full TX completion round-trip per batch
+     * (#1084). The umem is 4096 frames whether or not they get used, so this
+     * costs nothing and lifts the in-flight ceiling from batch_size to 4096.
+     */
+    COUNTER umem_index_mod = (umem_index % sp->umem_frame_count) * sp->frame_size;
     gen_eth_frame(sp->umem_info, umem_index_mod, pktdata, len);
     struct xdp_desc *xdp_desc = xsk_ring_prod__tx_desc(&(sp->xsk_info->tx), tx_idx);
     xdp_desc->addr = (COUNTER)(umem_index_mod);


### PR DESCRIPTION
Completes #1084 — removes the blocking wait itself, rather than just amortizing it.

## The change

The send path waited for every batch to complete before preparing the next packet. That wasn't a design choice so much as a consequence: umem frames were indexed `umem_index % sp->batch_size`, so only `batch_size` frames were ever used and a second batch in flight would have overwritten the first one's buffers. The block was load-bearing.

Indexing across the whole umem lifts the in-flight ceiling from `batch_size` to the umem's 4096 frames. The send path now only blocks when the next batch would land on a frame still in flight, so the kernel transmits one batch while userspace prepares the next.

## Answering the questions raised on the issue

**Does this imply `-K`?** No. Packets are copied into a umem frame as they are read, so nothing needs the pcap preloaded.

**Does it imply `-t`?** No. It helps most at top speed, but nothing about it requires it, and pacing is unaffected.

**Does it cost more memory than preload?** No — it costs *nothing*. The umem is allocated 4096 frames × 4096 bytes = 16 MB at socket open regardless of how many are used. At a batch of 64 that was **1.5% in use and 98.5% idle**. This change spends what was already paid for.

## Correctness

Sends are now in flight when the replay ends, so `sendpacket_drain()` grows an AF_XDP case: it waits for the tail before statistics are read, so `Successful packets` describes what reached the wire rather than what was queued, and anything undrainable moves to `Failed`. That also addresses the count inconsistency @fklassen spotted (`Actual: 242 / Successful: 179 / Failed: 64`).

`complete_tx_only()` now reaps the whole completion queue instead of one batch's worth — all it could usefully do when only one batch could ever be outstanding.

## Verification

Over 3580 packets on veth, `Actual`, `Successful` and the interface counter agree at every batch size:

| batch | before | after |
|---|---|---|
| 1 | 542k pps | **676k pps** |
| 8 | 662k pps | **845k pps** |
| 64 | 662k pps | **859k pps** |

Pacing unaffected: `--pps=100/500/2000` measure 101.25 / 506.07 / 1897.89. TX_RING and `--io-uring` unchanged. `make tcpprep tcprewrite tcpreplay` passes bar the pre-existing `replay_config`; clang-format clean; GCC warning-free.

The veth figures understate the benefit — veth completions are near-instant, so there is little round-trip to hide. The gain should be considerably larger on real hardware, where the blocking wait was costing @fklassen 19× on an e1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
