### PR TITLE
tcpliveplay: fix three heap OOB reads on a crafted pcap

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,7 @@
 08/11/2026 Version 4.6.1
+    - tcpliveplay: fix three heap OOB reads on a crafted pcap - an unclamped memcpy
+      length, missing minimum-caplen checks, and unbounded recovery-scan loops
+      (GHSA-4hqm-8v2c-9pwj)
     - common: reject cache files whose packets_per_byte doesn't match the hardcoded
       indexing stride, an OOB read via tcpprep/tcpreplay/tcprewrite --cachefile
       (GHSA-p3f2-88rg-9mch)

--- a/src/tcpliveplay.c
+++ b/src/tcpliveplay.c
@@ -502,10 +502,26 @@ setup_sched(struct tcp_sched *schedule)
         pkt_counter++; /*increment number of packets seen*/
 
         memcpy(&schedule[i].pkthdr, &header, sizeof(struct pcap_pkthdr));
-        schedule[i].packet_ptr = safe_malloc(schedule[i].pkthdr.len);
-        memcpy(schedule[i].packet_ptr, packet, schedule[i].pkthdr.len);
+
+        /*
+         * Copy only what was actually captured. header.len can exceed
+         * header.caplen for a truncated capture; copying len bytes out of a
+         * caplen-sized libpcap read buffer reads past its end. sendpacket()
+         * later transmits packet_ptr for pkthdr.len bytes too, so len must be
+         * clamped to what's actually allocated or that over-read happens
+         * again at send time.
+         */
+        if (schedule[i].pkthdr.len > schedule[i].pkthdr.caplen)
+            schedule[i].pkthdr.len = schedule[i].pkthdr.caplen;
+        schedule[i].packet_ptr = safe_malloc(schedule[i].pkthdr.caplen);
+        memcpy(schedule[i].packet_ptr, packet, schedule[i].pkthdr.caplen);
 
         /* extract necessary data */
+        if (schedule[i].pkthdr.caplen < SIZE_ETHERNET + sizeof(ipv4_hdr) + sizeof(tcp_hdr)) {
+            printf("ERROR: Packet too short to contain Ethernet/IP/TCP headers: %u bytes\n",
+                   schedule[i].pkthdr.caplen);
+            return 0;
+        }
         etherhdr = (ether_hdr *)(schedule[i].packet_ptr);
         iphdr = (ipv4_hdr *)(schedule[i].packet_ptr + SIZE_ETHERNET);
         size_ip = iphdr->ip_hl << 2;
@@ -710,6 +726,10 @@ got_packet(_U_ u_char *args, _U_ const struct pcap_pkthdr *header, const u_char 
     unsigned int flags;
 
     /* Extract and examine received packet headers */
+    if (header->caplen < SIZE_ETHERNET + sizeof(ipv4_hdr) + sizeof(tcp_hdr)) {
+        printf("ERROR: Packet too short to contain Ethernet/IP/TCP headers: %u bytes\n", header->caplen);
+        return;
+    }
     iphdr = (ipv4_hdr *)(packet + SIZE_ETHERNET);
     size_ip = iphdr->ip_hl << 2;
     if (size_ip < 20) {
@@ -757,9 +777,11 @@ got_packet(_U_ u_char *args, _U_ const struct pcap_pkthdr *header, const u_char 
         // printf("Remote Packet Loss! Resending Lost packet\n");
         sched_index = acked_index; /* Reset the schedule index back to the last correctly ACKed packet */
         // printf("ACKED Index = %d\n", acked_index);
-        while (!sched[sched_index].local) {
+        while (sched_index < pkts_scheduled && !sched[sched_index].local) {
             sched_index++;
         }
+        if (sched_index >= pkts_scheduled)
+            printf("ERROR: schedule recovery scan ran past the end of the schedule\n");
         return;
     }
 
@@ -771,9 +793,11 @@ got_packet(_U_ u_char *args, _U_ const struct pcap_pkthdr *header, const u_char 
         sched_index = acked_index; /* Reset the schedule index back to the last correctly ACKed packet */
         /*sched[sched_index].sent_counter=0; Reset the re-transmission counter for this ACKed packet?*/
         // printf("ACKED Index = %d\n", acked_index);
-        while (!sched[sched_index].local) {
+        while (sched_index < pkts_scheduled && !sched[sched_index].local) {
             sched_index++;
         }
+        if (sched_index >= pkts_scheduled)
+            printf("ERROR: schedule recovery scan ran past the end of the schedule\n");
         return;
     }
 
@@ -793,9 +817,11 @@ got_packet(_U_ u_char *args, _U_ const struct pcap_pkthdr *header, const u_char 
             /* packets were received matching expectation*/
             sched_index = acked_index; /* Reset the schedule index back to the last correctly ACKed packet */
             // printf("ACKED Index = %d\n", acked_index);
-            while (!sched[sched_index].local) {
+            while (sched_index < pkts_scheduled && !sched[sched_index].local) {
                 sched_index++;
             }
+            if (sched_index >= pkts_scheduled)
+                printf("ERROR: schedule recovery scan ran past the end of the schedule\n");
             return;
         }
         printf("Remote Packet Expectation met.\nProceeding in replay....\n");
@@ -939,6 +965,10 @@ rewrite(input_addr *new_remoteip,
         if (!warned && header->len > header->caplen) {
             fprintf(stderr, "warning: packet capture truncated to %d byte packets\n", header->caplen);
             warned = true;
+        }
+        if (header->caplen < SIZE_ETHERNET + sizeof(ipv4_hdr) + sizeof(tcp_hdr)) {
+            printf("ERROR: Packet too short to contain Ethernet/IP/TCP headers: %u bytes\n", header->caplen);
+            return ERROR;
         }
         etherhdr = (ether_hdr *)(packet);
         iphdr = (ipv4_hdr *)(packet + SIZE_ETHERNET);


### PR DESCRIPTION
## Summary
All three reachable from tcpliveplay's primary untrusted input, the user-supplied pcap file:

- **`setup_sched()`** copied `pkthdr.len` bytes from a `pkthdr.caplen`-sized libpcap read buffer. For an ordinary truncated capture (`len > caplen`) this reads past that buffer, and since `sendpacket()` later transmits `packet_ptr` for `pkthdr.len` bytes, the over-read heap content could reach the live network peer. Now copies `caplen` bytes and clamps `pkthdr.len` down to match, so neither the copy nor the later send can run past what's actually allocated.
- **`setup_sched()`, `rewrite()` and `got_packet()`** all dereferenced `ip_hl`/`th_off` without first checking `caplen` was large enough to contain an Ethernet+IP+TCP header — a regression against the sibling guard already present at `tcpprep.c:465`. Added the same minimum-caplen check at all three sites.
- **`got_packet()`'s three packet-loss recovery scans** (`while (!sched[sched_index].local) sched_index++;`) had no upper bound against `pkts_scheduled`. A capture whose tail is all server-originated packets (e.g. an ordinary FIN/ACK teardown) walks the scan off the end of the `sched` array. Added a `pkts_scheduled` bound to all three, with an error message on overrun instead of reading out of bounds.

Fixes [GHSA-4hqm-8v2c-9pwj](https://github.com/appneta/tcpreplay/security/advisories/GHSA-4hqm-8v2c-9pwj), reported by tao pan ([@pant0m](https://github.com/pant0m)). Severity: reliable DoS via any of the three; variant (a) additionally leaks adjacent heap memory onto the live network. Read primitives only, no write/RCE demonstrated. Running `tcpliveplay` legitimately requires root + a live interface (inherent to a packet-injection tool), but the untrusted input is the pcap file contents, not the privilege level.

## Test plan
- [ ] `sudo make test` (couldn't verify locally — this build has `tcpliveplay support: no`, since it needs Linux-only `SIOCGIFHWADDR`/`ifr_hwaddr`, unrelated to this fix)
- [x] Standalone syntax/type-check against the changed file: zero errors on the changed lines, confirming no new syntax/type issues; the only pre-existing errors are the unrelated `SIOCGIFHWADDR` platform gap. CI's Linux build is the real compile check for this file.