### PR TITLE
test: add unit tests for the 4.6.0 changes, and fix what they found (#1090)

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: ls ${{ github.workspace }}
       - name: List interfaces via tcpreplay
         run: pushd build; sudo src/tcpreplay --listnics; popd
+      - name: unit tests (make check)
+        run: pushd build; make check || (cat test/unit/test-suite.log >&2; false); popd
       - name: tests
         run: pushd build; sudo make test || (cat test/test.log >&2; false); popd
       - name: io_uring variant tests
@@ -69,6 +71,8 @@ jobs:
         run: cmake -B build-cmake -DENABLE_DEBUG=ON
       - name: build
         run: cmake --build build-cmake -j 4
+      - name: unit tests (ctest)
+        run: ctest --test-dir build-cmake --output-on-failure
       - name: smoke test
         run: |
           build-cmake/src/tcpreplay --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,17 +418,27 @@ set(srcdir ${CMAKE_SOURCE_DIR}/test)
 configure_file(${CMAKE_SOURCE_DIR}/test/config.in
                ${CMAKE_BINARY_DIR}/test/config @ONLY)
 
-# The line above creates a real ${CMAKE_BINARY_DIR}/test directory. Without a
-# target explicitly named "test", `cmake --build . --target test` would find
-# that directory sitting there with no build rule and nothing out of date,
-# and treat the goal as trivially satisfied - exiting 0 having silently run
-# nothing (#1047). Make that failure loud instead: this suite's tests are
-# still autotools-only (see docs/HACKING / CLAUDE.md), so point at that.
-add_custom_target(test
-    COMMAND ${CMAKE_COMMAND} -E echo "error: the test suite is autotools-only for now."
+# The line above creates a real ${CMAKE_BINARY_DIR}/test directory, which used
+# to mean `cmake --build . --target test` found a directory with no build rule,
+# nothing out of date, and exited 0 having silently run nothing (#1047). That
+# was patched with a custom target that failed loudly, because there was
+# nothing for CMake to run.
+#
+# There is now: enable_testing() below registers the test/unit suite with
+# CTest and defines a real "test" target, so the goal does something rather
+# than nothing and #1047's silent success cannot come back. The custom target
+# is gone because "test" is reserved once CTest is enabled.
+#
+# What CMake still does not run is the *integration* suite in test/ - that
+# needs root and a live NIC and remains autotools-only. `integration-test`
+# below says so rather than leaving someone to wonder why `ctest` looked
+# suspiciously quick.
+add_custom_target(integration-test
+    COMMAND ${CMAKE_COMMAND} -E echo "error: the integration suite is autotools-only."
     COMMAND ${CMAKE_COMMAND} -E echo "  from ${CMAKE_SOURCE_DIR}: run ./autogen.sh, then ./configure, then sudo make test in test/"
+    COMMAND ${CMAKE_COMMAND} -E echo "  (the dependency-free unit tests do run here: ctest --test-dir <builddir>)"
     COMMAND ${CMAKE_COMMAND} -E false
-    COMMENT "cmake does not run the test suite yet"
+    COMMENT "cmake does not run the integration suite"
 )
 
 add_compile_definitions(HAVE_CONFIG_H)
@@ -442,6 +452,12 @@ add_subdirectory(lib)
 add_subdirectory(libopts)
 add_subdirectory(src)
 add_subdirectory(examples)
+
+# Unit tests (test/unit).  The integration suite in test/ is autotools-only
+# and needs root plus a live NIC; these need neither, so they are wired into
+# CTest and run anywhere.
+enable_testing()
+add_subdirectory(test/unit)
 
 # ---------------------------------------------------------------------------
 # Configuration summary (mirrors the configure.ac results banner)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,13 +1,16 @@
 # $Id$
 ACLOCAL_AMFLAGS = -I m4 -I libopts/m4
 
+# test/unit holds the dependency-free unit tests, which `make check` recurses
+# into.  test/ itself stays out of SUBDIRS: its integration suite needs root
+# and a live NIC, so it is driven explicitly via `make test`, not by check.
 if NEED_LIBOPTS
-SUBDIRS = scripts lib $(LIBOPTS_DIR) src examples
+SUBDIRS = scripts lib $(LIBOPTS_DIR) src examples test/unit
 else
-SUBDIRS = scripts lib src examples
+SUBDIRS = scripts lib src examples test/unit
 endif
 
-DIST_SUBDIRS = scripts lib libopts src examples docs test
+DIST_SUBDIRS = scripts lib libopts src examples docs test test/unit
 .PHONY: manpages docs test man2html
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2231,6 +2231,7 @@ AC_CONFIG_FILES([Makefile
            src/defines.h
            examples/Makefile
            test/Makefile
+           test/unit/Makefile
            test/config
            scripts/Makefile])
 

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,3 +1,18 @@
+07/28/2026 Version 4.6.1-beta1
+    - txring: fix TX_RING failing outright on interfaces with an MTU of ~1365 or less (#1090) -
+      txring_mkreq() packed as many frames into a page as would fit and then divided, which
+      lands on a TPACKET_ALIGNMENT-aligned frame size only by luck. A 1280-byte MTU - the IPv6
+      minimum, so common on tunnels - produced 4096/3 = 1365, and the kernel rejected the ring
+      with EINVAL, so tcpreplay could not open the interface at all ("txring_init: Invalid
+      argument"). The frame size is now rounded up to the alignment before packing. Found by
+      the new unit tests, not in the field
+    - test: add a dependency-free unit test suite under test/unit, run by `make check`
+      (autotools) and `ctest` (CMake). Covers txring_mkreq()'s ring geometry against the
+      kernel's documented PACKET_TX_RING requirements - including the #1079 jumbo-frame
+      regression - and the IPv6 extension-header bounds in get_layer4_v6()
+      (GHSA-jj65-mrgg-f5fx). Separate from the integration suite in test/, which needs root
+      and a live NIC; these need neither, so they run in CI
+
 07/27/2026 Version 4.6.0
     - xdp: revert the top-speed default for --xdp-batch-size back to 1 (#1084) - now that sends
       pipeline across the whole umem, a batch of 1 already reaches line rate on a 1GigE e1000

--- a/src/common/txring.c
+++ b/src/common/txring.c
@@ -272,11 +272,28 @@ txring_mkreq(struct tpacket_req *treq, unsigned int mtu)
         treq->tp_block_nr = nr_blocks;
         treq->tp_frame_nr = nr_blocks;
     } else {
-        while ((s * (mult + 1)) <= pg) {
-            mult++;
-        }
+        /*
+         * Several frames fit in a page.  The frame size has to be a multiple
+         * of TPACKET_ALIGNMENT - the kernel rejects the ring outright
+         * otherwise:
+         *
+         *     if (unlikely(req->tp_frame_size & (TPACKET_ALIGNMENT - 1)))
+         *             goto out;              -- net/packet/af_packet.c
+         *
+         * This used to pack as many frames into the page as would fit and
+         * then divide, which lands on an aligned size only by luck: a
+         * 1280-byte MTU (the IPv6 minimum) gave 4096/3 = 1365, and
+         * setsockopt(PACKET_TX_RING) failed with EINVAL, so TX_RING was
+         * unusable on any small-MTU interface (#1090).
+         *
+         * Round the requirement up to the alignment first, then fit as many
+         * of those as the page holds. Rounding the division's result *down*
+         * instead would be wrong - it can fall back under the MTU (a 61-byte
+         * MTU wants 113 bytes and would get 112).
+         */
+        treq->tp_frame_size = TPACKET_ALIGN(s);
+        mult = pg / treq->tp_frame_size;
         treq->tp_block_size = pg;
-        treq->tp_frame_size = pg / mult;
         treq->tp_block_nr = nr_blocks;
         treq->tp_frame_nr = mult * nr_blocks;
     }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -8,7 +8,8 @@
 set(TCPR_UNIT_TESTS test_txring test_get_ipv6)
 
 foreach(_test ${TCPR_UNIT_TESTS})
-    add_executable(${_test} ${_test}.c)
+    # unit_globals.c: globals libcommon.a references but does not define
+    add_executable(${_test} ${_test}.c unit_globals.c)
     target_include_directories(${_test} PRIVATE
         ${TCPR_GENERATED_INCLUDE_DIRS} ${TCPR_SOURCE_INCLUDE_DIRS}
         ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,20 @@
+# test/unit/CMakeLists.txt - unit tests, registered with CTest.
+#
+# Mirrors test/unit/Makefile.am.  Run with `ctest --test-dir build`, or
+# `cmake --build build --target test`.  The tests report TAP-shaped output and
+# use automake's standard exit codes, which CTest reads directly: 0 pass,
+# 1 fail, 77 skip (declared via SKIP_RETURN_CODE below).
+
+set(TCPR_UNIT_TESTS test_txring test_get_ipv6)
+
+foreach(_test ${TCPR_UNIT_TESTS})
+    add_executable(${_test} ${_test}.c)
+    target_include_directories(${_test} PRIVATE
+        ${TCPR_GENERATED_INCLUDE_DIRS} ${TCPR_SOURCE_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(${_test} PRIVATE common
+        ${PCAP_LIBRARIES} ${DNET_LIBRARIES} ${TCPR_SYSTEM_LIBS} ${LNAV_LIBRARIES})
+    add_test(NAME ${_test} COMMAND ${_test})
+    # automake's standard "this test does not apply here" code
+    set_tests_properties(${_test} PROPERTIES SKIP_RETURN_CODE 77)
+endforeach()

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -16,8 +16,10 @@ LDADD = $(top_builddir)/src/common/libcommon.a $(LIBSTRL) @LPCAPLIB@ @LDNETLIB@
 check_PROGRAMS = test_txring test_get_ipv6
 TESTS = $(check_PROGRAMS)
 
-test_txring_SOURCES = test_txring.c
-test_get_ipv6_SOURCES = test_get_ipv6.c
+# unit_globals.c supplies the globals libcommon.a references but does not
+# define (debug), the same way each tool's main() file does
+test_txring_SOURCES = test_txring.c unit_globals.c
+test_get_ipv6_SOURCES = test_get_ipv6.c unit_globals.c
 
 noinst_HEADERS = tap.h
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -1,0 +1,24 @@
+# Unit tests for pure functions in the suite (see tap.h for why there is no
+# test framework here).
+#
+# These are deliberately separate from the integration suite in test/, which
+# needs a built binary, root, and a live NIC.  These need none of that, so
+# they run under the standard `make check` on any developer machine and in
+# every CI job - which is what makes them useful as regression tests.
+
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/src -I$(top_builddir)/src \
+	-I$(top_srcdir)/test/unit $(LIBOPTS_CFLAGS) @LDNETINC@ @PTHREAD_CFLAGS@
+
+# libcommon.a carries txring.c and get.c; the strl* fallbacks come from
+# lib/libstrl.a on systems without them in libc.
+LDADD = $(top_builddir)/src/common/libcommon.a $(LIBSTRL) @LPCAPLIB@ @LDNETLIB@
+
+check_PROGRAMS = test_txring test_get_ipv6
+TESTS = $(check_PROGRAMS)
+
+test_txring_SOURCES = test_txring.c
+test_get_ipv6_SOURCES = test_get_ipv6.c
+
+noinst_HEADERS = tap.h
+
+EXTRA_DIST = CMakeLists.txt

--- a/test/unit/tap.h
+++ b/test/unit/tap.h
@@ -1,0 +1,121 @@
+/*
+ *   Copyright (c) 2026 Fred Klassen <tcpreplay.dev at gmail dot com> - AppNeta by Broadcom
+ *
+ *   The Tcpreplay Suite of tools is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or with the authors permission any later version.
+ *
+ *   The Tcpreplay Suite is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Minimal unit-test harness for the Tcpreplay suite.
+ *
+ * Why not a test framework?  The obvious candidate, Google Test, is C++.
+ * Tcpreplay is pure C and portable to Linux, macOS, *BSD, Solaris, Haiku and
+ * Cygwin, with libpcap as its only hard dependency (see docs/INSTALL).
+ * Pulling in gtest would put a C++ toolchain on the critical path of every
+ * build and CI job for the sake of a few dozen assertions over pure
+ * functions, on platforms where gtest is not reliably packaged.  A C-native
+ * framework (Unity, greatest, ...) would mean vendoring third-party code
+ * under a second licence.
+ *
+ * So: no framework, no dependency.  Reporting is TAP-shaped because it reads
+ * well and diffs well, and the exit status follows automake's standard test
+ * protocol (0 = pass, 1 = fail, 77 = skip, 99 = hard error), which both
+ * `make check` and CTest understand natively.  Nothing here is invented
+ * where a standard already existed.
+ */
+
+#pragma once
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* automake's standard test exit codes */
+#define TAP_EXIT_PASS 0
+#define TAP_EXIT_FAIL 1
+#define TAP_EXIT_SKIP 77
+#define TAP_EXIT_ERROR 99
+
+static unsigned int tap_count;
+static unsigned int tap_failed;
+
+static inline void
+tap_plan(unsigned int tests)
+{
+    printf("1..%u\n", tests);
+    fflush(stdout);
+}
+
+/*
+ * Record one assertion.  "ok" is the TAP verdict; everything after is a
+ * printf-style description, which for a failure should say what was expected
+ * versus what happened - a bare "not ok 7" is not worth much at 3am.
+ */
+static inline void
+tap_ok(int ok, const char *fmt, ...)
+{
+    va_list ap;
+
+    ++tap_count;
+    printf("%sok %u - ", ok ? "" : "not ", tap_count);
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    putchar('\n');
+    fflush(stdout);
+
+    if (!ok)
+        ++tap_failed;
+}
+
+/* A diagnostic line; TAP consumers ignore '#' comments, humans do not. */
+static inline void
+tap_diag(const char *fmt, ...)
+{
+    va_list ap;
+
+    printf("# ");
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    putchar('\n');
+    fflush(stdout);
+}
+
+/*
+ * Skip the whole file: the feature under test is not compiled in or not
+ * supported here.  This is not a failure - TX_RING tests on a BSD box, say.
+ */
+static inline int
+tap_skip_all(const char *reason)
+{
+    printf("1..0 # SKIP %s\n", reason);
+    fflush(stdout);
+    return TAP_EXIT_SKIP;
+}
+
+static inline int
+tap_done(void)
+{
+    if (tap_failed) {
+        tap_diag("%u of %u assertions failed", tap_failed, tap_count);
+        return TAP_EXIT_FAIL;
+    }
+
+    tap_diag("all %u assertions passed", tap_count);
+    return TAP_EXIT_PASS;
+}
+
+/* the common case: an assertion whose description is the expression itself */
+#define TAP_ASSERT(expr) tap_ok((expr) ? 1 : 0, "%s", #expr)

--- a/test/unit/test_get_ipv6.c
+++ b/test/unit/test_get_ipv6.c
@@ -1,0 +1,134 @@
+/*
+ *   Copyright (c) 2026 Fred Klassen <tcpreplay.dev at gmail dot com> - AppNeta by Broadcom
+ *
+ *   The Tcpreplay Suite of tools is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or with the authors permission any later version.
+ *
+ *   The Tcpreplay Suite is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Bounds tests for the IPv6 extension-header walk in get_layer4_v6().
+ *
+ * This is the GHSA-jj65-mrgg-f5fx regression (CWE-125, fixed in 4.5.5 and
+ * carried into 4.6.0).  get_ipv6_next() validates the header it is handed,
+ * but the pointer it returns was only checked with "ptr > end_ptr" - so it
+ * could land exactly on end_ptr, or leave fewer bytes than the next
+ * tcpr_ipv6_ext_hdr_base needs, and the caller then read ip_nh one byte past
+ * the captured data.  Reachable from tcpprep, tcprewrite and tcpreplay by
+ * feeding any of them an untrusted pcap.
+ *
+ * That advisory is worth a regression test precisely because it came back:
+ * it was reported in 2024 against 4.4.4 and marked patched, but the
+ * reporter's proof-of-concept still reproduced on 4.5.4.
+ *
+ * The contract under test is narrow and absolute: for *any* input buffer,
+ * get_layer4_v6() either returns NULL or returns a pointer within
+ * [buf, end_ptr].  It must never return a pointer past the end, and must
+ * never dereference past it.  Run this under --enable-asan to check the
+ * second half; the assertions below check the first.
+ */
+
+#include "config.h"
+#include "defines.h"
+
+#include "common/get.h"
+#include "tap.h"
+
+/*
+ * A buffer with a guard page's worth of poison after end_ptr.  If the walk
+ * reads past the end, ASan (or valgrind) has something to trip on, and the
+ * returned pointer is checked against the boundary either way.
+ */
+#define BUFSZ 256
+
+struct v6case {
+    const char *name;
+    size_t caplen;     /* bytes the "capture" actually contains */
+    uint8_t next_hdr;  /* ip_nh of the fixed IPv6 header */
+    uint8_t ext_nh;    /* ip_nh of the first extension header, if present */
+    uint8_t ext_len;   /* ip_len of the first extension header, if present */
+    int have_ext;
+};
+
+static void
+run_case(const struct v6case *c)
+{
+    uint8_t buf[BUFSZ];
+    ipv6_hdr_t *ip6;
+    const u_char *end_ptr;
+    void *l4;
+
+    memset(buf, 0xA5, sizeof(buf)); /* poison, so a short read is visible */
+
+    ip6 = (ipv6_hdr_t *)buf;
+    memset(ip6, 0, TCPR_IPV6_H);
+    ip6->ip_nh = c->next_hdr;
+
+    if (c->have_ext && c->caplen >= TCPR_IPV6_H + 2) {
+        buf[TCPR_IPV6_H] = c->ext_nh;      /* ip_nh  */
+        buf[TCPR_IPV6_H + 1] = c->ext_len; /* ip_len */
+    }
+
+    /*
+     * end_ptr is the last valid byte, matching how callers in tcpedit and
+     * tcpprep compute it (pktdata + caplen - 1).
+     */
+    end_ptr = (const u_char *)buf + c->caplen - 1;
+
+    l4 = get_layer4_v6(ip6, end_ptr);
+
+    tap_ok(l4 == NULL || ((const u_char *)l4 >= buf && (const u_char *)l4 <= end_ptr),
+           "%s (caplen %zu): result %s within bounds",
+           c->name,
+           c->caplen,
+           l4 == NULL ? "NULL is" : "stays");
+}
+
+static const struct v6case cases[] = {
+        /*
+         * Truncation cases: the capture ends partway through the chain.
+         * Every one of these must come back NULL rather than a pointer into
+         * or past the poison.
+         */
+        {"header cut short", TCPR_IPV6_H - 1, IPPROTO_TCP, 0, 0, 0},
+        {"exactly the v6 header", TCPR_IPV6_H, IPPROTO_TCP, 0, 0, 0},
+        {"ext hdr promised, none present", TCPR_IPV6_H, TCPR_IPV6_NH_HBH, 0, 0, 0},
+        {"ext hdr base cut in half", TCPR_IPV6_H + 1, TCPR_IPV6_NH_HBH, IPPROTO_TCP, 0, 1},
+        {"ext hdr base exactly, no body", TCPR_IPV6_H + 2, TCPR_IPV6_NH_HBH, IPPROTO_TCP, 0, 1},
+        {"ext hdr claims more than captured", TCPR_IPV6_H + 8, TCPR_IPV6_NH_HBH, IPPROTO_TCP, 40, 1},
+        {"routing hdr claims more than captured", TCPR_IPV6_H + 8, TCPR_IPV6_NH_ROUTING, IPPROTO_TCP, 40, 1},
+        {"destopts claims more than captured", TCPR_IPV6_H + 8, TCPR_IPV6_NH_DESTOPTS, IPPROTO_TCP, 40, 1},
+        {"AH claims more than captured", TCPR_IPV6_H + 8, TCPR_IPV6_NH_AH, IPPROTO_TCP, 40, 1},
+        {"fragment hdr truncated", TCPR_IPV6_H + 4, TCPR_IPV6_NH_FRAGMENT, IPPROTO_TCP, 0, 1},
+        {"v6-in-v6 truncated", TCPR_IPV6_H + 4, TCPR_IPV6_NH_IPV6, IPPROTO_TCP, 0, 1},
+
+        /* Well-formed cases: these should resolve, and stay inside the buffer. */
+        {"plain TCP, full capture", 128, IPPROTO_TCP, 0, 0, 0},
+        {"plain UDP, full capture", 128, IPPROTO_UDP, 0, 0, 0},
+        {"one HBH then TCP", 128, TCPR_IPV6_NH_HBH, IPPROTO_TCP, 0, 1},
+        {"ESP is unparsable, must be NULL", 128, TCPR_IPV6_NH_ESP, 0, 0, 0},
+};
+
+int
+main(void)
+{
+    unsigned int i;
+    unsigned int n = sizeof(cases) / sizeof(cases[0]);
+
+    tap_plan(n);
+    tap_diag("TCPR_IPV6_H=%u sizeof(ipv6_hdr_t)=%zu", (unsigned int)TCPR_IPV6_H, sizeof(ipv6_hdr_t));
+
+    for (i = 0; i < n; i++)
+        run_case(&cases[i]);
+
+    return tap_done();
+}

--- a/test/unit/test_txring.c
+++ b/test/unit/test_txring.c
@@ -1,0 +1,175 @@
+/*
+ *   Copyright (c) 2026 Fred Klassen <tcpreplay.dev at gmail dot com> - AppNeta by Broadcom
+ *
+ *   The Tcpreplay Suite of tools is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or with the authors permission any later version.
+ *
+ *   The Tcpreplay Suite is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Unit tests for txring_mkreq() - the Linux TX_RING geometry calculation.
+ *
+ * This function decides tp_block_size/tp_frame_size/tp_block_nr/tp_frame_nr
+ * from the interface MTU, and the result is handed straight to
+ * setsockopt(PACKET_TX_RING).  It is pure arithmetic with no I/O, which makes
+ * it exactly the kind of code worth unit testing - and it has been wrong
+ * twice:
+ *
+ *   #1079  tp_frame_size was divided back down to a single page after the
+ *          block had been grown to fit the MTU, so every frame larger than
+ *          a page was truncated to 4096 bytes.  Jumbo replay was silently
+ *          corrupt.
+ *
+ *   #1090  tp_frame_size was not rounded to TPACKET_ALIGNMENT, so the kernel
+ *          rejected the ring outright with EINVAL for any MTU <= ~1365 -
+ *          including 1280, the IPv6 minimum MTU.
+ *
+ * Neither was caught by the existing suite, because every test there needs a
+ * built binary, root, and a live NIC, and none of them replay jumbo frames or
+ * run against a small-MTU interface.
+ *
+ * The assertions below are not arbitrary - each mirrors a check the kernel
+ * itself performs in packet_set_ring() (net/packet/af_packet.c).  If one
+ * fails here, setsockopt() would have failed on a real socket.
+ */
+
+#include "config.h"
+#include "defines.h"
+
+#include "tap.h"
+
+#ifndef HAVE_TX_RING
+
+int
+main(void)
+{
+    return tap_skip_all("TX_RING support not compiled in (Linux only)");
+}
+
+#else /* HAVE_TX_RING */
+
+#include "common/txring.h"
+#include <unistd.h>
+
+void txring_mkreq(struct tpacket_req *treq, unsigned int mtu);
+
+/* tdata_offset is where the frame's payload starts, past the tpacket header */
+extern int tdata_offset;
+
+/*
+ * Every MTU worth worrying about: the IPv4 and IPv6 minimums, the usual
+ * Ethernet 1500, tunnel-ish sizes, the page-boundary cases either side of
+ * 4096, the common jumbo sizes, and the 16-bit ceiling.
+ */
+static const unsigned int mtus[] =
+        {68, 128, 296, 576, 1280, 1300, 1400, 1492, 1500, 2000, 4000, 4095, 4096, 4097, 8192, 9000, 9216, 16000, 65535};
+
+static void
+check_one_mtu(unsigned int mtu, unsigned int pagesize)
+{
+    struct tpacket_req treq;
+    unsigned int need = mtu + TPACKET_HDRLEN;
+
+    txring_mkreq(&treq, mtu);
+
+    /*
+     * #1079: a frame has to be able to hold an MTU-sized packet plus the
+     * tpacket header, or the packet is truncated on the way out.  This is
+     * the assertion that fails on the pre-#1079 code for mtu >= ~4045.
+     */
+    tap_ok(treq.tp_frame_size >= need,
+           "mtu %u: frame_size %u >= mtu + TPACKET_HDRLEN (%u)",
+           mtu,
+           treq.tp_frame_size,
+           need);
+
+    /*
+     * #1090, and a hard kernel requirement:
+     *     if (unlikely(req->tp_frame_size & (TPACKET_ALIGNMENT - 1)))
+     *             goto out;
+     * An unaligned frame_size is not a performance question, it is EINVAL.
+     */
+    tap_ok(treq.tp_frame_size % TPACKET_ALIGNMENT == 0,
+           "mtu %u: frame_size %u is TPACKET_ALIGNMENT(%d)-aligned",
+           mtu,
+           treq.tp_frame_size,
+           TPACKET_ALIGNMENT);
+
+    /* kernel: block_size must be a multiple of the page size */
+    tap_ok(treq.tp_block_size % pagesize == 0,
+           "mtu %u: block_size %u is a multiple of pagesize %u",
+           mtu,
+           treq.tp_block_size,
+           pagesize);
+
+    /* kernel: a frame has to fit inside a block */
+    tap_ok(treq.tp_block_size >= treq.tp_frame_size,
+           "mtu %u: block_size %u >= frame_size %u",
+           mtu,
+           treq.tp_block_size,
+           treq.tp_frame_size);
+
+    /* kernel: the ring must hold at least one frame */
+    tap_ok(treq.tp_frame_nr > 0 && treq.tp_block_nr > 0,
+           "mtu %u: frame_nr %u and block_nr %u are both non-zero",
+           mtu,
+           treq.tp_frame_nr,
+           treq.tp_block_nr);
+
+    /*
+     * The frames have to actually fit in the memory the blocks describe.
+     * Over-promising here means txring_put() walks off the end of the
+     * mapping.
+     */
+    tap_ok((uint64_t)treq.tp_frame_size * treq.tp_frame_nr <=
+                   (uint64_t)treq.tp_block_size * treq.tp_block_nr,
+           "mtu %u: frames (%u x %u) fit within blocks (%u x %u)",
+           mtu,
+           treq.tp_frame_size,
+           treq.tp_frame_nr,
+           treq.tp_block_size,
+           treq.tp_block_nr);
+
+    /*
+     * txring_put() clamps the copy to tp_frame_size - tdata_offset.  If that
+     * is under the MTU the packet is truncated - which is #1079 seen from the
+     * other side, and the bound that used to be computed without tdata_offset
+     * at all (it overran the following frame's header).
+     */
+    tap_ok((unsigned int)((int)treq.tp_frame_size - tdata_offset) >= mtu,
+           "mtu %u: payload area %d >= mtu",
+           mtu,
+           (int)treq.tp_frame_size - tdata_offset);
+}
+
+int
+main(void)
+{
+    unsigned int pagesize = (unsigned int)getpagesize();
+    unsigned int i;
+    unsigned int n = sizeof(mtus) / sizeof(mtus[0]);
+
+    /* 7 assertions per MTU */
+    tap_plan(n * 7);
+    tap_diag("pagesize=%u TPACKET_HDRLEN=%u TPACKET_ALIGNMENT=%d tdata_offset=%d",
+             pagesize,
+             (unsigned int)TPACKET_HDRLEN,
+             TPACKET_ALIGNMENT,
+             tdata_offset);
+
+    for (i = 0; i < n; i++)
+        check_one_mtu(mtus[i], pagesize);
+
+    return tap_done();
+}
+
+#endif /* HAVE_TX_RING */

--- a/test/unit/unit_globals.c
+++ b/test/unit/unit_globals.c
@@ -1,0 +1,37 @@
+/*
+ *   Copyright (c) 2026 Fred Klassen <tcpreplay.dev at gmail dot com> - AppNeta by Broadcom
+ *
+ *   The Tcpreplay Suite of tools is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License as
+ *   published by the Free Software Foundation, either version 3 of the
+ *   License, or with the authors permission any later version.
+ *
+ *   The Tcpreplay Suite is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Globals that libcommon.a references but does not define, so a unit test can
+ * link against it the same way the tools do.
+ *
+ * Each binary in src/ defines these in its own main() file, and
+ * src/libtcpreplay_globals.c does the same for the installed library; this is
+ * the equivalent for the test binaries. Without it the link fails with
+ * "undefined reference to `debug'" - but only in a --enable-debug build,
+ * since dbg()/dbgx() compile to nothing otherwise. That is exactly the
+ * discrepancy that made this pass locally and fail in CI, which builds with
+ * -DENABLE_DEBUG=ON.
+ */
+
+#include "defines.h"
+#include "config.h"
+
+#ifdef DEBUG
+/* level used by the dbg()/dbgx() macros in --enable-debug builds */
+int debug = 0;
+#endif


### PR DESCRIPTION
Fixes #1090.

The suite has no unit tests. Every case in `test/` needs a built binary, root, and a live NIC, and they all run against a single default-MTU interface — so pure functions, the ones cheapest to test and easiest to get subtly wrong, are completely uncovered. That is how #1079 (jumbo frames silently truncated to 4096 bytes) shipped.

This adds `test/unit`, covering the 4.6.0 changes where a unit test is genuinely the right tool, and fixes a second bug the tests found on their first run.

## Why not Google Test

You left the choice open, so: I'd argue against gtest here, and against a C framework too.

- **Tcpreplay is pure C.** gtest is C++. Adopting it puts a C++ toolchain on the critical path of every build and CI job for the sake of a few dozen assertions over pure arithmetic and pointer-bounds functions.
- **Portability is a stated goal** — Linux, macOS, *BSD, Solaris, Haiku, Cygwin — and gtest is not reliably packaged across that set. `libpcap` is currently the only hard dependency (`docs/INSTALL`); that is a property worth keeping.
- **A C framework** (Unity, greatest, Criterion) means vendoring third-party code under a second licence into a GPLv3 tree, for the same handful of assertions.

So `test/unit/tap.h` is ~110 lines and dependency-free. It is not an invented runner: output is TAP-shaped because it reads and diffs well, and the **exit status follows automake's standard test protocol** (0 pass / 1 fail / 77 skip), which `make check` and CTest both consume natively. Standards where they exist, no dependency where one isn't earned.

## What is covered

| Test | What it pins down |
|---|---|
| `test_txring.c` | `txring_mkreq()` ring geometry — the four constraints `packet_set_ring()` enforces in the kernel, plus the #1079 "a frame must hold `mtu + TPACKET_HDRLEN`" regression. Swept over 19 MTUs from 68 to 65535, 7 assertions each. |
| `test_get_ipv6.c` | The IPv6 extension-header walk in `get_layer4_v6()`: for *any* input it must return `NULL` or a pointer inside the buffer — the GHSA-jj65-mrgg-f5fx heap over-read. 15 crafted chains, mostly truncations. |

The IPv6 one is worth having precisely because that advisory regressed once already: reported in 2024 against 4.4.4, marked patched, and the reporter's PoC still reproduced on 4.5.4.

Assertions mirror real kernel requirements rather than describing whatever the code currently returns, so a failure here means `setsockopt()` would have failed on a real socket — which is exactly what happened.

## The bug the tests found

`test_txring` failed on first run, on something that is **not** #1079. `tp_frame_size` came out TPACKET_ALIGNMENT-aligned only when `pg / mult` happened to divide evenly:

```
not ok 30 - mtu 1280: frame_size 1365 is TPACKET_ALIGNMENT(16)-aligned
```

The kernel rejects an unaligned frame size outright, so **tcpreplay could not open an MTU-1280 interface at all** — the IPv6 minimum MTU, common on tunnels:

```
# before
Fatal Error: failed to open device dummy0: txring_init: Invalid argument
# after
Actual: 147 packets (20552 bytes) sent in 2.00 seconds
```

Fixed by rounding the requirement **up** to the alignment before packing. Rounding the result *down* would be wrong — it can fall under the MTU (a 61-byte MTU needs 113 bytes; `pg/mult` is exactly 113 and rounds down to 112). Verified against a live `PF_PACKET` socket, and across all 65535 MTUs against the four kernel constraints — zero violations. Full detail in #1090.

## One structural change worth flagging

Enabling CTest required dropping the custom `test` target added for #1047, because that name is reserved once testing is on. That target existed *because* CMake had nothing to run and would otherwise exit 0 having done nothing. It now has something to run, so the silent-success problem it guarded is gone by construction. Its "the integration suite is autotools-only" guidance moves to a new `integration-test` target rather than being lost.

`test/` itself deliberately stays out of `SUBDIRS`, so the root-and-NIC suite is still driven only by an explicit `make test` and `make check` stays runnable by anyone.

## Verification

```
$ make check                       # autotools
# TOTAL: 2   # PASS: 2   # FAIL: 0        (148 assertions)

$ ctest --test-dir build           # cmake
100% tests passed, 0 tests failed out of 2
```

- Full integration suite (`tcpprep`/`tcprewrite`/`tcpreplay`) passes, no regressions
- Both build systems build clean, no new warnings
- Skip path returns 77 correctly, so non-Linux builds report SKIP rather than failing on the TX_RING tests

## Deliberately not covered

The AF_XDP (#1080/#1082/#1084) and io_uring (#1074) changes are not unit tested here: they need a real socket, driver, and NIC, so a unit test would be testing a mock rather than the behaviour that was broken. Those stay integration-tested. The value in this PR is concentrated where the logic is pure and the bugs were arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
