### PR TITLE
fragroute: wire up mod_close() to fix leak of the module chain

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,7 @@
 08/11/2026 Version 4.6.1
+    - fragroute: wire up mod_close(), which was implemented but never called -
+      fragroute_close() leaked the whole parsed rule chain on every call
+      (OSS-Fuzz 545818605)
     - fragroute: fix a null-deref in delay_apply() on an empty packet queue
       (OSS-Fuzz 545965632)
     - fragroute: fix a null-deref in raw_ip_opt_parse() when a "tcp_opt raw" rule

--- a/src/fragroute/fragroute.c
+++ b/src/fragroute/fragroute.c
@@ -37,6 +37,7 @@ void
 fragroute_close(fragroute_t *ctx)
 {
     assert(ctx);
+    mod_close();
     free(ctx->pktq);
     free(ctx);
     pkt_close();


### PR DESCRIPTION
## Summary
- `mod_close()` frees every parsed rule and each module's own `data` — it's fully implemented in `mod.c` ([mod.c:184](https://github.com/appneta/tcpreplay/blob/master/src/fragroute/mod.c#L184)) — but was never called anywhere in the codebase.
- `fragroute_close()` freed `ctx->pktq`, `ctx`, and called `pkt_close()`, but never `mod_close()`, so the rule chain `mod_open()` builds leaked on **every** `fragroute_close()` call — not just on rules-file parse-failure paths.
- This leaks in ordinary use too (`tcprewrite --fragroute`, `tcpbridge`), just invisibly, since a one-shot process reclaims memory on exit. LeakSanitizer catches it via `fuzz_fragroute`, which calls `fragroute_close()` every iteration in the same persistent process.
- Fixes [OSS-Fuzz issue 545818605](https://issues.oss-fuzz.com/issues/545818605) (`fuzz_fragroute`, `Direct-leak` in `mod_open`). Severity S4/P2 — memory leak, not memory corruption.

## Test plan
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)