### PR TITLE
fragroute: fix pointer corruption in ip_chaff_apply on failed option insert

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,7 @@
 08/11/2026 Version 4.6.1
+    - fragroute: fix pointer corruption in ip_chaff_apply() on a failed option insert -
+      an unchecked -1 return shifted pkt_ip_data out of bounds, causing an OOB read
+      downstream in ip_checksum() (OSS-Fuzz 545925319)
     - fragroute: fix a heap-buffer-overflow in ip_chaff_apply()'s option insertion -
       a 2-byte buffer-capacity miscalculation let libdnet write past the allocation
       (OSS-Fuzz 545965630)

--- a/src/fragroute/mod_ip_chaff.c
+++ b/src/fragroute/mod_ip_chaff.c
@@ -104,11 +104,13 @@ ip_chaff_apply(void *d, struct pktq *pktq)
                                   IP_PROTO_IP,
                                   &opt,
                                   opt.opt_len);
-                /* XXX - whack opt with random crap */
-                *(uint32_t *)new->pkt_ip_data = rand_uint32(data->rnd);
-                new->pkt_ip_data += i;
-                new->pkt_end += i;
-                ip_checksum(new->pkt_ip, new->pkt_ip_data - new->pkt_eth_data);
+                if (i > 0) {
+                    /* XXX - whack opt with random crap */
+                    *(uint32_t *)new->pkt_ip_data = rand_uint32(data->rnd);
+                    new->pkt_ip_data += i;
+                    new->pkt_end += i;
+                    ip_checksum(new->pkt_ip, new->pkt_ip_data - new->pkt_eth_data);
+                }
             } else if (eth_type == ETH_TYPE_IPV6) {
                 continue;
             }


### PR DESCRIPTION
## Summary
- `ip_add_option()` can fail (`-1`, e.g. not enough room), but `ip_chaff_apply()`'s `CHAFF_TYPE_OPT` case used its return value `i` unconditionally: wrote 4 bytes of random data at `pkt_ip_data` assuming success, then did `pkt_ip_data += i` / `pkt_end += i` with `i == -1` — silently shifting `pkt_ip_data` backward by a byte on every failed call.
- `mod_apply()` runs each rules-file directive over the whole evolving `pktq`, so a rules file stacking several `ip_chaff opt` directives re-duplicates and re-shifts the same packet lineage each time. `pkt_ip_data` can walk backward past `pkt_eth_data`, and any later `pkt_ip_data - pkt_eth_data` (e.g. `ip_tos_apply`'s checksum call) underflows to a huge unsigned length, driving libdnet's `ip_checksum()`/`ip_cksum_add()` into an out-of-bounds read.
- `mod_ip_opt.c`'s `ip_opt_apply()` already gets this right — only acts on `ip_add_option()`'s result when it's positive ([mod_ip_opt.c:91](https://github.com/appneta/tcpreplay/blob/master/src/fragroute/mod_ip_opt.c#L91)). Brought `ip_chaff_apply()` in line with it.
- Fixes [OSS-Fuzz issue 545925319](https://issues.oss-fuzz.com/issues/545925319) (`fuzz_fragroute`/honggfuzz, `UNKNOWN READ` in `ip_cksum_add`). Severity S2/P2, Recommended Security Severity: Medium.
- Builds on the buffer-capacity fix in #1132 (same function, different bug — that one was an OOB *write* from a wrong capacity calc; this one is pointer corruption from an unchecked error return).

## Test plan
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)