### PR TITLE
common: reject cache files whose packets_per_byte doesn't match the hardcoded stride

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,7 @@
 08/11/2026 Version 4.6.1
+    - common: reject cache files whose packets_per_byte doesn't match the hardcoded
+      indexing stride, an OOB read via tcpprep/tcpreplay/tcprewrite --cachefile
+      (GHSA-p3f2-88rg-9mch)
     - fragroute: bound mod_apply() against exponential packet-count growth from
       duplicating rules like "ip_chaff"/"tcp_chaff" (OSS-Fuzz 546146015)
     - fragroute: fix a rand_t leak in ip_frag_open()/tcp_seg_open() when a rules

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -109,6 +109,22 @@ read_cache(char **cachedata, const char *cachefile, char **comment)
     /* malloc our cache block */
     header.num_packets = ntohll(header.num_packets);
     header.packets_per_byte = ntohs(header.packets_per_byte);
+
+    /*
+     * The on-disk field is informational only: every reader indexes with the
+     * compile-time CACHE_PACKETS_PER_BYTE, never header.packets_per_byte. A
+     * mismatching value would size this allocation by one stride while
+     * check_cache() and friends walk it with another, reading out of bounds.
+     * Reject anything that doesn't match rather than trust a file-controlled
+     * divisor (which could also be zero).
+     */
+    if (header.packets_per_byte != CACHE_PACKETS_PER_BYTE)
+        errx(-1,
+             "Unable to process %s: unsupported packets_per_byte %u (expected %u)",
+             cachefile,
+             header.packets_per_byte,
+             CACHE_PACKETS_PER_BYTE);
+
     cache_size = header.num_packets / header.packets_per_byte;
 
     /* deal with any remainder, because above division is integer */


### PR DESCRIPTION
## Summary
- `read_cache()` sized the allocation with the file-controlled `header.packets_per_byte`, but every consumer (`check_cache()` and friends) always indexes with the compile-time constant `CACHE_PACKETS_PER_BYTE` (4) — the two were never cross-checked.
- A crafted cache file claiming a large `packets_per_byte` collapses the allocation while `check_cache()`'s indexing still walks it at a stride of 4, reading far past the buffer.
- The on-disk field is informational only in practice — the writer always emits `CACHE_PACKETS_PER_BYTE` — so this rejects anything else at read time rather than trust a file-controlled divisor for buffer sizing (which could also be zero).
- Reachable via `tcpprep --print-info`/`--print-comment`/`--print-stats` and `tcpreplay`/`tcprewrite --cachefile` on an attacker-supplied cache file.
- Fixes [GHSA-p3f2-88rg-9mch](https://github.com/appneta/tcpreplay/security/advisories/GHSA-p3f2-88rg-9mch), reported by tao pan ([@pant0m](https://github.com/pant0m)). Severity medium (CVSS 6.1), local-only + user-interaction required, DoS + low-bandwidth heap-content read oracle.

## Test plan
- [x] Reproduced the advisory's exact PoC cache file (`packets_per_byte=65535`, `num_packets=60000`) — before the fix, ASAN caught a heap-buffer-overflow read in `check_cache()`; after, `tcpprep --print-info` cleanly rejects it: `Unable to process evil.cache: unsupported packets_per_byte 65535 (expected 4)` (exit 255, no crash)
- [x] Verified a legitimate cache file generated by real `tcpprep --auto=first` still reads and prints correctly