### PR TITLE
fragroute: fix heap-buffer-overflow in ip_chaff_apply's option insertion

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,7 @@
 08/11/2026 Version 4.6.1
+    - fragroute: fix a heap-buffer-overflow in ip_chaff_apply()'s option insertion -
+      a 2-byte buffer-capacity miscalculation let libdnet write past the allocation
+      (OSS-Fuzz 545965630)
     - common: fix an Unexpected-exit in get_l2len_protocol() on an unsupported DLT type -
       errx() exited the process instead of returning -1 (OSS-Fuzz 545718476)
     - fragroute: fix an Unexpected-exit in pktq_shuffle() on an empty packet queue -

--- a/src/fragroute/mod_ip_chaff.c
+++ b/src/fragroute/mod_ip_chaff.c
@@ -99,7 +99,11 @@ ip_chaff_apply(void *d, struct pktq *pktq)
             if (eth_type == ETH_TYPE_IP) {
                 opt.opt_type = 0x42;
                 opt.opt_len = IP_OPT_LEN;
-                i = ip_add_option(new->pkt_ip, new->pkt_buf_size - ETH_HDR_LEN, IP_PROTO_IP, &opt, opt.opt_len);
+                i = ip_add_option(new->pkt_ip,
+                                  new->pkt_buf + new->pkt_buf_size - (u_char *)new->pkt_ip,
+                                  IP_PROTO_IP,
+                                  &opt,
+                                  opt.opt_len);
                 /* XXX - whack opt with random crap */
                 *(uint32_t *)new->pkt_ip_data = rand_uint32(data->rnd);
                 new->pkt_ip_data += i;


### PR DESCRIPTION
## Summary
- `ip_chaff_apply()`'s `CHAFF_TYPE_OPT` case computed the buffer capacity passed to libdnet's `ip_add_option()` as `new->pkt_buf_size - ETH_HDR_LEN`, which assumes `pkt_ip == pkt_buf + ETH_HDR_LEN`.
- That's wrong: `pkt_data` (and everything derived from it, including `pkt_ip`) actually starts at `pkt_buf + PKT_BUF_ALIGN` (2 bytes further in) — see `pkt_new()`/`pkt_dup()` in `pkt.c`.
- So the capacity handed to `ip_add_option()` overstated real room by `PKT_BUF_ALIGN` (2) bytes, and libdnet wrote the inserted IP option 2 bytes past the end of the heap allocation — matches the fuzzer's `Heap-buffer-overflow WRITE 2` exactly.
- `mod_ip_opt.c`'s `ip_opt_apply()` already computes this correctly: `pkt->pkt_buf + pkt->pkt_buf_size - (u_char *)pkt->pkt_ip` (buffer-end minus the actual `pkt_ip` pointer, not a hardcoded offset). Brought `ip_chaff_apply()` in line with it.
- Fixes [OSS-Fuzz issue 545965630](https://issues.oss-fuzz.com/issues/545965630) (`fuzz_fragroute`, Heap-buffer-overflow in `ip_add_option`). Severity **S1/P2, Recommended Security Severity: High** — real memory corruption (write), unlike the two prior DoS-only exit() bugs.

## Test plan
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)