### PR TITLE
common: fix undersized struct bpf_program stub; fragroute: fix uninitialized-stack debug read

### DIFF
--- a/src/defines.h.in
+++ b/src/defines.h.in
@@ -58,8 +58,15 @@
 #include <bpf/libbpf.h>
 #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
 
+/*
+ * libpcap's real struct bpf_program, reproduced verbatim: PCAP_DONT_INCLUDE_PCAP_BPF_H
+ * above hides it to avoid a struct bpf_insn clash with libbpf's headers, but
+ * tcpr_bpf_t embeds this by value, and pcap_compile()/pcap_setfilter() write
+ * through it at libpcap's real size - a zero-byte stub here was an OOB write (#1121).
+ */
 struct bpf_program {
-char dummy[0];
+    unsigned int bf_len;
+    struct bpf_insn *bf_insns;
 };
 
 #endif

--- a/src/fragroute/mod.c
+++ b/src/fragroute/mod.c
@@ -109,7 +109,7 @@ mod_open(const char *script, char *errbuf)
             break;
         }
 
-        dbgx(1, "argc = %d, %s, %s, %s", argc, argv[0], argv[1], argv[2]);
+        dbgx(1, "argc = %d, %s, %s, %s", argc, argv[0], argc > 1 ? argv[1] : "", argc > 2 ? argv[2] : "");
         /* check first keyword against modules */
         for (m = mods; *m != NULL; m++) {
             if (strcasecmp((*m)->name, argv[0]) == 0) {


### PR DESCRIPTION
## Summary
- `struct bpf_program` stub for `HAVE_LIBBPF` builds was zero-byte, but `tcpr_bpf_t` embeds it by value and libpcap writes through it at real size — OOB write on every `-f` use. Fixed by matching libpcap's real layout. Fixes #1121.
- `fragroute/mod.c`: debug logging read `argv[1]`/`argv[2]` unconditionally, past `argc` — uninitialized-stack read, intermittent crash. Found while stress-testing the above; confirmed pre-existing on baseline. Fixes #1124.

## Test plan
- [x] `sizeof(struct bpf_program)`/`sizeof(tcpr_bpf_t)` now match a non-`HAVE_LIBBPF` build
- [x] Canary test against `pcap_compile()`/`pcap_setfilter()` confirms OOB write gone
- [x] `fragroute_badrules` flakiness: 0/30 crashes after fix vs. 8-12/30 before (both baseline and patched)
- [x] `sudo make test`: 78/78 OK
