### PR TITLE
fragroute: fix Unexpected-exit in pktq_shuffle on empty queue

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,3 +1,10 @@
+08/14/2026 Version 4.6.2-beta1
+    - fragroute: fix an Unexpected-exit in pktq_shuffle() when the order module runs
+      against an empty packet queue (e.g. a drop rule ahead of it) - the allocation-skip
+      path for an empty queue fell through into the OOM check and called exit(-1),
+      misdiagnosing an empty queue as an allocation failure. Found by fuzz_fragroute
+      (OSS-Fuzz issue 545904182)
+
 08/11/2026 Version 4.6.1
     - common: fix two undefined-behaviour defects found by UBSan - misaligned MPLS label
       parsing, negative left shift in fragroute's ip_ttl (#1100)

--- a/src/fragroute/pkt.c
+++ b/src/fragroute/pkt.c
@@ -317,7 +317,9 @@ pktq_shuffle(rand_t *r, struct pktq *pktq)
     {
         i++;
     }
-    if (i > 0 && i > pvlen) {
+    if (i == 0)
+        return;
+    if (i > pvlen) {
         pvlen = i;
         if (pvbase == NULL)
             pvbase = malloc(sizeof(pkt) * pvlen);


### PR DESCRIPTION
## Summary
- `pktq_shuffle()` only allocated its shuffle scratch buffer when the queue was non-empty (`i > 0`), but `pvbase` starts `NULL` and is reset to `NULL` by `pkt_close()` after every fragroute context teardown.
- Shuffling an empty queue skipped allocation entirely, then hit the unconditional `if (!pvbase) err(-1, "out of memory")`, misdiagnosing an empty queue as an allocation failure and calling `exit(-1)`.
- Trigger: a rules file where `order` runs against zero packets (e.g. a `drop` rule ahead of it) — no memory pressure required, 100% reproducible.
- Fixes [OSS-Fuzz issue 545904182](https://issues.oss-fuzz.com/issues/545904182) (`fuzz_fragroute`, Unexpected-exit in `pktq_shuffle`). Severity S4/P2 — DoS-only exit, no memory corruption.
- CHANGELOG updated (4.6.2-beta1 entry).

## Test plan
- [x] `gcc -fsyntax-only` clean on `src/fragroute/pkt.c`
- [x] `sudo make test`