### PR TITLE
fix: mark wire-format header structs packed, enable UBSan alignment checking (#1104)

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -95,20 +95,21 @@ jobs:
   # Linux only: the integration suite needs a live interface, and a dummy
   # device gives one without touching the runner's real networking.
   #
-  # UndefinedBehaviorSanitizer runs alongside, minus the alignment check.
+  # UndefinedBehaviorSanitizer runs alongside, alignment checking included.
   #
-  # The two defects that blocked it are fixed (#1100): a misaligned struct
-  # access in the MPLS parser and a left shift of a negative value in
-  # fragroute's ip_ttl. Everything UBSan checks other than alignment is clean
-  # across the whole suite.
-  #
-  # -fno-sanitize=alignment because misaligned access is systemic rather than a
-  # defect or two: parsing a packet here means casting a buffer offset to a
-  # header struct, and an Ethernet payload starts 14 bytes in, so any 4-byte
-  # field in it is misaligned by construction. 15 sites across get.c, flows.c
-  # and en10mb.c (#1104). Leaving the check on would mean a red job and no
-  # coverage of anything else; turning it off keeps the integer-overflow,
-  # shift and bad-enum checks working today, and #1104 can re-enable it.
+  # The two defects that first blocked it are fixed (#1100): a misaligned
+  # struct access in the MPLS parser and a left shift of a negative value in
+  # fragroute's ip_ttl. Alignment itself was systemic rather than a defect or
+  # two - parsing a packet here means casting a buffer offset to a header
+  # struct, and an Ethernet payload starts 14 bytes in, so any 4-byte field in
+  # it is misaligned by construction - and had to stay off for a while (15
+  # sites across get.c, flows.c and en10mb.c, #1104) rather than turn the job
+  # red with no coverage of anything else. Fixed by marking the wire-format
+  # header structs those sites cast onto (tcpr_ipv4_hdr, tcpr_ipv6_hdr,
+  # tcpr_in6_addr, tcpr_tcp_hdr, tcpr_icmpv4_hdr, in tcpr.h) __attribute__
+  # ((packed)): none of them had compiler-inserted padding to begin with, so
+  # this is a no-op for sizeof()/wire layout, and only tells the compiler the
+  # struct's start address isn't guaranteed aligned - which it never was.
   #
   # Leak detection is off for the same reason: the tools exit without freeing
   # everything, and that is a separate cleanup from memory-corruption
@@ -132,7 +133,7 @@ jobs:
         run: |
           pushd build-asan
           ../configure --enable-asan --with-testnic=dummy0 --with-testnic2=dummy0 \
-            CFLAGS="-fsanitize=undefined -fno-sanitize=alignment -fno-sanitize-recover=undefined -g -O1"
+            CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -g -O1"
           popd
       - name: make
         run: pushd build-asan; make -j 4; popd

--- a/src/tcpr.h
+++ b/src/tcpr.h
@@ -713,7 +713,17 @@ struct tcpr_ipv4_hdr {
     uint8_t ip_p;                  /* protocol */
     uint16_t ip_sum;               /* checksum */
     struct in_addr ip_src, ip_dst; /* source and dest address */
-};
+/*
+ * packed: this struct is overlaid directly on a packet buffer at whatever
+ * byte offset the preceding headers add up to - an Ethernet header is 14
+ * bytes, so an IPv4 header right after one starts 2 mod 4, misaligning every
+ * multi-byte field here. Without packed, the compiler assumes the natural
+ * alignment its members would need and member access is undefined behaviour;
+ * with it, the compiler emits an unaligned load instead (#1104). No layout
+ * change: every field here already falls on a self-consistent offset with no
+ * inserted padding, so sizeof() and wire compatibility are unaffected.
+ */
+} __attribute__((packed));
 
 /*
  *  IP options
@@ -749,7 +759,7 @@ struct tcpr_in6_addr {
         u_int16_t __u6_addr16[8];
         u_int32_t __u6_addr32[4];
     } __u6_addr; /* 128-bit IP6 address */
-};
+} __attribute__((packed)); /* see the comment on tcpr_ipv4_hdr (#1104) */
 #define tcpr_s6_addr __u6_addr.__u6_addr8
 #define tcpr_s6_addr8 __u6_addr.__u6_addr8
 #define tcpr_s6_addr16 __u6_addr.__u6_addr16
@@ -766,7 +776,7 @@ struct tcpr_ipv6_hdr {
     uint8_t ip_nh;                       /* next header */
     uint8_t ip_hl;                       /* hop limit */
     struct tcpr_in6_addr ip_src, ip_dst; /* source and dest address */
-};
+} __attribute__((packed)); /* see the comment on tcpr_ipv4_hdr (#1104) */
 
 struct tcpr_ipv6_ext_hdr_base {
     uint8_t ip_nh;  /* next header */
@@ -1031,7 +1041,7 @@ struct tcpr_icmpv4_hdr {
 #undef icmp_ttime
 #define icmp_ttime dun.ts.its_ttime
     } dun;
-};
+} __attribute__((packed)); /* see the comment on tcpr_ipv4_hdr (#1104) */
 
 /*
  *  IGMP header
@@ -1536,7 +1546,7 @@ struct tcpr_tcp_hdr {
     uint16_t th_win; /* window */
     uint16_t th_sum; /* checksum */
     uint16_t th_urp; /* urgent pointer */
-};
+} __attribute__((packed)); /* see the comment on tcpr_ipv4_hdr (#1104) */
 
 /*
  *  Token Ring Header


### PR DESCRIPTION
Fixes #1104.

Misaligned struct access was systemic, not the two isolated defects #1100 fixed: parsing a packet here means casting a buffer offset to a header struct, and an Ethernet payload starts 14 bytes in, so any 4-byte field in the header right after it is misaligned by construction - 15 sites across `get.c`, `flows.c` and `en10mb.c`, all the same shape (cast, then dereference).

## The fix

Marked the five structs those 15 sites actually cast onto `__attribute__((packed))`: `tcpr_ipv4_hdr`, `tcpr_ipv6_hdr`, `tcpr_in6_addr`, `tcpr_tcp_hdr`, `tcpr_icmpv4_hdr` (`src/tcpr.h`).

None of them had compiler-inserted padding to begin with - every field already falls on a self-consistent offset - so this is a **no-op for `sizeof()` and wire layout**. Verified identical `sizeof()` before/after for all five:

```
ipv4_hdr: 20   ipv6_hdr: 40   in6_addr: 16   tcp_hdr: 20   icmpv4_hdr: 28
```

before and after, unchanged. `packed` here only removes the compiler's *assumption* that the struct's start address is naturally aligned - which it never was, since it's overlaid on packet buffers at whatever offset the preceding headers add up to.

## Why not the other ~55 wire structs in tcpr.h

Deliberately left alone. They're not implicated by any UBSan finding the corpus has actually produced (BGP4, OSPF, DHCP, SEBEK, and the rest aren't exercised the same way), and packing them without that evidence would trade real, exercised coverage for speculative coverage of paths nothing here tests - same reasoning #1104 itself gave for not folding this into #1100.

## CI

`-fno-sanitize=alignment` dropped from the `asan` job - alignment checking now runs alongside everything else UBSan already checked (integer overflow, shifts, bad enums, null dereference).

## Verification

- Alignment enabled with `-fno-sanitize-recover` (abort on first violation, not just log it): **78/78, 0 sanitizer reports**.
- Same result under the plain non-sanitizer autotools build (matching the `tests` CI job) and under CMake.
- `sudo make tcpreplay` (full replay group): 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
