### PR TITLE
skills: add delete-merged-branch, release-checklist, security-advisory-triage

### DIFF
--- a/.claude/skills/delete-merged-branch/skill.md
+++ b/.claude/skills/delete-merged-branch/skill.md
@@ -1,0 +1,52 @@
+---
+name: Delete Merged Branch
+description: After merging a PR in this repo, clean up the head branch unless it's protected. Use whenever a `gh pr merge` succeeds.
+---
+
+## Delete Merged Branch
+
+After merging a PR (`gh pr merge`), delete its head branch on origin — unless
+it's protected. Stale merged branches accumulate fast in this repo (56 got
+swept in one pass on 2026-08-15), and nobody references a feature/fix branch
+by name once its work has landed on the target branch.
+
+### Protected — leave these alone
+
+- `master` (and `main`, if ever renamed)
+- A bare version-number branch: `^v?[0-9]+(\.[0-9]+)*$` — e.g. `4.6.1`,
+  `4.6.0`, `3.4`. These are permanent release-history branches, not
+  work-in-progress.
+- Anything the user names as an exception for this merge. Example from
+  2026-08-15: `4.6.1-beta1` had to stay because an external OSS-Fuzz build
+  config (`project.yaml`) still pointed its fuzzing job at that branch name.
+  If unsure whether such a pin still applies, ask rather than assume it's
+  gone.
+
+### Not protected — delete these, even if they look version-ish
+
+A version number *with a suffix* (`4.6.0-alpha`, `4.5.0-beta3`,
+`v4.5.3-beta2`) is not a permanent branch — it's leftover from a pre-release
+cycle that's over. Default to deleting it. The same goes for anything
+descriptive (`fix-*`, `Bug_*`, `credit-*`, PR-author feature branches, etc.).
+When genuinely unsure whether a branch name is "version-like enough" to
+protect, treat it as not protected — the cost of a mistaken delete is low
+(commits stay reachable via the target branch's history for anything that
+was actually merged; `git reflog`/GitHub's branch-restore banner covers the
+rest for a while), and the point of this skill is to stop clutter from
+piling up.
+
+### How
+
+```
+gh pr merge <number> --merge --delete-branch
+```
+
+`--delete-branch` handles both the merge and cleanup in one call. If you
+already merged without it, delete separately:
+
+```
+git push origin --delete <branch>
+```
+
+Either way, confirm and mention the branch is gone (or why it was kept) —
+don't do this silently.

--- a/.claude/skills/release-checklist/skill.md
+++ b/.claude/skills/release-checklist/skill.md
@@ -1,0 +1,107 @@
+---
+name: Release Checklist
+description: Walk through preparing a tcpreplay beta or full release, given a version number. Use when the user says things like "let's release 4.6.2", "prep a beta for X", "is <branch> ready for a release", or references the wiki Release Checklist.
+---
+
+## Release Checklist
+
+Source of truth: https://github.com/appneta/tcpreplay/wiki/Release-Checklist
+This skill loosely follows it, adapted to what actually happened preparing
+4.6.1 on 2026-08-15 — read that as a worked example if anything here is
+ambiguous.
+
+Ask which of these the user wants before doing anything, since they change
+the steps: **a beta** (pre-release, ships from a `-betaN` branch, no merge to
+`master` yet) or **a full release** (ships from the clean version branch,
+merges to `master` after).
+
+### 1. Readiness check (do this first, always)
+
+- `gh run list --branch <branch> --limit 5` — CI green on the latest commit?
+- `git log origin/master..origin/<branch> --oneline | wc -l` — how far
+  ahead of `master`, and does anything on `master` need pulling in first
+  (`git log origin/<branch>..origin/master --oneline`)?
+- Read the top of `docs/CHANGELOG` — does it match the branch's actual
+  state? Any leftover beta-cycle headers that should be squashed into one?
+- Report status plainly (ready / blockers) before touching anything. Don't
+  assume "ready to release" means "go ahead and merge" — that's a separate
+  confirmation.
+
+### 2. Update CHANGELOG (checklist step 4)
+
+- Top entry's date should be the actual release date, version should be the
+  release's clean version number (not `-betaN`) even for a beta build — the
+  suffix lives in the branch name and the tag, not the CHANGELOG header.
+- Remove/squash beta-cycle sub-headers if any accumulated during
+  development — one version header, one list of entries.
+- Keep individual entries terse (1-2 lines) unless the user asks otherwise.
+
+### 3. Update CREDIT (docs/CREDIT)
+
+- Anyone who reported a security advisory (GHSA) fixed in this release gets
+  an entry, grouped by reporter if they filed more than one — see the
+  existing file for the pattern (e.g. `tinyb0y`, `tao pan`).
+- Automated fuzzer findings (OSS-Fuzz) don't get individual CREDIT entries —
+  they're credited in the CHANGELOG line itself (`OSS-Fuzz <issue-id>`), not
+  here.
+
+### 4. Version number (configure.ac)
+
+- `AC_INIT([tcpreplay],[X.Y.Z],...)` — bump if not already done. Check
+  `CMakeLists.txt` derives from this automatically (it does, via regex on
+  configure.ac's version) rather than hardcoding a second copy.
+
+### 5. Branch merges
+
+Order matters less than making sure both directions happen before the next
+step:
+- If `master` has commits the release branch doesn't (e.g. a hotfix merged
+  there directly), merge `master` into the release branch first.
+- Merge the beta/working branch into the clean version branch (e.g.
+  `4.6.1-beta1` → `4.6.1`), or create the clean version branch now if it
+  doesn't exist yet.
+- Push. Wait for CI green on the pushed branch before anything downstream
+  depends on it.
+
+### 6. Tagging, building, signing — not yours to do
+
+You cannot create the actual git tag, build tarballs, or sign them — the
+maintainer does this on a separate system with the signing key. Don't
+attempt `git tag` on the release branch. If the user says "I've tagged and
+built it," treat the tag as fixed: any further commits you make land *after*
+it, and you should say so rather than silently pushing past it.
+
+### 7. PR to master (full release only; skip for a beta)
+
+- `gh pr create --base master --head <branch> --title "Release X.Y.Z"`.
+- Check CI on the PR before merging — don't merge on a hunch, wait for
+  green (`gh pr checks <number>`, poll if needed).
+- After merge: run the [Delete Merged Branch](../delete-merged-branch/skill.md)
+  skill's logic on the head branch, same as any other PR.
+
+### 8. Release notes and announcement
+
+- Draft release notes matching the style of the most recent actual release
+  (`gh release view v<previous>` for the template) — highlights, a security
+  table if applicable, a "What's Changed" list, download/verification
+  instructions. Save as a file and hand it to the user rather than trying to
+  create/publish the GitHub Release yourself — they attach it when uploading
+  tarballs.
+- If asked to announce: post to
+  https://github.com/appneta/tcpreplay/discussions/categories/announcements
+  via `gh discussion create --category Announcements`. Note that pinning a
+  discussion has no API — that's a manual step via the `···` menu on the
+  discussion page.
+- A short mailing-list-style announcement email (overview, bullet summary,
+  download link) is a nice companion — see 2026-08-15's 4.6.1 announcement
+  for tone.
+
+### 9. Cleanup
+
+- Check for open GitHub milestones matching this version;
+  close if any exist (often there aren't any — OSS-Fuzz findings and
+  security advisories don't get milestones by default in this repo).
+- Confirm `docs-deploy.yml`'s branch trigger list includes wherever the docs
+  source actually lives post-merge (currently `master` plus whichever beta
+  branch is active) — the live site only rebuilds on push to a listed
+  branch with `docs/**` or `*_opts.def` changes.

--- a/.claude/skills/security-advisory-triage/skill.md
+++ b/.claude/skills/security-advisory-triage/skill.md
@@ -1,0 +1,86 @@
+---
+name: Security Advisory Triage
+description: Move a GitHub Security Advisory through accept, fix, and publish for this repo. Use when the user shares a GHSA URL, asks to triage/accept/publish an advisory, or asks whether new advisories apply to the current code.
+---
+
+## Security Advisory Triage
+
+Worked example: three advisories (GHSA-pmmx-m8p5-969j, GHSA-4hqm-8v2c-9pwj,
+GHSA-p3f2-88rg-9mch) went through this exact flow on 2026-08-15.
+
+### 1. Check if it applies
+
+Don't assume a reported advisory still reproduces — verify against the
+current code before doing anything else:
+
+```
+gh api repos/appneta/tcpreplay/security-advisories/<GHSA-id>
+```
+
+Read the description for the exact file/function/line cited, then check
+that code as it exists now (`Read`, not memory). A vulnerable-version range
+like `<= 4.5.1` doesn't mean it's still broken on `master` — confirm the
+specific bug is still there before treating it as real work.
+
+### 2. Decide: fix in the open, or fix privately first
+
+- **DoS-only, memory leak, or anything not exploitable beyond a crash**: fix
+  in the open, same as a normal bug — branch, PR, merge.
+- **Memory corruption reachable by attacker-controlled input (heap/stack
+  overflow, UAF, OOB write)**: this needs private handling before anything
+  public. On the advisory page, the maintainer clicks **Accept and open as
+  draft security advisory** — this is a UI action, not something to attempt
+  via API (there's no reliable "accept" endpoint, and getting it wrong risks
+  not actually keeping the fix private). Ask the user to click it and hand
+  you the resulting private fork's URL.
+- Once a private fork exists: clone it, branch, fix, verify (ideally
+  reproduce the PoC before/after — see below), push and open a PR *within
+  the private fork*, not the public repo. Only cherry-pick the fix commit
+  onto the public release branch after the user says the private fork PR is
+  merged.
+
+### 3. Verify the fix actually works
+
+Reproduce the reported crash before the fix and confirm it's gone after,
+where the advisory includes a PoC. This caught real details worth putting
+in the PR description (e.g. the radiotap fix's exact byte-overflow amount
+matched the advisory's own numbers once verified). Don't just trust that the
+code change "looks right" — these are exploitability claims, worth the extra
+few minutes.
+
+### 4. Publishing the advisory
+
+Once the fix is merged (public or cherry-picked from private), the advisory
+record itself still needs three things set, in this order:
+
+1. **`patched_versions`** — set to the version this ships in, even if
+   unreleased/untagged yet:
+   ```
+   gh api repos/.../security-advisories/<id> -X PATCH --input payload.json
+   ```
+   (PATCH needs the full `vulnerabilities[]` array reposted with
+   `ecosystem: "other"` for a C project — GitHub's ecosystem enum doesn't
+   have a "c" option, even though a resolved advisory may display one.)
+
+2. **CVE request** — ask the user; don't assume. Severity matters here:
+   higher-CVSS/RCE-potential findings usually warrant one, lower-severity
+   DoS findings are more of a judgment call. If the user doesn't answer or
+   dismisses the question, proceed without requesting one rather than
+   blocking — it can be requested later:
+   ```
+   gh api repos/.../security-advisories/<id>/cve -X POST
+   ```
+
+3. **Publish**:
+   ```
+   gh api repos/.../security-advisories/<id> -X PATCH -f state=published
+   ```
+   This works directly from `triage` state — no need to route through
+   `draft` first for advisories that were never accepted into a private
+   fork.
+
+### 5. Credit
+
+Add the reporter to `docs/CREDIT`, grouped by person if they filed more than
+one advisory. Match the file's existing format (name, GitHub handle, bullet
+list of what they found with GHSA links).


### PR DESCRIPTION
## Summary
Three project skills under `.claude/skills/`, capturing the workflow patterns from today's 4.6.1 release cycle:

- **`delete-merged-branch`** — after `gh pr merge`, delete the head branch unless it's `master`, a bare version-number branch (`4.6.1`, `3.4`, ...), or an explicit named exception (e.g. `4.6.1-beta1`, pinned by an external OSS-Fuzz build config).
- **`release-checklist`** — walks a beta or full release given a version number: readiness check, CHANGELOG/CREDIT/version bump, branch merges, PR to master, release notes/announcement, cleanup. Loosely follows the [wiki Release Checklist](https://github.com/appneta/tcpreplay/wiki/Release-Checklist), adapted to what actually happened today.
- **`security-advisory-triage`** — moves a GHSA through verify → accept (private fork if needed) → fix → verify PoC → publish (`patched_versions`, CVE request, publish) → credit.

Same lightweight format as the existing `.claude/skills/*` files (frontmatter + concise steps) — no eval scaffolding, since these are narrow, deterministic, repo-specific behavioral skills rather than generalizable content-generation skills.

## Test plan
N/A — documentation/tooling config, nothing to build or test.