### PR TITLE
ci: run the existing test corpus under AddressSanitizer (#1093)

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -84,3 +84,51 @@ jobs:
         run: |
           build-cmake/src/tcprewrite -i test/test.pcap -o portmap.pcap -r 80:8080
           cmp portmap.pcap test/test2.rewrite_portmap
+
+  # AddressSanitizer build. --enable-asan has been supported for a long time
+  # but nothing ever ran it, so the checking existed and was never applied
+  # (#1093). Given that 15 memory-safety advisories were published against
+  # this project in 2026 - every one reported from outside - running the
+  # existing corpus under ASan is the cheapest coverage available: no new
+  # tests, no new dependencies.
+  #
+  # Linux only: the integration suite needs a live interface, and a dummy
+  # device gives one without touching the runner's real networking.
+  #
+  # UBSan is deliberately not enabled here yet. It finds two genuine defects
+  # on the current tree (a misaligned struct access in the MPLS parser and a
+  # left shift of a negative value in fragroute's ip_ttl) - see #1100. Turning it on before those are fixed would just mean a permanently
+  # red job.
+  #
+  # Leak detection is off for the same reason: the tools exit without freeing
+  # everything, and that is a separate cleanup from memory-corruption
+  # coverage, which is the class the advisories actually fall into.
+  asan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install prereqs
+        run: sudo apt -y install autogen asciidoctor libpcap-dev automake autoconf libtool libxdp-dev liburing-dev
+      - name: Create a dummy interface for the replay tests
+        run: |
+          sudo ip link add dummy0 type dummy
+          sudo ip link set dummy0 up
+      - name: Create a build directory
+        run: mkdir -p build-asan
+      - name: Create configure script
+        run: pushd build-asan; ../autogen.sh; popd
+      - name: configure
+        run: pushd build-asan; ../configure --enable-asan --with-testnic=dummy0 --with-testnic2=dummy0; popd
+      - name: make
+        run: pushd build-asan; make -j 4; popd
+      - name: unit tests under ASan
+        env:
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
+        run: pushd build-asan; make check || (cat test/unit/test-suite.log >&2; false); popd
+      - name: integration suite under ASan
+        run: |
+          pushd build-asan
+          sudo ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 make test \
+            || (cat test/test.log >&2; false)
+          popd


### PR DESCRIPTION
Fixes #1093.

`--enable-asan` has been supported by `configure` for a long time, and CMake has matching `asan`/`tsan` presets. **Nothing ever ran them** — `grep -i asan .github/workflows/` returned nothing. The checking existed and was applied only when a maintainer remembered to invoke it by hand.

Given 15 memory-safety advisories published against this project in 2026, all reported from outside, running the corpus that already exists under ASan is the cheapest coverage available: no new tests, no new dependencies, one job. It exercises the DLT plugins, fragroute modules and pcap read path — where the advisories keep landing.

Verified locally before pushing: **ASan is clean on the current tree, 74/74 with no reports**, so this arrives green rather than pre-broken.

## Two things deliberately left off

**UBSan.** I did run it, and it found two genuine defects on the current tree:

```
get.c:115:16: runtime error: member access within misaligned address ...
              for type 'struct tcpr_mpls_label', which requires 4 byte alignment
mod_ip_ttl.c:61:40: runtime error: left shift of negative value -4
```

Both are invisible on x86-64 and real on the SPARC/BSD targets listed in `docs/INSTALL`. Filed as #1100. Enabling UBSan before those are fixed would mean a permanently red job, which just teaches people to ignore it — it should land once #1100 is closed, as a one-line change to the `configure` invocation here.

**Leak detection.** `detect_leaks=0`. The tools exit without freeing everything; that's a separate cleanup from the memory-corruption coverage the advisory history actually calls for, and turning it on now would bury the signal.

## Notes

Linux only — the integration suite needs a live interface, and a `dummy` device provides one without touching the runner's real networking.

That UBSan found two real bugs on its first run, in a codebase this heavily audited, is the argument for the whole issue: the tooling was already present and simply wasn't pointed at anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
