### PR TITLE
tcpedit: fix inverted bounds check in dlt_radiotap_get_80211()

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,4 +1,7 @@
 08/11/2026 Version 4.6.1
+    - tcpedit: fix an inverted bounds check in dlt_radiotap_get_80211() that made
+      an oversized memcpy() run exactly when it was guaranteed to overflow
+      (GHSA-pmmx-m8p5-969j)
     - tcpliveplay: fix three heap OOB reads on a crafted pcap - an unclamped memcpy
       length, missing minimum-caplen checks, and unbounded recovery-scan loops
       (GHSA-4hqm-8v2c-9pwj)

--- a/src/tcpedit/plugins/dlt_radiotap/radiotap.c
+++ b/src/tcpedit/plugins/dlt_radiotap/radiotap.c
@@ -364,7 +364,7 @@ dlt_radiotap_get_80211(tcpeditdlt_t *ctx, const u_char *packet, int pktlen, int 
         return NULL;
 
     extra = (radiotap_extra_t *)(ctx->decoded_extra);
-    if (pktlen >= radiolen && (size_t)(pktlen - radiolen) >= sizeof(extra->packet) &&
+    if (pktlen >= radiolen && (size_t)(pktlen - radiolen) <= sizeof(extra->packet) &&
         lastpacket != ctx->tcpedit->runtime.packetnum) {
         memcpy(extra->packet, &packet[radiolen], pktlen - radiolen);
         lastpacket = ctx->tcpedit->runtime.packetnum;


### PR DESCRIPTION
## Summary
Cherry-pick of commit \`2a4d479e\`, already merged to \`master\` via the GHSA-pmmx-m8p5-969j private security fork PR, onto \`4.6.1-beta1\` for consistency with today's other fixes.

- The guard meant to stop \`memcpy()\` from overflowing the fixed 262166-byte \`extra->packet\` buffer used \`>=\` where it needed \`<=\`, so the copy ran *exactly when it was guaranteed to overflow* — every packet that would fit safely was skipped instead.
- Introduced in \`441e82e4\` (Jan 2018), which was meant to *add* this bounds check; the broken guard existed ~8 years.
- **Not reachable through the bundled CLIs** — each clamps \`caplen\` before calling \`tcpedit_packet()\`. Only reachable by third-party code linking libtcpedit directly on unclamped input.
- Fixes [GHSA-pmmx-m8p5-969j](https://github.com/appneta/tcpreplay/security/advisories/GHSA-pmmx-m8p5-969j), reported by tao pan ([@pant0m](https://github.com/pant0m)). Realistic RCE potential.

## Test plan
- [x] Verified in the private fork with the advisory's own PoC technique — before: ASAN aborts on a 299992-byte write into a 262166-byte buffer; after: copy correctly skipped, no crash