### PR TITLE
community: fix issue-template label case mismatch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Something in tcpreplay/tcprewrite/tcpprep/tcpbridge/tcpliveplay/tcpcapinfo is broken.
 title: "[Bug] "
-labels: ["Bug"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea, new flag, or capability for the suite.
 title: "[Feature] "
-labels: ["Enhancement"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
`bug_report.yml`/`feature_request.yml` set `labels: ["Bug"]`/`["Enhancement"]`, but the repo's actual labels are lowercase `bug`/`enhancement`. Left as-is, the first issue filed through either form would auto-create a capitalized duplicate label instead of applying the existing one.

## Test plan
N/A — template-only change.