### PR TITLE
fix: flow_decode() over-required bytes for a minimal ICMP/ICMPv6 header (#1119)

### DIFF
--- a/src/common/flows.c
+++ b/src/common/flows.c
@@ -295,7 +295,18 @@ flow_decode(flow_hash_table_t *fht,
     }
     case IPPROTO_ICMP:
     case IPPROTO_ICMPV6: {
-        size_t required_len = sizeof(icmpv4_hdr_t) + l2len + ip_len;
+        /*
+         * Only icmp_type and icmp_code - the first two bytes, same offsets in
+         * both struct tcpr_icmpv4_hdr and struct tcpr_icmpv6_hdr - are read
+         * below. sizeof(icmpv4_hdr_t) demanded the entire struct, including
+         * the union of type-specific payloads following the base header (up
+         * to 28 bytes, for the embedded IP header a "destination
+         * unreachable" reply carries) - so a minimal, complete ICMP echo
+         * with no data (`ping -s 0`, 8 bytes on the wire: type, code,
+         * checksum, id, sequence) was rejected as too short for something it
+         * never needed (#1119).
+         */
+        size_t required_len = 2 + l2len + ip_len;
         if (pkt_len < required_len) {
             warnx("flow_decode: packet " COUNTER_SPEC " needs at least %zd bytes for %s header but only %d available",
                   packetnum,


### PR DESCRIPTION
Fixes #1119.

Reported externally: replaying a `ping -s 0` capture (an 8-byte ICMP echo with zero payload) logs a spurious warning on every packet:

```
Warning: flow_decode: packet 1 needs at least 62 bytes for ICMP header but only 42 available
```

(or for ICMPv6: `needs at least 82 bytes ... but only 62 available`).

## Root cause

`flow_decode()` only ever reads `icmp_type` and `icmp_code` - the first two bytes, at identical offsets in both `struct tcpr_icmpv4_hdr` and `struct tcpr_icmpv6_hdr` - to key flow tracking. The bounds check demanded `sizeof(icmpv4_hdr_t)` instead: the *entire* struct, including the union of type-specific payloads that follows the 4-byte base header - up to 28 bytes, sized for the embedded original-packet copy a "destination unreachable" reply carries. A complete, valid packet that just doesn't happen to carry one of those larger message types was rejected as too short for bytes nothing here reads.

## Fix

`required_len` now adds `2` (what's actually read) instead of `sizeof(icmpv4_hdr_t)`.

## Verification

Reproduced the exact report with a synthetic 42-byte ICMPv4 echo (14 Ethernet + 20 IPv4 + 8 ICMP, matching the issue's own byte counts) and a 62-byte ICMPv6 equivalent - confirmed both warn on the unpatched code (via `git stash`) and replay silently after the fix, not just "the warning happens to be gone now":

```
$ git stash && sudo tcpreplay -i dummy0 -l 1 -t ping0.pcap
Warning in flows.c:flow_decode() line 300:
flow_decode: packet 1 needs at least 62 bytes for ICMP header but only 42 available
...
$ git stash pop && sudo tcpreplay -i dummy0 -l 1 -t ping0.pcap
Actual: 3 packets (126 bytes) sent in 0.000465 seconds
# no warning
```

Full suite under CI's exact `asan` job config (ASan+UBSan, alignment included): 78/78, 0 sanitizer reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBmWiWg46r8BLbdwozKo6v
