### PR TITLE
fragroute: fix null-deref in delay_apply on empty packet queue

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,6 @@
 08/11/2026 Version 4.6.1
+    - fragroute: fix a null-deref in delay_apply() on an empty packet queue
+      (OSS-Fuzz 545965632)
     - fragroute: fix a null-deref in raw_ip_opt_parse() when a "tcp_opt raw" rule
       supplies too few tokens (OSS-Fuzz 545904184)
     - fragroute: fix pointer corruption in ip_chaff_apply() on a failed option insert -

--- a/src/fragroute/mod_delay.c
+++ b/src/fragroute/mod_delay.c
@@ -80,6 +80,9 @@ delay_apply(void *d, struct pktq *pktq)
     else
         pkt = pktq_random(data->rnd, pktq);
 
+    if (pkt == NULL)
+        return (0);
+
     memcpy(&pkt->pkt_ts, &data->tv, sizeof(pkt->pkt_ts));
 
     return (0);


### PR DESCRIPTION
## Summary
- `delay_apply()` picks a packet via `TAILQ_FIRST`/`TAILQ_LAST`/`pktq_random` and unconditionally `memcpy`'s into its `pkt_ts`, without checking for `NULL`.
- All three return `NULL` on an empty `pktq` — e.g. a rules file where an earlier `drop` rule removes every packet before `delay` runs.
- Same class of bug as `pktq_shuffle`'s fix in #1130: a mangling module that doesn't handle an empty queue.
- Fixes [OSS-Fuzz issue 545965632](https://issues.oss-fuzz.com/issues/545965632) (`fuzz_fragroute`, `Null-dereference` in `delay_apply`). Severity S4/P2 — DoS-only crash, no memory corruption.

## Test plan
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)