### PR TITLE
test: verify packet ordering empirically for the first time (#1098)

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,6 +34,7 @@ FRAGROUTE_TESTS =
 endif
 
 EXTRA_DIST = wirecheck.sh mtu_matrix.sh mtu_check_jumbo.py gen_jumbo_pcap.py \
+		replay_order.sh order_compare.py \
 		test.pcap test_jumbo.pcap test_nano.pcap test_fragroute.pcap \
 		test.auto_bridge test.auto_client test.auto_router \
 		test.auto_server test.auto_first test.cidr test.comment test.port test.mac \
@@ -244,7 +245,7 @@ tcprewrite: rewrite_portmap rewrite_range_portmap rewrite_endpoint \
 	rewrite_fixlen_pad rewrite_fixlen_trunc rewrite_fixlen_del \
 	$(FRAGROUTE_TESTS)
 
-tcpreplay: replay_wirecheck replay_mtu_jumbo replay_mtu_small replay_basic replay_nano_timer replay_cache \
+tcpreplay: replay_wirecheck replay_mtu_jumbo replay_mtu_small replay_ordering replay_basic replay_nano_timer replay_cache \
 	replay_pps replay_rate replay_top \
 	replay_config replay_multi replay_pps_multi replay_precache \
 	replay_stats replay_dualfile replay_maxsleep replay_include replay_exclude replay_unique_ip
@@ -480,6 +481,18 @@ replay_mtu_small:
 	$(PRINTF) "%s" "[tcpreplay] Small MTU (1280) test: "
 	$(PRINTF) "%s\n" "*** [tcpreplay] Small MTU (1280) test: " >> test.log
 	$(MTU_MATRIX) small test.log $(TCPREPLAY) $(ENABLE_DEBUG); \
+	rc=$$?; \
+	if [ $$rc -eq 0 ] ; then $(PRINTF) "\t\t%s\n" "OK"; \
+	elif [ $$rc -eq 77 ] ; then $(PRINTF) "\t\t%s\n" "SKIPPED"; \
+	else $(PRINTF) "\t\t%s\n" "FAILED"; tail -n 40 test.log >&2; false; fi
+
+# #1098: ordering was never verified empirically, only reasoned about from
+# the code (#1074, #1078). Linux-only (dummy interfaces); skips cleanly
+# elsewhere.
+replay_ordering:
+	$(PRINTF) "%s" "[tcpreplay] Packet ordering test: "
+	$(PRINTF) "%s\n" "*** [tcpreplay] Packet ordering test: " >> test.log
+	$(srcdir)/replay_order.sh test.log $(TCPREPLAY) $(ENABLE_DEBUG); \
 	rc=$$?; \
 	if [ $$rc -eq 0 ] ; then $(PRINTF) "\t\t%s\n" "OK"; \
 	elif [ $$rc -eq 77 ] ; then $(PRINTF) "\t\t%s\n" "SKIPPED"; \

--- a/test/order_compare.py
+++ b/test/order_compare.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Compare a captured pcap's packet order against the source pcap it was
+# replayed from (#1098). Used by replay_order.sh; not a standalone test.
+#
+# A pure count or pure content check can't tell reordering apart from loss:
+# #1078's actual defect was frames leaving out of order while every one of
+# them still arrived, so this walks the capture and asks a different
+# question - does each captured packet that matches something in the
+# original show up no earlier, relative to the others, than it did in the
+# source?
+#
+# Matching is by exact packet bytes, not identity, since the pcap can contain
+# duplicate-looking packets; a greedy earliest-unconsumed-occurrence match
+# handles duplicates while still catching a real swap. Anything captured
+# that matches nothing in the original (background interface noise) is
+# skipped rather than treated as a mismatch - loss and noise are not what
+# this check is for; see mtu_matrix.sh's wirecheck.sh call for loss.
+#
+# usage: order_compare.py <original.pcap> <captured.pcap>
+
+import struct, sys
+from collections import defaultdict, deque
+
+def read_packets(path):
+    pkts = []
+    with open(path, "rb") as f:
+        f.read(24)  # global header
+        while True:
+            hdr = f.read(16)
+            if len(hdr) < 16:
+                break
+            _, _, incl_len, _ = struct.unpack("<IIII", hdr)
+            pkts.append(f.read(incl_len))
+    return pkts
+
+orig = read_packets(sys.argv[1])
+cap = read_packets(sys.argv[2])
+
+print("original packet count: %d" % len(orig))
+print("captured packet count: %d" % len(cap))
+
+if len(cap) == 0:
+    # Same "capture never actually attached" signature as mtu_check_jumbo.py -
+    # safe for the caller to retry the whole cycle without risking masking a
+    # real reordering, since that reproduces deterministically once a capture
+    # attaches at all.
+    print("FAIL: captured 0 packets - capture likely wasn't attached in time")
+    sys.exit(2)
+
+# index all occurrences of each distinct packet's bytes, in original order
+occurrences = defaultdict(deque)
+for i, pkt in enumerate(orig):
+    occurrences[pkt].append(i)
+
+last_matched = -1
+matched = 0
+violations = []
+for cap_i, pkt in enumerate(cap):
+    candidates = occurrences.get(pkt)
+    if not candidates:
+        continue  # matches nothing in the source: unrelated noise, not ours
+
+    # consume occurrences up to (not including) the first one still ahead of
+    # what's already been matched, so a later duplicate can't be mistaken for
+    # an earlier one that already went by
+    while candidates and candidates[0] <= last_matched:
+        candidates.popleft()
+
+    if not candidates:
+        violations.append((cap_i, pkt))
+        continue
+
+    last_matched = candidates.popleft()
+    matched += 1
+
+print("matched %d captured packets against the source, in order" % matched)
+
+if violations:
+    for cap_i, pkt in violations[:10]:
+        print("FAIL: captured packet %d (%d bytes) arrived out of order - every one of its "
+              "occurrences in the source was already accounted for by an earlier arrival "
+              "(the #1078 signature)" % (cap_i, len(pkt)))
+    if len(violations) > 10:
+        print("... and %d more" % (len(violations) - 10))
+    sys.exit(1)
+
+if matched == 0:
+    print("FAIL: none of the captured traffic matched the source pcap at all")
+    sys.exit(2)
+
+print("OK: every matched packet arrived in source order")
+sys.exit(0)

--- a/test/replay_order.sh
+++ b/test/replay_order.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+#
+#   Copyright (c) 2026 Fred Klassen <tcpreplay.dev at gmail dot com> - AppNeta by Broadcom
+#
+#   The Tcpreplay Suite of tools is free software: you can redistribute it
+#   and/or modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or with the authors permission any later version.
+#
+#   The Tcpreplay Suite is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with the Tcpreplay Suite.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Verify packets reach the wire in the order they appear in the pcap (#1098).
+#
+# Two 4.6 changes touched ordering directly and were both backed only by
+# reasoning about the code, never measurement:
+#
+#   #1078  TX_RING filled ring frames out of order, reordering the wire.
+#          Fixed by filling in order.
+#   #1074  io_uring submissions were not chained, so a send that could not
+#          complete inline was retried out of band and packets behind it
+#          went out first. Fixed with IOSQE_IO_HARDLINK.
+#
+# The reason this was never verified before: at --topspeed, the 179-packet
+# test capture is on the wire in under a millisecond, and no capture attaches
+# fast enough to see it - this was attempted and failed three times while
+# working on the two fixes above. --pps here paces the replay to roughly 1.8
+# real seconds instead, which is what actually makes an ordering check
+# feasible rather than a bigger version of the same losing race (see
+# mtu_matrix.sh's replay_mtu_jumbo, which hit the identical problem: more
+# packets sent instantaneously is still instantaneous).
+#
+# `ip link add ... type dummy` makes this cheap and hermetic - no hardware
+# needed - which also makes it Linux-only; skips cleanly (exit 77) elsewhere.
+#
+# usage: replay_order.sh <logfile> <tcpreplay-binary> [args...]
+#
+# Exit 0 on success, 1 on failure, 77 (automake's "skip") where dummy
+# interfaces or the tools to verify them aren't available.
+
+set -u
+
+if [ $# -lt 2 ]; then
+    echo "usage: $0 <logfile> <tcpreplay-binary> [args...]" >&2
+    exit 99
+fi
+
+logfile="$1"; shift
+dir=$(dirname "$0")
+iface="tcprorder0"
+pcap="$dir/test.pcap"
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "replay_order: dummy interfaces are Linux-only, skipping" >> "$logfile"
+    exit 77
+fi
+if ! command -v ip >/dev/null 2>&1; then
+    echo "replay_order: 'ip' not found, skipping" >> "$logfile"
+    exit 77
+fi
+if ! command -v tcpdump >/dev/null 2>&1; then
+    echo "replay_order: tcpdump not found, skipping" >> "$logfile"
+    exit 77
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "replay_order: python3 not found, skipping" >> "$logfile"
+    exit 77
+fi
+
+cleanup() {
+    ip link delete "$iface" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# in case a previous run was interrupted before its own cleanup ran
+ip link delete "$iface" >/dev/null 2>&1 || true
+
+if ! ip link add "$iface" type dummy >> "$logfile" 2>&1; then
+    echo "replay_order: could not create $iface (need root?), skipping" >> "$logfile"
+    exit 77
+fi
+# test.pcap's largest frame is 1514 bytes - above a default 1500 MTU. Give it
+# headroom so nothing here is incidentally exercising the MTU-truncation bugs
+# replay_mtu_jumbo/replay_mtu_small already cover; this test is about order,
+# not size.
+ip link set "$iface" mtu 2000 >> "$logfile" 2>&1
+ip link set "$iface" up >> "$logfile" 2>&1
+
+echo "replay_order: $iface up" >> "$logfile"
+
+# Same retry shape as replay_mtu_jumbo, and for the same reason: retrying on
+# "captured nothing at all" only papers over a scheduling race on a loaded CI
+# runner, never a real reordering, which reproduces deterministically once a
+# capture attaches at all.
+attempt=1
+checkrc=2
+while [ $attempt -le 3 ] && [ $checkrc -eq 2 ]; do
+    if [ $attempt -gt 1 ]; then
+        echo "replay_order: retrying capture (attempt $attempt/3)" >> "$logfile"
+    fi
+
+    capfile=$(mktemp) || exit 99
+    tcpdump_out=$(mktemp) || { rm -f "$capfile"; exit 99; }
+
+    tcpdump -i "$iface" -w "$capfile" -s 0 > "$tcpdump_out" 2>&1 &
+    tcpdump_pid=$!
+
+    i=0
+    ready=0
+    while [ $i -lt 50 ]; do
+        if grep -q "listening on" "$tcpdump_out" 2>/dev/null; then
+            ready=1
+            break
+        fi
+        if ! kill -0 "$tcpdump_pid" 2>/dev/null; then
+            echo "replay_order: tcpdump exited before it started capturing:" >> "$logfile"
+            cat "$tcpdump_out" >> "$logfile"
+            rm -f "$capfile" "$tcpdump_out"
+            exit 1
+        fi
+        i=$((i + 1))
+        sleep 0.1
+    done
+    if [ "$ready" -eq 0 ]; then
+        echo "replay_order: tcpdump did not report 'listening on' within 5s, proceeding anyway" >> "$logfile"
+    fi
+    cat "$tcpdump_out" >> "$logfile"
+    rm -f "$tcpdump_out"
+    sleep 1
+
+    # --pps=100 spreads the 179-packet capture over ~1.8 real seconds - the
+    # actual fix for the timing problem, not a bigger burst (see the comment
+    # at the top of this file and in replay_mtu_jumbo/mtu_matrix.sh).
+    "$@" -i "$iface" --pps=100 "$pcap" >> "$logfile" 2>&1
+    rc=$?
+
+    sleep 0.5
+    kill "$tcpdump_pid" >/dev/null 2>&1
+    wait "$tcpdump_pid" 2>/dev/null
+
+    if [ $rc -ne 0 ]; then
+        echo "replay_order: tcpreplay exited $rc" >> "$logfile"
+        rm -f "$capfile"
+        exit $rc
+    fi
+
+    python3 "$dir/order_compare.py" "$pcap" "$capfile" >> "$logfile" 2>&1
+    checkrc=$?
+    rm -f "$capfile"
+    attempt=$((attempt + 1))
+done
+
+exit $checkrc


### PR DESCRIPTION
Fixes #1098.

Two 4.6 changes touched packet ordering directly, and both were verified only by reasoning about the code:

- **#1078** - TX_RING filled ring frames out of order, reordering the wire. Fixed by filling in order.
- **#1074** - io_uring submissions weren't chained, so a send that couldn't complete inline was retried out of band and packets behind it went out first. Fixed with `IOSQE_IO_HARDLINK`.

I tried to verify either empirically three times while working on those fixes and failed every time: at `--topspeed`, the 179-packet test capture is on the wire in under a millisecond - no capture attaches fast enough to see it.

## The actual fix for the timing problem

Same one `replay_mtu_jumbo` needed for the identical race (#1097, #1109): pace the replay so there's real wall-clock duration for the capture to be attached *during*, rather than a bigger instantaneous burst. `--pps=100` spreads the 179-packet capture over ~1.8 real seconds.

## What "verify order" actually means here

`order_compare.py` matches captured packets against the source pcap by **exact bytes**, not length or count, and checks that matched packets appear in non-decreasing source order - a greedy earliest-unconsumed-occurrence match, so duplicate-content packets in a real capture don't produce false matches or false violations.

A pure count check can't distinguish reordering from loss - #1078's actual defect was frames leaving out of order while every single one of them still arrived, so counting alone would have looked fine both before and after that fix. Unmatched captured packets (interface bring-up noise, and the occasional real drop) are tolerated rather than treated as a failure; that's what `replay_wirecheck` already covers - this test is about order alone.

## Proving the check has teeth

Before trusting it, I manually swapped two packets in a copy of `test.pcap` and confirmed `order_compare.py` flags the violation - not just exercised the passing path.

```
$ python3 order_compare.py test.pcap /tmp/reordered.pcap
matched 134 captured packets against the source, in order
FAIL: captured packet 6 (66 bytes) arrived out of order - every one of its
occurrences in the source was already accounted for by an earlier arrival
(the #1078 signature)
...
```

## Verification

- 5 consecutive clean standalone runs of `replay_order.sh`.
- `sudo make tcpreplay` (the full replay group): 19/19 OK.
- CI's exact `asan` job config (ASan+UBSan): 78/78, 0 sanitizer reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
