### PR TITLE
build: move LICENSE to repo root, strip custom preamble

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,3 @@
-Please note that this license covers the files that I have written.
-Some files distributed with the Tcpreplay Suite are copyrighted by 
-other authors and have a different license.  These files & directories
-are marked as such.  If you have questions about the licensing that
-applies to various Tcpreplay files or modules, please contact the 
-author: Aaron Turner.
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,7 @@ DISTCLEANFILES = .tm_project.cache stamp-h1 *.tar.*
 
 MAINTAINERCLEANFILES = Makefile.in configure *.bak
 
-EXTRA_DIST = doxygen.cfg.in \
+EXTRA_DIST = doxygen.cfg.in LICENSE \
 	m4/libtool.m4 m4/ltoptions.m4 m4/ltsugar.m4 \
 	m4/ltversion.m4 m4/lt~obsolete.m4 acinclude.m4 \
 	CMakeLists.txt CMakePresets.json \

--- a/README.md
+++ b/README.md
@@ -308,7 +308,13 @@ License
 =======
 Tcpreplay is licensed under [GPLv3], and includes software developed by the
 University of California, Berkeley, Lawrence Berkeley Laboratory and its
-contributors. See [`docs/LICENSE`](docs/LICENSE) for the full text.
+contributors. See [`LICENSE`](LICENSE) for the full text.
+
+This covers the files written for the project; some files distributed with
+the Tcpreplay Suite are copyrighted by other authors and carry a different
+license, and are marked as such in-file. Questions about the licensing that
+applies to a specific file or module can go to the
+[tcpreplay-users mailing list](https://sourceforge.net/p/tcpreplay/mailman/tcpreplay-users/).
 
 Authors
 =======

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -36,7 +36,7 @@ postweb: manpages
 	scp CHANGELOG TODO aturner@malbec.synfin.net:/var/vhosts/tcpreplay/
 
 
-EXTRA_DIST = CHANGELOG CREDIT HACKING INSTALL LICENSE Win32Readme.txt
+EXTRA_DIST = CHANGELOG CREDIT HACKING INSTALL Win32Readme.txt
 
 clean-docs: clean
 	-rm -f web/*.html

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -20,7 +20,7 @@ In the near future expect native support for Windows (volunteers please). For mo
 please read the Win32Readme.txt file.
 
 ## How is Tcpreplay licensed?
-Tcpreplay is licensed under [GPLv3][gplv3]. For details see the docs/LICENSE file included 
+Tcpreplay is licensed under [GPLv3][gplv3]. For details see the LICENSE file included 
 with the source code.
 
 ## Running Tcpreplay


### PR DESCRIPTION
## Summary
- GitHub's license detector (`licensee`) only looks for `LICENSE` at the repo root — `docs/LICENSE` wasn't being detected at all, which is why the community-standards page still showed "Add a license" and the community profile's `license` field read `null`.
- Separately, `docs/LICENSE` had a 6-line custom preamble prepended directly to the GPL-3.0 text ("this covers the files I've written, contact Aaron Turner for other licensing questions") — exactly the kind of thing that drops `licensee`'s fuzzy-match confidence even after moving to root.
- `LICENSE` now contains only the canonical GPL-3.0 text. The preamble's content moved into README's License section, which is where a reader would look for that scope clarification anyway.
- Updated the `EXTRA_DIST` reference from `docs/Makefile.am` to the top-level `Makefile.am` so `make dist` still packages it from the new location.
- Fixed the two remaining `docs/LICENSE` references (`README.md`, `docs/guide/faq.md`).

## Test plan
- [x] Verified with a fresh `./autogen.sh` that the `Makefile.am` `EXTRA_DIST` changes are valid (no errors)
- [x] Confirmed no other tracked references to `docs/LICENSE` remain