### PR TITLE
get: fix Unexpected-exit in get_l2len_protocol on unsupported DLT

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,11 +1,8 @@
-08/14/2026 Version 4.6.2-beta1
-    - fragroute: fix an Unexpected-exit in pktq_shuffle() when the order module runs
-      against an empty packet queue (e.g. a drop rule ahead of it) - the allocation-skip
-      path for an empty queue fell through into the OOM check and called exit(-1),
-      misdiagnosing an empty queue as an allocation failure. Found by fuzz_fragroute
-      (OSS-Fuzz issue 545904182)
-
 08/11/2026 Version 4.6.1
+    - common: fix an Unexpected-exit in get_l2len_protocol() on an unsupported DLT type -
+      errx() exited the process instead of returning -1 (OSS-Fuzz 545718476)
+    - fragroute: fix an Unexpected-exit in pktq_shuffle() on an empty packet queue -
+      an empty queue was misdiagnosed as an allocation failure (OSS-Fuzz 545904182)
     - common: fix two undefined-behaviour defects found by UBSan - misaligned MPLS label
       parsing, negative left shift in fragroute's ip_ttl (#1100)
     - ci: run UBSan alongside ASan; mark wire-format header structs packed to fix

--- a/src/common/get.c
+++ b/src/common/get.c
@@ -461,10 +461,10 @@ get_l2len_protocol(const u_char *pktdata,
         *protocol = ntohs(sll2_hdr->sll2_protocol);
         break;
     default:
-        errx(-1,
-             "Unable to process unsupported DLT type: %s (0x%x)",
-             pcap_datalink_val_to_description(datalink),
-             datalink);
+        warnx("Unable to process unsupported DLT type: %s (0x%x)",
+              pcap_datalink_val_to_description(datalink),
+              datalink);
+        return -1;
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- `get_l2len_protocol()`'s DLT switch called `errx()` — which calls `exit()` — in its `default:` case, for any DLT not in its explicit list (`DLT_NULL`, `DLT_RAW`, `DLT_JUNIPER_ETHER`, `DLT_EN10MB`, `DLT_PPP_SERIAL`, `DLT_C_HDLC`, `DLT_LINUX_SLL`, `DLT_LINUX_SLL2`).
- `datalink` comes straight from the pcap file's global header (`pcap_datalink()`), so any capture with an uncommon/unsupported linktype kills the whole process — no crafted packet payload needed.
- Every other error branch in this function returns `-1` with a `warnx()`; this was the one outlier that exited instead. Fixed to match.
- Fixes [OSS-Fuzz issue 545718476](https://issues.oss-fuzz.com/issues/545718476) (`fuzz_pcap`, Unexpected-exit in `get_l2len_protocol`). Severity S4/P2 — DoS-only exit, no memory corruption.
- CHANGELOG updated under 4.6.1 (no release tag exists yet for that version).

## Test plan
- [x] `sudo make test`