### PR TITLE
fragroute: fix null-deref in raw_ip_opt_parse on too-few args

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,6 @@
 08/11/2026 Version 4.6.1
+    - fragroute: fix a null-deref in raw_ip_opt_parse() when a "tcp_opt raw" rule
+      supplies too few tokens (OSS-Fuzz 545904184)
     - fragroute: fix pointer corruption in ip_chaff_apply() on a failed option insert -
       an unchecked -1 return shifted pkt_ip_data out of bounds, causing an OOB read
       downstream in ip_checksum() (OSS-Fuzz 545925319)

--- a/src/fragroute/iputil.c
+++ b/src/fragroute/iputil.c
@@ -96,6 +96,10 @@ raw_ip_opt_parse(int argc, char *argv[], uint8_t *opt_type, uint8_t *opt_len, ui
 {
     int i, j;
 
+    if (argc < 2) {
+        warn("raw option needs at least a type and a length");
+        return -1;
+    }
     if (sscanf(argv[0], "%hhx", opt_type) != 1) {
         warn("invalid opt_type");
         return -1;


### PR DESCRIPTION
## Summary
- `raw_ip_opt_parse()` reads `argv[0]` (opt_type) and `argv[1]` (opt_len) unconditionally, without checking `argc >= 2` first.
- `mod_tcp_opt.c`'s `tcp_opt_open()` only requires `argc >= 3` for the whole `tcp_opt` directive (enough for `tcp_opt mss <size>`), then for the `raw` sub-command passes `argc - 2` straight through ([mod_tcp_opt.c:58](https://github.com/appneta/tcpreplay/blob/master/src/fragroute/mod_tcp_opt.c#L58)). A rules-file line of exactly `tcp_opt raw <one-token>` (`argc == 3`) satisfies that gate but leaves `argc - 2 == 1` — one token short of what `raw_ip_opt_parse` needs. It reads `argv[1]`, past the actual token array, onto a NULL terminator, and `sscanf(NULL, ...)` null-derefs.
- `mod_ip_opt.c`'s `ip_opt_open()` happens to be safe here — its own overall `argc >= 4` gate guarantees `argc - 2 >= 2` for its `raw` branch too — but the bug belongs in the shared parser, not each caller's numeric threshold. Fixed at the shared function.
- Fixes [OSS-Fuzz issue 545904184](https://issues.oss-fuzz.com/issues/545904184) (`fuzz_fragroute`/afl, `Null-dereference READ` in `raw_ip_opt_parse`). Severity S4/P2 — DoS-only crash, no memory corruption.

## Test plan
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)