### PR TITLE
fragroute: bound mod_apply() against exponential packet-count growth

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,6 @@
 08/11/2026 Version 4.6.1
+    - fragroute: bound mod_apply() against exponential packet-count growth from
+      duplicating rules like "ip_chaff"/"tcp_chaff" (OSS-Fuzz 546146015)
     - fragroute: fix a rand_t leak in ip_frag_open()/tcp_seg_open() when a rules
       file repeats "ip_frag" or "tcp_seg" (OSS-Fuzz 545925322)
     - fragroute: wire up mod_close(), which was implemented but never called -

--- a/src/fragroute/mod.c
+++ b/src/fragroute/mod.c
@@ -170,14 +170,41 @@ mod_open(const char *script, char *errbuf)
     return (ret);
 }
 
+/*
+ * Modules like ip_chaff and tcp_chaff duplicate every packet currently in
+ * the queue each time they're applied, so a rules file stacking enough of
+ * those directives doubles the packet count - and total work - on each one:
+ * 2^n growth in the number of such directives.  A rules file well within
+ * any legitimate use turns one input packet into gigabytes of output and
+ * runs for minutes.  Real fragroute usage - fragmenting/duplicating one
+ * packet through a short, hand-written rules file - never approaches this
+ * many fragments, so stop applying further rules once the queue crosses it
+ * rather than let a pathological rules file run unbounded.
+ */
+#define MOD_APPLY_MAX_PACKETS 8192
+
 void
 mod_apply(struct pktq *pktq)
 {
     struct rule *rule;
+    struct pkt *pkt;
+    unsigned int count;
 
     TAILQ_FOREACH(rule, &rules, next)
     {
         rule->mod->apply(rule->data, pktq);
+
+        count = 0;
+        TAILQ_FOREACH(pkt, pktq, pkt_next)
+        {
+            count++;
+        }
+        if (count > MOD_APPLY_MAX_PACKETS) {
+            warnx("rule chain produced %u packets, stopping further rule application (limit %u)",
+                  count,
+                  MOD_APPLY_MAX_PACKETS);
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Modules like `ip_chaff` and `tcp_chaff` duplicate every packet currently in the queue each time they're applied, so a rules file stacking enough of those directives doubles the packet count — and total work — on each one: 2^n growth in the number of such directives.
- Confirmed empirically against the real `tcprewrite --fragroute` binary: `ip_chaff dup` repeated 15 times took 31s and produced 159MB of output from one input packet; 20 repeats didn't finish in 2 minutes. A rules file well within the fuzzer's 64KB input cap reaches this.
- `mod_apply()` now checks the packet count *between* rule applications (not inside them — a single `apply()` at most doubles the queue, so checking between bounds the worst case at 2× the limit) and stops applying further rules with a warning once it's crossed, rather than returning failure — rules already applied still take effect, matching how other apply paths handle a partial/bounded outcome.
- Real fragroute usage — fragmenting/duplicating one packet through a short, hand-written rules file — never approaches the 8192-packet limit; verified `fragroute_valid`/`fragroute_negsize`/`fragroute_badrules` are unaffected.
- Fixes [OSS-Fuzz issue 546146015](https://issues.oss-fuzz.com/issues/546146015) (`fuzz_fragroute`, `Timeout (exceeds 60 secs)`).

## Decision
This is a policy call (harness-level cap vs. library-level bound), discussed with the repo owner — chose library-level, since `mod_apply()` is the one chokepoint covering `dup`, `ip_chaff`, `tcp_chaff`, `ip_frag`, `tcp_seg`, and any future duplicating module, protecting real `tcprewrite --fragroute`/`tcpbridge` callers against a pathological rules file, not just the fuzz harness.

## Test plan
- [x] Empirically verified: capped output plateaus at ~79.5MB/~6.2s regardless of rule count (tested 15/20/30 stacked `ip_chaff dup` rules, all identical once past the cap)
- [x] `sudo make test` — all `[tcprewrite] Fragroute *` tests pass; full suite clean except a pre-existing, unrelated `replay_unique_ip` segfault (also present before this change, passes in CI)