### PR TITLE
tcpedit: fix 17 -Waddress-of-packed-member warnings (#1122)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -15,6 +15,8 @@
       HAVE_LIBBPF builds, hit by tcpprep/tcpbridge's -f option (#1121)
     - fragroute: fix uninitialized-stack read in mod_open()'s debug logging, an
       intermittent crash under --dbug (#1124)
+    - tcpedit: fix 17 -Waddress-of-packed-member warnings left by #1104's packed-struct
+      fix (#1122)
 
 07/27/2026 Version 4.6.0
     - xdp: revert the top-speed default for --xdp-batch-size back to 1 (#1084) - now that sends

--- a/src/tcpedit/checksum.c
+++ b/src/tcpedit/checksum.c
@@ -26,7 +26,14 @@
 #include "checksum.h"
 #include "config.h"
 
-static int do_checksum_math(uint16_t *, int);
+/*
+ * aligned(1): callers pass &pkt_hdr->field addresses from packed wire structs
+ * (#1104) - relaxing this type's alignment carries that through the pointer
+ * parameter instead of losing it at the call boundary (#1122).
+ */
+typedef uint16_t unaligned_uint16_t __attribute__((aligned(1)));
+
+static int do_checksum_math(unaligned_uint16_t *, int);
 
 /**
  * Returns -1 on error and 0 on success, 1 on warn
@@ -95,13 +102,13 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
          * length is 2x a single IP
          */
         if (ipv6 != NULL) {
-            sum = do_checksum_math((uint16_t *)&ipv6->ip_src, 32);
+            sum = do_checksum_math((unaligned_uint16_t *)&ipv6->ip_src, 32);
         } else {
-            sum = do_checksum_math((uint16_t *)&ipv4->ip_src, 8);
+            sum = do_checksum_math((unaligned_uint16_t *)&ipv4->ip_src, 8);
         }
 
         sum += ntohs(IPPROTO_TCP + len);
-        sum += do_checksum_math((uint16_t *)tcp, len);
+        sum += do_checksum_math((unaligned_uint16_t *)tcp, len);
         tcp->th_sum = CHECKSUM_CARRY(sum);
         break;
 
@@ -116,12 +123,12 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
             break;
         udp->uh_sum = 0;
         if (ipv6 != NULL) {
-            sum = do_checksum_math((uint16_t *)&ipv6->ip_src, 32);
+            sum = do_checksum_math((unaligned_uint16_t *)&ipv6->ip_src, 32);
         } else {
-            sum = do_checksum_math((uint16_t *)&ipv4->ip_src, 8);
+            sum = do_checksum_math((unaligned_uint16_t *)&ipv4->ip_src, 8);
         }
         sum += ntohs(IPPROTO_UDP + len);
-        sum += do_checksum_math((uint16_t *)udp, len);
+        sum += do_checksum_math((unaligned_uint16_t *)udp, len);
         udp->uh_sum = CHECKSUM_CARRY(sum);
         break;
 
@@ -133,10 +140,10 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
         icmp = (icmpv4_hdr_t *)(data + ip_hl);
         icmp->icmp_sum = 0;
         if (ipv6 != NULL) {
-            sum = do_checksum_math((uint16_t *)&ipv6->ip_src, 32);
+            sum = do_checksum_math((unaligned_uint16_t *)&ipv6->ip_src, 32);
             icmp->icmp_sum = CHECKSUM_CARRY(sum);
         }
-        sum += do_checksum_math((uint16_t *)icmp, len);
+        sum += do_checksum_math((unaligned_uint16_t *)icmp, len);
         icmp->icmp_sum = CHECKSUM_CARRY(sum);
         break;
 
@@ -148,17 +155,17 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
         icmp6 = (icmpv6_hdr_t *)(data + ip_hl);
         icmp6->icmp_sum = 0;
         if (ipv6 != NULL) {
-            sum = do_checksum_math((u_int16_t *)&ipv6->ip_src, 32);
+            sum = do_checksum_math((unaligned_uint16_t *)&ipv6->ip_src, 32);
         }
         sum += ntohs(IPPROTO_ICMP6 + len);
-        sum += do_checksum_math((u_int16_t *)icmp6, len);
+        sum += do_checksum_math((unaligned_uint16_t *)icmp6, len);
         icmp6->icmp_sum = CHECKSUM_CARRY(sum);
         break;
 
     default:
         if (ipv4) {
             ipv4->ip_sum = 0;
-            sum = do_checksum_math((uint16_t *)data, ip_hl);
+            sum = do_checksum_math((unaligned_uint16_t *)data, ip_hl);
             ipv4->ip_sum = CHECKSUM_CARRY(sum);
         } else {
             tcpedit_setwarn(tcpedit, "Unsupported protocol for checksum: 0x%x", proto);
@@ -173,7 +180,7 @@ do_checksum(tcpedit_t *tcpedit, uint8_t *data, int proto, int len, const u_char 
  * code to do a ones-compliment checksum
  */
 static int
-do_checksum_math(uint16_t *data, int len)
+do_checksum_math(unaligned_uint16_t *data, int len)
 {
     int sum = 0;
     union {

--- a/src/tcpedit/edit_packet.c
+++ b/src/tcpedit/edit_packet.c
@@ -356,10 +356,17 @@ randomize_ipv4_addr(tcpedit_t *tcpedit, uint32_t ip)
     return res_ip;
 }
 
+/*
+ * aligned(1): addr is a field inside a packed wire struct (#1104) - relaxing
+ * this type's alignment carries that through the pointer instead of losing
+ * it at the call boundary (#1122).
+ */
+typedef uint32_t unaligned_uint32_t __attribute__((aligned(1)));
+
 static void
 randomize_ipv6_addr(tcpedit_t *tcpedit, struct tcpr_in6_addr *addr)
 {
-    uint32_t *p;
+    unaligned_uint32_t *p;
     int i;
     bool was_multicast;
 

--- a/src/tcpedit/incremental_checksum.h
+++ b/src/tcpedit/incremental_checksum.h
@@ -41,6 +41,16 @@ typedef uint16_t __sum16;
 typedef uint32_t __wsum;
 
 /*
+ * csum_replace*()'s sum parameter is routinely &pkt_hdr->field from one of
+ * the packed wire structs (#1104). __sum16 itself can't carry the relaxed
+ * alignment - system headers (linux/types.h) may already have their own
+ * unaligned __sum16 typedef, and GCC keeps the first declaration's alignment
+ * on redeclaration - so use a distinctly-named type for the pointer instead
+ * (#1122).
+ */
+typedef uint16_t tcpr_unaligned_sum16_t __attribute__((aligned(1)));
+
+/*
  * Fold a partial checksum
  */
 static inline __sum16
@@ -89,7 +99,7 @@ csum_unfold(__sum16 n)
 
 __wsum csum_partial(const void *buff, int len, __wsum wsum);
 static inline void
-csum_replace16(__sum16 *sum, const __be32 *from, const __be32 *to)
+csum_replace16(tcpr_unaligned_sum16_t *sum, const __be32 *from, const __be32 *to)
 {
     __be32 diff[] = {
             ~from[0],
@@ -106,13 +116,13 @@ csum_replace16(__sum16 *sum, const __be32 *from, const __be32 *to)
 }
 
 static inline void
-csum_replace4(__sum16 *sum, __be32 from, __be32 to)
+csum_replace4(tcpr_unaligned_sum16_t *sum, __be32 from, __be32 to)
 {
     *sum = csum_fold(csum_add(csum_sub(~csum_unfold(*sum), from), to));
 }
 
 static inline void
-csum_replace2(__sum16 *sum, __be16 from, __be16 to)
+csum_replace2(tcpr_unaligned_sum16_t *sum, __be16 from, __be16 to)
 {
     *sum = ~csum16_add(csum16_sub(~(*sum), from), to);
 }


### PR DESCRIPTION
## Summary
Fixes #1122. #1104 made *direct* field access to the packed wire structs well-defined, but taking a field's *address* and handing it to a function with a plain (naturally-aligned) pointer parameter loses that information at the call boundary - the callee has no way to know the pointer might be misaligned.

- `incremental_checksum.h`: `csum_replace2/4/16()`'s `sum` parameter is now `tcpr_unaligned_sum16_t *` (a `uint16_t` with `aligned(1)`) instead of `__sum16 *`. `__sum16` itself can't carry this - it turns out `linux/types.h` already typedefs `__sum16` without the attribute, and GCC keeps the *first* declaration's alignment on redeclaration, so a same-named redeclaration silently doesn't apply. A distinctly-named type sidesteps that entirely.
- `checksum.c`: `do_checksum_math()`'s parameter is now `unaligned_uint16_t *`.
- `edit_packet.c`: `randomize_ipv6_addr()`'s local `p` is now `unaligned_uint32_t *`.

No behavior change - same values read/written, just via a pointer type that accurately declares the reduced alignment instead of one that doesn't.

## Test plan
- [x] Compiled all 5 affected files with `-Waddress-of-packed-member` explicitly enabled: 0 warnings (was 17)
- [x] `sudo make test`: 78/78 OK, including the checksum/portmap/TCP-sequence tests that exercise this exact code path
