### PR TITLE
xdp: remove --xdp-batch-size (#1128)

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -17,6 +17,8 @@
       intermittent crash under --dbug (#1124)
     - tcpedit: fix 17 -Waddress-of-packed-member warnings left by #1104's packed-struct
       fix (#1122)
+    - xdp: remove --xdp-batch-size - measurement on 100GigE found no benefit from
+      raising it above the default of 1 (#1128)
 
 07/27/2026 Version 4.6.0
     - xdp: revert the top-speed default for --xdp-batch-size back to 1 (#1084) - now that sends

--- a/docs/guide/guides/fast-paths.md
+++ b/docs/guide/guides/fast-paths.md
@@ -39,10 +39,7 @@ The backend is just a flag on an otherwise normal replay. Combine it with
     default queue doesn't exist — tcpreplay warns and falls back to the default
     injection method rather than failing the run. Pass `--xdp-no-fallback` to
     turn that into a hard error, which you want when benchmarking: a silent
-    change of injector changes what's being measured. `--xdp-batch-size`
-    exists for very high-speed links (100GigE+, especially with small packets)
-    but shouldn't normally need changing — sends already pipeline across the
-    UMEM at the default batch of 1.
+    change of injector changes what's being measured.
 
 === "io_uring"
 

--- a/src/tcpreplay_api.c
+++ b/src/tcpreplay_api.c
@@ -446,16 +446,13 @@ tcpreplay_post_args(tcpreplay_t *ctx, int argc)
          * blocked on every batch completing before preparing the next packet
          * (#1084). Since sends were pipelined across the whole umem, a batch
          * of 1 reaches line rate on its own - 941 Mbps / 305k pps on a 1GigE
-         * e1000, ahead of the default injector - so 1 is the default at every
-         * speed, paced or not.
-         *
-         * The knob stays for links this can't yet saturate: 100GigE and up,
-         * especially with small (e.g. 64-byte) packets, may still benefit
-         * from a deeper batch to amortize whatever per-packet cost remains.
-         * Untested above 1GigE - if you have the hardware, --xdp-batch-size
-         * is there to try.
+         * e1000, ahead of the default injector - so 1 is used at every speed,
+         * paced or not. This used to be tunable via --xdp-batch-size for
+         * links that might still benefit from a deeper batch (100GigE and up
+         * with small packets), but measurement on 100GigE found no benefit
+         * from raising it, so the option was removed (#1128).
          */
-        ctx->intf1->batch_size = HAVE_OPT(XDP_BATCH_SIZE) ? OPT_VALUE_XDP_BATCH_SIZE : 1;
+        ctx->intf1->batch_size = 1;
 #endif
 #if defined HAVE_NETMAP
         ctx->intf1->netmap_delay = ctx->options->netmap_delay;

--- a/src/tcpreplay_opts.def
+++ b/src/tcpreplay_opts.def
@@ -747,26 +747,6 @@ EOText;
 
 flag = {
     ifdef       = HAVE_LIBXDP;
-    name        = xdp-batch-size;
-    flags-cant  = oneatatime;
-    flags-cant  = pps-multi;
-    flags-must  = xdp;
-    flags-must  = topspeed;
-  arg-type    = number;
-    arg-range   = "1->4096";
-    descrip     = "The maximum number of packets that can be submitted to the AF_XDP TX ring at once";
-    arg-default = 1;
-    doc         = <<- EOText
-Only allowed if sending at top speed. AF_XDP sends are pipelined across the
-whole UMEM regardless of this setting, so a batch of 1 already reaches line
-rate on common adapters - this should not normally need changing. It exists
-for very high speed links (100GigE and up), especially with small packet
-sizes, where a deeper batch may still help amortize per-packet overhead.
-EOText;
-};
-
-flag = {
-    ifdef       = HAVE_LIBXDP;
     name        = xdp-queue;
     flags-must  = xdp;
     arg-type    = number;


### PR DESCRIPTION
## Summary
Fixes #1128. `--xdp-batch-size` let AF_XDP top-speed sends reserve/fill more than one TX descriptor per outer loop iteration, in theory to help very high-speed links amortize per-packet overhead. Measurement on 100GigE found no benefit from raising it above the default of 1.

- `src/tcpreplay_opts.def`: drop the `xdp-batch-size` flag entirely
- `src/tcpreplay_api.c`: hardcode the AF_XDP batch size to 1 (already its effective value at every speed except `--topspeed` with the option set)
- `docs/guide/guides/fast-paths.md`: remove the now-stale mention

Man pages (`.adoc`/`.1`) are generated from `tcpreplay_opts.def` at build time and aren't committed to git, so no separate edit was needed there - confirmed the option is gone from both the regenerated man page and `--help` output.

## Test plan
- [x] `tcpreplay --help`: `--xdp-batch-size` gone
- [x] Regenerated `tcpreplay.adoc`/`tcpreplay.1`: no mention of batch size
- [x] `sudo make test`: 78/78 OK
