### PR TITLE
docs(fuzz): add the required Apache 2.0 header to oss-fuzz/build.sh

### DIFF
--- a/test/fuzz/oss-fuzz/build.sh
+++ b/test/fuzz/oss-fuzz/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
 #
 # OSS-Fuzz build script for tcpreplay.
 #


### PR DESCRIPTION
OSS-Fuzz's own presubmit check (`infra/presubmit.py license`) requires this header on every `.sh` file submitted under `projects/<name>/`, found while preparing the actual OSS-Fuzz submission for #1092. `project.yaml` and the `Dockerfile` already carry it or are exempt (YAML files aren't checked by that tool); `build.sh` was the one file missing it.

Small, comment-only change - verified `bash -n` still parses it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v