### PR TITLE
fragroute: fix rand_t leak in ip_frag_open/tcp_seg_open on repeated directive

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,6 @@
 08/11/2026 Version 4.6.1
+    - fragroute: fix a rand_t leak in ip_frag_open()/tcp_seg_open() when a rules
+      file repeats "ip_frag" or "tcp_seg" (OSS-Fuzz 545925322)
     - fragroute: wire up mod_close(), which was implemented but never called -
       fragroute_close() leaked the whole parsed rule chain on every call
       (OSS-Fuzz 545818605)

--- a/src/fragroute/mod_ip_frag.c
+++ b/src/fragroute/mod_ip_frag.c
@@ -51,6 +51,8 @@ ip_frag_open(int argc, char *argv[])
         warn("need fragment <size> in bytes");
         return (NULL);
     }
+    if (ip_frag_data.rnd != NULL)
+        rand_close(ip_frag_data.rnd);
     ip_frag_data.rnd = rand_open();
     ip_frag_data.size = (int)strtol(argv[1], NULL, 10);
 

--- a/src/fragroute/mod_tcp_seg.c
+++ b/src/fragroute/mod_tcp_seg.c
@@ -47,6 +47,8 @@ tcp_seg_open(int argc, char *argv[])
         warn("need segment <size> in bytes");
         return (NULL);
     }
+    if (tcp_seg_data.rnd != NULL)
+        rand_close(tcp_seg_data.rnd);
     tcp_seg_data.rnd = rand_open();
 
     /*


### PR DESCRIPTION
## Summary
- `ip_frag_open()` and `tcp_seg_open()` store their `rand_t` in a `static`, file-scope struct rather than a fresh per-rule heap allocation like every other module (`delay`, `drop`, `ip_chaff`, `order`, `dup`, `tcp_chaff` all `calloc`/`malloc` a new `data` struct per directive).
- Each call unconditionally did `.rnd = rand_open()`, so a rules file repeating `ip_frag` or `tcp_seg` more than once overwrote the static field on the second call, discarding the first `rand_open()` result without ever closing it — leaked at open time, independent of whether `mod_close()` runs at teardown (it only closes the *last* one).
- Fixed by closing any existing handle before opening a new one, matching the pattern already used at teardown (`ip_frag_close`/`tcp_seg_close`).
- Distinct from #1136 (`mod_close()` never wired up) — that fix doesn't cover this case, since the leak happens at *open* time on the second occurrence of the directive, before teardown is ever reached.
- Fixes [OSS-Fuzz issue 545925322](https://issues.oss-fuzz.com/issues/545925322) (`fuzz_fragroute`, `Direct-leak` in `rand_open`). Severity S4/P2 — memory leak, not memory corruption.

## Test plan
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)